### PR TITLE
Add per-session cache APIs and on-heap implementations

### DIFF
--- a/llap-client/src/java/org/apache/hadoop/hive/llap/io/api/LlapIo.java
+++ b/llap-client/src/java/org/apache/hadoop/hive/llap/io/api/LlapIo.java
@@ -35,6 +35,8 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.Reporter;
 import org.apache.orc.impl.OrcTail;
+import org.apache.hadoop.hive.llap.io.session.LlapIoSession;
+import org.apache.hadoop.hive.llap.io.session.SessionConfig;
 
 import javax.annotation.Nullable;
 
@@ -117,5 +119,16 @@ public interface LlapIo<T> {
   void loadDataIntoCache(LlapDaemonProtocolProtos.CacheEntryList metadata);
 
   boolean usingLowLevelCache();
+
+  /**
+   * Open a per-(DAG, table) on-heap cache session.
+   * Implementations must:
+   *  - allocate isolated data+metadata caches obeying cfg limits
+   *  - install an InflightTracker
+   *  - return a session whose close() clears both caches
+   */
+  default LlapIoSession openSession(SessionConfig cfg, long dagId, long tableId) {
+    throw new UnsupportedOperationException("openSession not implemented");
+  }
 
 }

--- a/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/CacheAdmissionPolicy.java
+++ b/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/CacheAdmissionPolicy.java
@@ -1,0 +1,17 @@
+package org.apache.hadoop.hive.llap.io.session;
+
+import org.apache.hadoop.hive.llap.cache.FileCacheKey;
+import org.apache.hadoop.hive.common.io.DiskRange;
+
+public interface CacheAdmissionPolicy {
+  /** Return true if this range should be admitted into the cache under current conditions. */
+  boolean shouldCache(FileCacheKey key, DiskRange range, long estimatedBytes, CacheStats stats, CacheTag tag);
+
+  interface CacheStats {
+    long usedBytes();
+    long capacityBytes();
+  }
+
+  /** Default allow-all policy. */
+  CacheAdmissionPolicy ALWAYS = (k, r, est, s, t) -> true;
+}

--- a/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/CacheContext.java
+++ b/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/CacheContext.java
@@ -1,0 +1,25 @@
+package org.apache.hadoop.hive.llap.io.session;
+
+import org.apache.hadoop.hive.llap.io.session.LowLevelCache;
+import org.apache.hadoop.hive.llap.io.session.MetadataCache;
+
+/** Immutable routing handle for all cache operations. */
+public final class CacheContext {
+  public final LowLevelCache dataCache;
+  public final MetadataCache metadataCache;
+  public final CacheAdmissionPolicy admission;
+  public final CacheTag tag;
+  public final InflightTracker inflight;
+
+  public CacheContext(LowLevelCache dataCache,
+                      MetadataCache metadataCache,
+                      CacheAdmissionPolicy admission,
+                      CacheTag tag,
+                      InflightTracker inflight) {
+    this.dataCache = dataCache;
+    this.metadataCache = metadataCache;
+    this.admission = (admission == null) ? CacheAdmissionPolicy.ALWAYS : admission;
+    this.tag = tag;
+    this.inflight = inflight;
+  }
+}

--- a/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/CacheTag.java
+++ b/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/CacheTag.java
@@ -1,0 +1,13 @@
+package org.apache.hadoop.hive.llap.io.session;
+
+/** Optional identifier for diagnostics. */
+public final class CacheTag {
+  public final long dagId;
+  public final long tableId;
+  public CacheTag(long dagId, long tableId) {
+    this.dagId = dagId;
+    this.tableId = tableId;
+  }
+  @Override
+  public String toString() { return "dag=" + dagId + ",table=" + tableId; }
+}

