### PR TITLE
Log NDV values during column stats computation

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDAFComputeStats.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDAFComputeStats.java
@@ -454,6 +454,7 @@ public class GenericUDAFComputeStats extends AbstractGenericUDAFResolver {
       protected Object serialize(Object[] result) {
         serializeCommon(result);
         long dv = numDV != null ? numDV.estimateNumDistinctValues() : 0;
+        LOG.info("Computed distinct_count={} for column type {} in NumericStatsAgg", dv, columnType);
         ((LongWritable) result[4]).set(dv);
         if (numDV != null) {
           byte[] buf = numDV.serialize();
@@ -982,6 +983,7 @@ public class GenericUDAFComputeStats extends AbstractGenericUDAFResolver {
       StringStatsAgg myagg = (StringStatsAgg) agg;
 
       long numDV = myagg.numDV == null ? 0 : myagg.numDV.estimateNumDistinctValues();
+      LOG.info("Computed distinct_count={} for column type {} in StringStatsAgg", numDV, myagg.columnType);
       double avgLength = 0.0;
       long total = myagg.count + myagg.countNulls;
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/api/utils/DecimalUtils.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/api/utils/DecimalUtils.java
@@ -43,6 +43,13 @@ public class DecimalUtils {
     return new Decimal((short) d.scale(), ByteBuffer.wrap(d.unscaledValue().toByteArray()));
   }
 
+  /**
+   * Create a {@link BigDecimal} from a thrift {@link Decimal} instance.
+   */
+  public static BigDecimal createBigDecimal(Decimal decimal) {
+    return new BigDecimal(new BigInteger(decimal.getUnscaled()), decimal.getScale());
+  }
+
   public static String createJdoDecimalString(Decimal d) {
     return new BigDecimal(new BigInteger(d.getUnscaled()), d.getScale()).toString();
   }


### PR DESCRIPTION
## Summary
- add informational logging for distinct_count estimates when column statistics are produced during ANALYZE

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f9bb8fe8883288a8af4bff16d40f3)