### PR TITLE
Populate dummy partition values for Iceberg stats

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/DummyPartition.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/DummyPartition.java
@@ -58,6 +58,10 @@ public class DummyPartition extends Partition {
     tPart.setParameters(Maps.newHashMap());
 
     List<String> values = new ArrayList<>(Math.max(tbl.getPartCols().size(), partSpec.size()));
+    // Iceberg tables may report zero partition columns to Hive even though the
+    // partition spec is present in the partSpec map. When partition columns are
+    // available use them to order values by column name; otherwise fall back to
+    // the provided map ordering to keep partition key/value pairs intact.
     if (!tbl.getPartCols().isEmpty()) {
       for (FieldSchema field : tbl.getPartCols()) {
         values.add(partSpec.get(field.getName()));

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/DummyPartition.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/DummyPartition.java
@@ -57,9 +57,13 @@ public class DummyPartition extends Partition {
     tPart.setSd(tbl.getSd().deepCopy());
     tPart.setParameters(Maps.newHashMap());
 
-    List<String> values = new ArrayList<>(tbl.getPartCols().size());
-    for (FieldSchema field : tbl.getPartCols()) {
-      values.add(partSpec.get(field.getName()));
+    List<String> values = new ArrayList<>(Math.max(tbl.getPartCols().size(), partSpec.size()));
+    if (!tbl.getPartCols().isEmpty()) {
+      for (FieldSchema field : tbl.getPartCols()) {
+        values.add(partSpec.get(field.getName()));
+      }
+    } else {
+      values.addAll(partSpec.values());
     }
     tPart.setDbName(tbl.getDbName());
     tPart.setTableName(tbl.getTableName());

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/DummyPartition.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/DummyPartition.java
@@ -56,6 +56,14 @@ public class DummyPartition extends Partition {
         new org.apache.hadoop.hive.metastore.api.Partition();
     tPart.setSd(tbl.getSd().deepCopy());
     tPart.setParameters(Maps.newHashMap());
+
+    List<String> values = new ArrayList<>(tbl.getPartCols().size());
+    for (FieldSchema field : tbl.getPartCols()) {
+      values.add(partSpec.get(field.getName()));
+    }
+    tPart.setDbName(tbl.getDbName());
+    tPart.setTableName(tbl.getTableName());
+    tPart.setValues(values);
     
     this.partSpec = Maps.newLinkedHashMap(partSpec);
     setTPartition(tPart);


### PR DESCRIPTION
## Summary
- populate DummyPartition objects with database name, table name, and partition values so stats updates send complete partition thrift objects

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69381efc18f0832892e1b1279fced804)