--- a/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/InflightTracker.java
+++ b/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/InflightTracker.java
@@ -1,0 +1,28 @@
+package org.apache.hadoop.hive.llap.io.session;
+
+import java.util.concurrent.*;
+import java.util.function.Supplier;
+
+/** Deduplicates concurrent loads of the same chunk within a CacheContext. */
+public final class InflightTracker {
+  private final ConcurrentHashMap<Object, CompletableFuture<Object>> map = new ConcurrentHashMap<>();
+
+  @SuppressWarnings("unchecked")
+  public <K, V> V getOrLoad(K key, Supplier<V> loader) {
+    CompletableFuture<Object> f = map.computeIfAbsent(key, k -> new CompletableFuture<>());
+    // Fast path: already completed by another thread.
+    if (f.isDone()) return (V) f.join();
+
+    // Attempt to be the loader; others await the same future.
+    boolean doLoad = f.completeAsync(() -> {
+      V v = loader.get();
+      return v;
+    }).isDone();
+
+    try {
+      return (V) f.join();
+    } finally {
+      map.remove(key, f);
+    }
+  }
+}

--- a/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/LlapIoSession.java
+++ b/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/LlapIoSession.java
@@ -1,0 +1,8 @@
+package org.apache.hadoop.hive.llap.io.session;
+
+public interface LlapIoSession extends AutoCloseable {
+  /** The routing handle to be passed into read pipelines. */
+  CacheContext context();
+  /** Clears the data+metadata caches and releases all associated memory. */
+  @Override void close();
+}

--- a/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/LowLevelCache.java
+++ b/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/LowLevelCache.java
@@ -1,0 +1,16 @@
+package org.apache.hadoop.hive.llap.io.session;
+
+import java.nio.ByteBuffer;
+
+/** Minimal data cache interface for per-session cache. */
+public interface LowLevelCache {
+  /** Returns a retained entry or null on miss. */
+  ByteBuffer get(Object chunkKey);
+  /** Inserts the entry if admitted; returns true if inserted. */
+  boolean put(Object chunkKey, ByteBuffer buf);
+  long usedBytes();
+  long capacityBytes();
+  void clear();
+  void incRef(ByteBuffer buf);
+  void decRef(ByteBuffer buf);
+}

--- a/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/MetadataCache.java
+++ b/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/MetadataCache.java
@@ -1,0 +1,10 @@
+package org.apache.hadoop.hive.llap.io.session;
+
+/** Minimal metadata cache interface for per-session use. */
+public interface MetadataCache {
+  Object get(Object key);
+  void put(Object key, Object value, long weight);
+  void clear();
+  long usedBytes();
+  long capacityBytes();
+}

--- a/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/README.md
+++ b/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/README.md
@@ -1,0 +1,16 @@
+# LLAP IO Session Caching
+
+This package provides a minimal per-(DAG, table) on-heap cache used by MR3
+workers. Sessions are opened via `LlapIo.openSession` which allocates isolated
+caches for data and metadata along with an `InflightTracker` to deduplicate
+concurrent loads. Each reader receives a `CacheContext` and all cache operations
+are routed through this handle.
+
+Configuration keys:
+- `mr3.llap.session.data.cache.bytes`
+- `mr3.llap.session.metadata.cache.bytes`
+- `mr3.llap.session.admission.watermark`
+
+Workers should open a session when the first task for a table arrives and close
+it when all tasks for that table complete. Closing the session drops all cached
+content.

--- a/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/SessionConfig.java
+++ b/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/SessionConfig.java
@@ -1,0 +1,15 @@
+package org.apache.hadoop.hive.llap.io.session;
+
+public final class SessionConfig {
+  /** Max on-heap bytes for data cache. */
+  public final long dataCacheBytes;
+  /** Max on-heap bytes for metadata cache. */
+  public final long metadataCacheBytes;
+  /** Optional soft-admission threshold; e.g. 0.8 means stop admitting above 80% used. */
+  public final double admissionWatermark;
+  public SessionConfig(long dataCacheBytes, long metadataCacheBytes, double admissionWatermark) {
+    this.dataCacheBytes = dataCacheBytes;
+    this.metadataCacheBytes = metadataCacheBytes;
+    this.admissionWatermark = admissionWatermark;
+  }
+}

--- a/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/heap/HeapCacheFactory.java
+++ b/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/heap/HeapCacheFactory.java
@@ -1,0 +1,16 @@
+package org.apache.hadoop.hive.llap.io.session.heap;
+
+import org.apache.hadoop.hive.llap.io.session.LowLevelCache;
+import org.apache.hadoop.hive.llap.io.session.MetadataCache;
+
+public final class HeapCacheFactory {
+  private HeapCacheFactory() {}
+
+  public static LowLevelCache createDataCache(long capacity) {
+    return new OnHeapLowLevelCache(capacity);
+  }
+
+  public static MetadataCache createMetadataCache(long capacity) {
+    return new OnHeapMetadataCache(capacity);
+  }
+}

--- a/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/heap/OnHeapLowLevelCache.java
+++ b/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/heap/OnHeapLowLevelCache.java
@@ -1,0 +1,104 @@
+package org.apache.hadoop.hive.llap.io.session.heap;
+
+import java.nio.ByteBuffer;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.hadoop.hive.llap.io.session.LowLevelCache;
+
+/**
+ * Simple on-heap cache with LRU eviction and reference counting.
+ */
+public class OnHeapLowLevelCache implements LowLevelCache {
+  private static final class Entry {
+    final ByteBuffer buf;
+    int refCount = 1; // held by cache itself
+    Entry(ByteBuffer b) { this.buf = b; }
+  }
+
+  private final long capacity;
+  private volatile long used;
+
+  private final ConcurrentHashMap<Object, Entry> map = new ConcurrentHashMap<>();
+  private final LinkedHashMap<Object, Entry> lru = new LinkedHashMap<>(16, 0.75f, true);
+
+  public OnHeapLowLevelCache(long capacity) {
+    this.capacity = capacity;
+  }
+
+  @Override
+  public ByteBuffer get(Object chunkKey) {
+    Entry e = map.get(chunkKey);
+    if (e == null) return null;
+    synchronized (e) { e.refCount++; }
+    synchronized (lru) { lru.get(chunkKey); }
+    return e.buf.duplicate();
+  }
+
+  @Override
+  public boolean put(Object chunkKey, ByteBuffer buf) {
+    int size = buf.remaining();
+    Entry e = new Entry(buf.slice());
+    Entry prev = map.putIfAbsent(chunkKey, e);
+    if (prev != null) {
+      return false;
+    }
+    used += size;
+    synchronized (lru) { lru.put(chunkKey, e); }
+    evictIfNeeded();
+    return true;
+  }
+
+  private void evictIfNeeded() {
+    synchronized (lru) {
+      while (used > capacity && !lru.isEmpty()) {
+        Map.Entry<Object, Entry> eldest = lru.entrySet().iterator().next();
+        Entry e = eldest.getValue();
+        synchronized (e) {
+          if (e.refCount > 1) {
+            // in use, move to end and continue
+            lru.remove(eldest.getKey());
+            lru.put(eldest.getKey(), e);
+            continue;
+          }
+        }
+        lru.remove(eldest.getKey());
+        map.remove(eldest.getKey());
+        used -= e.buf.remaining();
+      }
+    }
+  }
+
+  @Override
+  public long usedBytes() { return used; }
+
+  @Override
+  public long capacityBytes() { return capacity; }
+
+  @Override
+  public void clear() {
+    map.clear();
+    synchronized (lru) { lru.clear(); }
+    used = 0;
+  }
+
+  @Override
+  public void incRef(ByteBuffer buf) {
+    // find entry by buffer identity
+    map.forEach((k, e) -> {
+      if (e.buf == buf) {
+        synchronized (e) { e.refCount++; }
+      }
+    });
+  }
+
+  @Override
+  public void decRef(ByteBuffer buf) {
+    map.forEach((k, e) -> {
+      if (e.buf == buf) {
+        synchronized (e) { e.refCount--; }
+      }
+    });
+  }
+}

--- a/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/heap/OnHeapMetadataCache.java
+++ b/llap-client/src/java/org/apache/hadoop/hive/llap/io/session/heap/OnHeapMetadataCache.java
@@ -1,0 +1,39 @@
+package org.apache.hadoop.hive.llap.io.session.heap;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.hadoop.hive.llap.io.session.MetadataCache;
+
+/** Simple on-heap metadata cache. */
+public class OnHeapMetadataCache implements MetadataCache {
+  private final ConcurrentHashMap<Object, Object> map = new ConcurrentHashMap<>();
+  private final long capacity;
+  private volatile long used;
+
+  public OnHeapMetadataCache(long capacity) {
+    this.capacity = capacity;
+  }
+
+  @Override
+  public Object get(Object key) {
+    return map.get(key);
+  }
+
+  @Override
+  public void put(Object key, Object value, long weight) {
+    map.put(key, value);
+    used += weight;
+  }
+
+  @Override
+  public void clear() {
+    map.clear();
+    used = 0;
+  }
+
+  @Override
+  public long usedBytes() { return used; }
+
+  @Override
+  public long capacityBytes() { return capacity; }
+}

--- a/llap-client/src/test/java/org/apache/hadoop/hive/llap/io/session/InflightTrackerTest.java
+++ b/llap-client/src/test/java/org/apache/hadoop/hive/llap/io/session/InflightTrackerTest.java
@@ -1,0 +1,28 @@
+package org.apache.hadoop.hive.llap.io.session;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class InflightTrackerTest {
+  @Test
+  public void testDeduplication() throws Exception {
+    InflightTracker tracker = new InflightTracker();
+    AtomicInteger loads = new AtomicInteger();
+    Callable<Integer> call = () -> tracker.getOrLoad("k", () -> {
+      loads.incrementAndGet();
+      try { Thread.sleep(50); } catch (InterruptedException e) {}
+      return 5;
+    });
+    var ex = Executors.newFixedThreadPool(2);
+    Future<Integer> f1 = ex.submit(call);
+    Future<Integer> f2 = ex.submit(call);
+    assertEquals(5, (int)f1.get());
+    assertEquals(5, (int)f2.get());
+    assertEquals(1, loads.get());
+    ex.shutdown();
+  }
+}

--- a/llap-client/src/test/java/org/apache/hadoop/hive/llap/io/session/heap/OnHeapLowLevelCacheTest.java
+++ b/llap-client/src/test/java/org/apache/hadoop/hive/llap/io/session/heap/OnHeapLowLevelCacheTest.java
@@ -1,0 +1,21 @@
+package org.apache.hadoop.hive.llap.io.session.heap;
+
+import java.nio.ByteBuffer;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class OnHeapLowLevelCacheTest {
+  @Test
+  public void testPutGetEvict() {
+    OnHeapLowLevelCache cache = new OnHeapLowLevelCache(10);
+    ByteBuffer b1 = ByteBuffer.wrap(new byte[8]);
+    cache.put("a", b1);
+    assertNotNull(cache.get("a"));
+    ByteBuffer b2 = ByteBuffer.wrap(new byte[8]);
+    cache.put("b", b2); // should evict one due to capacity
+    int count = 0;
+    if (cache.get("a") != null) count++;
+    if (cache.get("b") != null) count++;
+    assertEquals(1, count);
+  }
+}

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/io/api/impl/LlapIoImpl.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/io/api/impl/LlapIoImpl.java
@@ -104,6 +104,9 @@ import org.apache.parquet.hadoop.ParquetFileWriter;
 import org.apache.parquet.hadoop.util.HadoopStreams;
 import org.apache.parquet.io.SeekableInputStream;
 
+import org.apache.hadoop.hive.llap.io.session.*;
+import org.apache.hadoop.hive.llap.io.session.heap.HeapCacheFactory;
+
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -542,6 +545,30 @@ public class LlapIoImpl implements LlapIo<VectorizedRowBatch>, LlapIoDebugDump {
   @Override
   public boolean usingLowLevelCache() {
     return useLowLevelCache;
+  }
+
+  @Override
+  public LlapIoSession openSession(SessionConfig cfg, long dagId, long tableId) {
+    final CacheAdmissionPolicy ap = (key, range, est, stats, tag) ->
+        ((double)stats.usedBytes() / Math.max(1.0, stats.capacityBytes())) < cfg.admissionWatermark;
+
+    final CacheContext ctx = new CacheContext(
+        HeapCacheFactory.createDataCache(cfg.dataCacheBytes),
+        HeapCacheFactory.createMetadataCache(cfg.metadataCacheBytes),
+        ap,
+        new CacheTag(dagId, tableId),
+        new InflightTracker()
+    );
+
+    return new LlapIoSession() {
+      private volatile boolean closed;
+      @Override public CacheContext context() { return ctx; }
+      @Override public void close() {
+        if (closed) return; closed = true;
+        try { ctx.metadataCache.clear(); } catch (Throwable t) {}
+        try { ctx.dataCache.clear(); } catch (Throwable t) {}
+      }
+    };
   }
 
 }

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/io/decode/ColumnVectorProducer.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/io/decode/ColumnVectorProducer.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.Reporter;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.impl.SchemaEvolution;
+import org.apache.hadoop.hive.llap.io.session.CacheContext;
 
 /**
  * Entry point used by LlapInputFormat to create read pipeline to get data.
@@ -63,4 +64,14 @@ public interface ColumnVectorProducer {
       Includes includes, SearchArgument sarg, QueryFragmentCounters counters,
       SchemaEvolutionFactory sef, InputFormat<?, ?> sourceInputFormat, Deserializer sourceSerDe,
       Reporter reporter, JobConf job, Map<Path, PartitionDesc> parts) throws IOException;
+
+  default ReadPipeline createReadPipeline(Consumer<ColumnVectorBatch> consumer, FileSplit split,
+      Includes includes, SearchArgument sarg, QueryFragmentCounters counters,
+      SchemaEvolutionFactory sef, InputFormat<?, ?> sourceInputFormat, Deserializer sourceSerDe,
+      Reporter reporter, JobConf job, Map<Path, PartitionDesc> parts, CacheContext ctx) throws IOException {
+    ReadPipeline p = createReadPipeline(consumer, split, includes, sarg, counters, sef,
+        sourceInputFormat, sourceSerDe, reporter, job, parts);
+    if (p != null) p.setCacheContext(ctx);
+    return p;
+  }
 }

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/io/decode/ReadPipeline.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/io/decode/ReadPipeline.java
@@ -23,8 +23,12 @@ import org.apache.hadoop.hive.llap.ConsumerFeedback;
 import org.apache.hadoop.hive.llap.io.api.impl.ColumnVectorBatch;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.impl.SchemaEvolution;
+import org.apache.hadoop.hive.llap.io.session.CacheContext;
 
 public interface ReadPipeline extends ConsumerFeedback<ColumnVectorBatch> {
   public Callable<Void> getReadCallable();
   SchemaEvolution getSchemaEvolution();
+
+  default void setCacheContext(CacheContext ctx) {}
+  default CacheContext getCacheContext() { return null; }
 }

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/io/session/SessionRegistry.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/io/session/SessionRegistry.java
@@ -1,0 +1,33 @@
+package org.apache.hadoop.hive.llap.io.session;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.hadoop.hive.llap.LlapProxy;
+
+/** Worker-local registry of LlapIoSession per (dagId, tableId). */
+public final class SessionRegistry {
+  private final ConcurrentHashMap<Key, LlapIoSession> sessions = new ConcurrentHashMap<>();
+
+  private static final class Key {
+    final long d, t;
+    Key(long d, long t) { this.d = d; this.t = t; }
+    @Override public int hashCode() { return Long.hashCode(d * 31 + t); }
+    @Override public boolean equals(Object o) {
+      if (!(o instanceof Key)) return false;
+      Key k = (Key)o; return k.d == d && k.t == t;
+    }
+  }
+
+  public LlapIoSession getOrOpen(long dagId, long tableId, SessionConfig cfg) {
+    return sessions.computeIfAbsent(new Key(dagId, tableId),
+        k -> LlapProxy.getIo().openSession(cfg, dagId, tableId));
+  }
+
+  /** Called when all reads for (dagId, tableId) are finished. */
+  public void close(long dagId, long tableId) {
+    LlapIoSession s = sessions.remove(new Key(dagId, tableId));
+    if (s != null) {
+      try { s.close(); } catch (Exception e) { }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- introduce session-aware cache APIs including CacheContext, CacheTag, and InflightTracker
- provide simple on-heap data and metadata caches with a heap-based factory
- add openSession entrypoint in LlapIo and implement in LlapIoImpl
- expose session registry and cache-context wiring in read pipeline interfaces

## Testing
- `mvn -q -pl llap-client -am test` *(fails: Non-resolvable parent POM due to missing artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a409f0bc832891d17d93f86cc575