### PR TITLE
Add logging for column statistics updates

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/ColStatsProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/ColStatsProcessor.java
@@ -330,7 +330,7 @@ public class ColStatsProcessor implements IStatsProcessor {
   }
 
   private String getNdvBitVectorMetadata(ColumnStatisticsData data) {
-    ByteBuffer bitVector = null;
+    byte[] bitVector = null;
     if (data.isSetLongStats()) {
       LongColumnStatsData stats = data.getLongStats();
       bitVector = stats.isSetBitVectors() ? stats.getBitVectors() : null;
@@ -353,9 +353,7 @@ public class ColStatsProcessor implements IStatsProcessor {
     if (bitVector == null) {
       return "none";
     }
-    ByteBuffer duplicate = bitVector.asReadOnlyBuffer();
-    int length = duplicate.remaining();
-    return "length=" + length;
+    return "length=" + bitVector.length;
   }
 
   private String getLowValue(ColumnStatisticsData data) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/ColStatsProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/ColStatsProcessor.java
@@ -36,8 +36,18 @@ import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.ColumnStatistics;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsDesc;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
+import org.apache.hadoop.hive.metastore.api.ColumnStatisticsData;
+import org.apache.hadoop.hive.metastore.api.DateColumnStatsData;
+import org.apache.hadoop.hive.metastore.api.Date;
+import org.apache.hadoop.hive.metastore.api.Decimal;
+import org.apache.hadoop.hive.metastore.api.DecimalColumnStatsData;
 import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.LongColumnStatsData;
+import org.apache.hadoop.hive.metastore.api.DoubleColumnStatsData;
+import org.apache.hadoop.hive.metastore.api.StringColumnStatsData;
+import org.apache.hadoop.hive.metastore.api.TimestampColumnStatsData;
+import org.apache.hadoop.hive.metastore.api.Timestamp;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.SetPartitionsStatsRequest;
 import org.apache.hadoop.hive.ql.CompilationOpContext;
@@ -62,6 +72,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.hadoop.mapred.JobConf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.hadoop.hive.metastore.api.utils.DecimalUtils;
 
 
 public class ColStatsProcessor implements IStatsProcessor {
@@ -226,6 +237,7 @@ public class ColStatsProcessor implements IStatsProcessor {
       if (colStats.isEmpty()) {
         continue;
       }
+      logColumnStats(colStats);
       SetPartitionsStatsRequest request = new SetPartitionsStatsRequest(colStats);
       request.setNeedMerge(colStatDesc.isNeedMerge());
       if (txnMgr != null) {
@@ -248,6 +260,103 @@ public class ColStatsProcessor implements IStatsProcessor {
       LOG.info("Time taken to update " + colStats.size() + " stats : " + ((end - start)/1000F) + " seconds.");
     }
     return 0;
+  }
+
+  private void logColumnStats(List<ColumnStatistics> columnStatisticsList) {
+    for (ColumnStatistics columnStatistics : columnStatisticsList) {
+      ColumnStatisticsDesc desc = columnStatistics.getStatsDesc();
+      String tableName = desc.getDbName() + "." + desc.getTableName();
+      String level = desc.isIsTblLevel() ? "table-level" : "partition-level";
+      String partitionName = desc.isIsTblLevel() ? "N/A" : desc.getPartName();
+      for (ColumnStatisticsObj obj : columnStatistics.getStatsObj()) {
+        ColumnStatisticsData data = obj.getStatsData();
+        LOG.info("Column statistics ({}) for table {} partition {} column {}: ndv={}, lowValue={}, highValue={}",
+            level, tableName, partitionName, obj.getColName(),
+            getNumDistinctValues(data), getLowValue(data), getHighValue(data));
+      }
+    }
+  }
+
+  private String getNumDistinctValues(ColumnStatisticsData data) {
+    if (data.isSetLongStats()) {
+      LongColumnStatsData stats = data.getLongStats();
+      return stats.isSetNumDVs() ? String.valueOf(stats.getNumDVs()) : "null";
+    }
+    if (data.isSetDoubleStats()) {
+      DoubleColumnStatsData stats = data.getDoubleStats();
+      return stats.isSetNumDVs() ? String.valueOf(stats.getNumDVs()) : "null";
+    }
+    if (data.isSetStringStats()) {
+      StringColumnStatsData stats = data.getStringStats();
+      return stats.isSetNumDVs() ? String.valueOf(stats.getNumDVs()) : "null";
+    }
+    if (data.isSetDecimalStats()) {
+      DecimalColumnStatsData stats = data.getDecimalStats();
+      return stats.isSetNumDVs() ? String.valueOf(stats.getNumDVs()) : "null";
+    }
+    if (data.isSetDateStats()) {
+      DateColumnStatsData stats = data.getDateStats();
+      return stats.isSetNumDVs() ? String.valueOf(stats.getNumDVs()) : "null";
+    }
+    if (data.isSetTimestampStats()) {
+      TimestampColumnStatsData stats = data.getTimestampStats();
+      return stats.isSetNumDVs() ? String.valueOf(stats.getNumDVs()) : "null";
+    }
+    return "N/A";
+  }
+
+  private String getLowValue(ColumnStatisticsData data) {
+    if (data.isSetLongStats()) {
+      LongColumnStatsData stats = data.getLongStats();
+      return stats.isSetLowValue() ? String.valueOf(stats.getLowValue()) : "null";
+    }
+    if (data.isSetDoubleStats()) {
+      DoubleColumnStatsData stats = data.getDoubleStats();
+      return stats.isSetLowValue() ? String.valueOf(stats.getLowValue()) : "null";
+    }
+    if (data.isSetDecimalStats()) {
+      DecimalColumnStatsData stats = data.getDecimalStats();
+      Decimal lowValue = stats.isSetLowValue() ? stats.getLowValue() : null;
+      return lowValue == null ? "null" : DecimalUtils.createBigDecimal(lowValue).toString();
+    }
+    if (data.isSetDateStats()) {
+      DateColumnStatsData stats = data.getDateStats();
+      Date lowValue = stats.isSetLowValue() ? stats.getLowValue() : null;
+      return lowValue == null ? "null" : lowValue.toString();
+    }
+    if (data.isSetTimestampStats()) {
+      TimestampColumnStatsData stats = data.getTimestampStats();
+      Timestamp lowValue = stats.isSetLowValue() ? stats.getLowValue() : null;
+      return lowValue == null ? "null" : lowValue.toString();
+    }
+    return "N/A";
+  }
+
+  private String getHighValue(ColumnStatisticsData data) {
+    if (data.isSetLongStats()) {
+      LongColumnStatsData stats = data.getLongStats();
+      return stats.isSetHighValue() ? String.valueOf(stats.getHighValue()) : "null";
+    }
+    if (data.isSetDoubleStats()) {
+      DoubleColumnStatsData stats = data.getDoubleStats();
+      return stats.isSetHighValue() ? String.valueOf(stats.getHighValue()) : "null";
+    }
+    if (data.isSetDecimalStats()) {
+      DecimalColumnStatsData stats = data.getDecimalStats();
+      Decimal highValue = stats.isSetHighValue() ? stats.getHighValue() : null;
+      return highValue == null ? "null" : DecimalUtils.createBigDecimal(highValue).toString();
+    }
+    if (data.isSetDateStats()) {
+      DateColumnStatsData stats = data.getDateStats();
+      Date highValue = stats.isSetHighValue() ? stats.getHighValue() : null;
+      return highValue == null ? "null" : highValue.toString();
+    }
+    if (data.isSetTimestampStats()) {
+      TimestampColumnStatsData stats = data.getTimestampStats();
+      Timestamp highValue = stats.isSetHighValue() ? stats.getHighValue() : null;
+      return highValue == null ? "null" : highValue.toString();
+    }
+    return "N/A";
   }
 
   @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/ColStatsProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/ColStatsProcessor.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -69,6 +70,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
 import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.hadoop.mapred.JobConf;
@@ -136,11 +138,13 @@ public class ColStatsProcessor implements IStatsProcessor {
         PrimitiveTypeInfo typeInfo = (PrimitiveTypeInfo) TypeInfoUtils.getTypeInfoFromTypeString(columnType);
         List<ColumnStatsField> columnStatsFields = ColumnStatsType.getColumnStats(typeInfo);
         columnStatsFields = ColumnStatsType.removeDisabledStatistics(conf, columnStatsFields);
+        logRawColumnFields(columnName, columnStatsFields, pos, fields, values);
         try {
           ColumnStatisticsObj statObj = ColumnStatisticsObjTranslator.readHiveColumnStatistics(
               columnName, columnType, columnStatsFields, pos, fields, values);
           statsObjs.add(statObj);
           numStats++;
+          logTranslatedColumnStats(statObj);
         } catch (Exception e) {
           if (isStatsReliable) {
             throw new HiveException("Statistics collection failed while (hive.stats.reliable)", e);
@@ -211,6 +215,18 @@ public class ColStatsProcessor implements IStatsProcessor {
     return statsDesc;
   }
 
+  private void logRawColumnFields(String columnName, List<ColumnStatsField> columnStatsFields, int startPos,
+      List<? extends StructField> fields, List<Object> values) {
+    List<String> rawFieldStrings = new ArrayList<>();
+    for (int j = 0; j < columnStatsFields.size(); j++) {
+      StructField field = fields.get(startPos + j);
+      Object rawValue = values.get(startPos + j);
+      Object standardized = ObjectInspectorUtils.copyToStandardJavaObject(rawValue, field.getFieldObjectInspector());
+      rawFieldStrings.add(columnStatsFields.get(j).getFieldName() + "=" + String.valueOf(standardized));
+    }
+    LOG.info("Raw packed row fields for column {}: {}", columnName, String.join(", ", rawFieldStrings));
+  }
+
   public int persistColumnStats(Hive db, Table tbl) throws HiveException, MetaException, IOException {
     // Construct a column statistics object from the result
 
@@ -263,6 +279,13 @@ public class ColStatsProcessor implements IStatsProcessor {
     return 0;
   }
 
+  private void logTranslatedColumnStats(ColumnStatisticsObj obj) {
+    ColumnStatisticsData data = obj.getStatsData();
+    LOG.info("Translated column statistics for column {}: ndv={}, lowValue={}, highValue={}, ndvBitVector={}",
+        obj.getColName(), getNumDistinctValues(data), getLowValue(data), getHighValue(data),
+        getNdvBitVectorMetadata(data));
+  }
+
   private void logColumnStats(List<ColumnStatistics> columnStatisticsList) {
     for (ColumnStatistics columnStatistics : columnStatisticsList) {
       ColumnStatisticsDesc desc = columnStatistics.getStatsDesc();
@@ -271,9 +294,9 @@ public class ColStatsProcessor implements IStatsProcessor {
       String partitionName = desc.isIsTblLevel() ? "N/A" : desc.getPartName();
       for (ColumnStatisticsObj obj : columnStatistics.getStatsObj()) {
         ColumnStatisticsData data = obj.getStatsData();
-        LOG.info("Column statistics ({}) for table {} partition {} column {}: ndv={}, lowValue={}, highValue={}",
+        LOG.info("Column statistics ({}) for table {} partition {} column {}: ndv={}, lowValue={}, highValue={}, ndvBitVector={}",
             level, tableName, partitionName, obj.getColName(),
-            getNumDistinctValues(data), getLowValue(data), getHighValue(data));
+            getNumDistinctValues(data), getLowValue(data), getHighValue(data), getNdvBitVectorMetadata(data));
       }
     }
   }
@@ -304,6 +327,35 @@ public class ColStatsProcessor implements IStatsProcessor {
       return stats.isSetNumDVs() ? String.valueOf(stats.getNumDVs()) : "null";
     }
     return "N/A";
+  }
+
+  private String getNdvBitVectorMetadata(ColumnStatisticsData data) {
+    ByteBuffer bitVector = null;
+    if (data.isSetLongStats()) {
+      LongColumnStatsData stats = data.getLongStats();
+      bitVector = stats.isSetBitVectors() ? stats.getBitVectors() : null;
+    } else if (data.isSetDoubleStats()) {
+      DoubleColumnStatsData stats = data.getDoubleStats();
+      bitVector = stats.isSetBitVectors() ? stats.getBitVectors() : null;
+    } else if (data.isSetStringStats()) {
+      StringColumnStatsData stats = data.getStringStats();
+      bitVector = stats.isSetBitVectors() ? stats.getBitVectors() : null;
+    } else if (data.isSetDecimalStats()) {
+      DecimalColumnStatsData stats = data.getDecimalStats();
+      bitVector = stats.isSetBitVectors() ? stats.getBitVectors() : null;
+    } else if (data.isSetDateStats()) {
+      DateColumnStatsData stats = data.getDateStats();
+      bitVector = stats.isSetBitVectors() ? stats.getBitVectors() : null;
+    } else if (data.isSetTimestampStats()) {
+      TimestampColumnStatsData stats = data.getTimestampStats();
+      bitVector = stats.isSetBitVectors() ? stats.getBitVectors() : null;
+    }
+    if (bitVector == null) {
+      return "none";
+    }
+    ByteBuffer duplicate = bitVector.asReadOnlyBuffer();
+    int length = duplicate.remaining();
+    return "length=" + length;
   }
 
   private String getLowValue(ColumnStatisticsData data) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/ColStatsProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/ColStatsProcessor.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.hive.ql.stats;
 
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -72,7 +74,6 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.hadoop.mapred.JobConf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.hadoop.hive.metastore.api.utils.DecimalUtils;
 
 
 public class ColStatsProcessor implements IStatsProcessor {
@@ -317,7 +318,7 @@ public class ColStatsProcessor implements IStatsProcessor {
     if (data.isSetDecimalStats()) {
       DecimalColumnStatsData stats = data.getDecimalStats();
       Decimal lowValue = stats.isSetLowValue() ? stats.getLowValue() : null;
-      return lowValue == null ? "null" : DecimalUtils.createBigDecimal(lowValue).toString();
+      return lowValue == null ? "null" : createBigDecimal(lowValue).toString();
     }
     if (data.isSetDateStats()) {
       DateColumnStatsData stats = data.getDateStats();
@@ -332,6 +333,13 @@ public class ColStatsProcessor implements IStatsProcessor {
     return "N/A";
   }
 
+  private BigDecimal createBigDecimal(Decimal decimal) {
+    if (decimal == null) {
+      return null;
+    }
+    return new BigDecimal(new BigInteger(decimal.getUnscaled()), decimal.getScale());
+  }
+
   private String getHighValue(ColumnStatisticsData data) {
     if (data.isSetLongStats()) {
       LongColumnStatsData stats = data.getLongStats();
@@ -344,7 +352,7 @@ public class ColStatsProcessor implements IStatsProcessor {
     if (data.isSetDecimalStats()) {
       DecimalColumnStatsData stats = data.getDecimalStats();
       Decimal highValue = stats.isSetHighValue() ? stats.getHighValue() : null;
-      return highValue == null ? "null" : DecimalUtils.createBigDecimal(highValue).toString();
+      return highValue == null ? "null" : createBigDecimal(highValue).toString();
     }
     if (data.isSetDateStats()) {
       DateColumnStatsData stats = data.getDateStats();

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/columnstats/aggr/ColumnStatsAggregator.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/columnstats/aggr/ColumnStatsAggregator.java
@@ -134,4 +134,8 @@ public abstract class ColumnStatsAggregator {
 
     throw new IllegalArgumentException(currColStatsObj.getColType() + " is not supported for merging column stats histograms");
   }
+
+  protected String formatNdvMetadata(boolean hasEstimator, int bitVectorBytes) {
+    return String.format("estimatorPresent=%s, bitVectorBytes=%d", hasEstimator, bitVectorBytes);
+  }
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/columnstats/aggr/LongColumnStatsAggregator.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/columnstats/aggr/LongColumnStatsAggregator.java
@@ -50,31 +50,30 @@ public class LongColumnStatsAggregator extends ColumnStatsAggregator implements
       List<String> partNames, boolean areAllPartsFound) throws MetaException {
     checkStatisticsList(colStatsWithSourceInfo);
 
-    ColumnStatisticsObj statsObj = null;
-    String colType;
-    String colName = null;
+    ColumnStatisticsObj firstStatsObj = colStatsWithSourceInfo.get(0).getColStatsObj();
+    String colName = firstStatsObj.getColName();
+    String colType = firstStatsObj.getColType();
+    ColumnStatisticsObj statsObj = ColumnStatsAggregatorFactory.newColumnStaticsObj(colName, colType,
+        firstStatsObj.getStatsData().getSetField());
     // check if all the ColumnStatisticsObjs contain stats and all the ndv are
     // bitvectors
     boolean doAllPartitionContainStats = partNames.size() == colStatsWithSourceInfo.size();
+    LOG.trace("doAllPartitionContainStats for column: {} is: {}", colName, doAllPartitionContainStats);
     NumDistinctValueEstimator ndvEstimator = null;
     boolean areAllNDVEstimatorsMergeable = true;
     for (ColStatsObjWithSourceInfo csp : colStatsWithSourceInfo) {
       ColumnStatisticsObj cso = csp.getColStatsObj();
-      if (statsObj == null) {
-        colName = cso.getColName();
-        colType = cso.getColType();
-        statsObj = ColumnStatsAggregatorFactory.newColumnStaticsObj(colName, colType,
-            cso.getStatsData().getSetField());
-        LOG.trace("doAllPartitionContainStats for column: {} is: {}", colName, doAllPartitionContainStats);
-      }
       LongColumnStatsDataInspector columnStatsData = longInspectorFromStats(cso);
+      byte[] bitVectors = columnStatsData.isSetBitVectors() ? columnStatsData.getBitVectors() : null;
+      NumDistinctValueEstimator estimator = columnStatsData.getNdvEstimator();
+      logIncomingPartitionStats(colName, csp.getPartName(), columnStatsData, estimator != null,
+          bitVectors == null ? 0 : bitVectors.length);
 
       // check if we can merge NDV estimators
-      if (columnStatsData.getNdvEstimator() == null) {
+      if (estimator == null) {
         areAllNDVEstimatorsMergeable = false;
         break;
       } else {
-        NumDistinctValueEstimator estimator = columnStatsData.getNdvEstimator();
         if (ndvEstimator == null) {
           ndvEstimator = estimator;
         } else {
@@ -91,6 +90,7 @@ public class LongColumnStatsAggregator extends ColumnStatsAggregator implements
     LOG.debug("all of the bit vectors can merge for {} is {}", colName, areAllNDVEstimatorsMergeable);
 
     ColumnStatisticsData columnStatisticsData = initColumnStatisticsData();
+    String ndvSource = "ndvTuner bounds";
     if (doAllPartitionContainStats || colStatsWithSourceInfo.size() < 2) {
       LongColumnStatsDataInspector aggregateData = null;
       long lowerBound = 0;
@@ -123,6 +123,7 @@ public class LongColumnStatsAggregator extends ColumnStatsAggregator implements
         // use uniform distribution assumption because we can merge bitvectors
         // to get a good estimation.
         aggregateData.setNumDVs(ndvEstimator.estimateNumDistinctValues());
+        ndvSource = "merged estimator";
       } else {
         long estimation;
         if (useDensityFunctionForNDVEstimation) {
@@ -144,6 +145,7 @@ public class LongColumnStatsAggregator extends ColumnStatsAggregator implements
           } else if (estimation > higherBound) {
             estimation = higherBound;
           }
+          ndvSource = "density function";
         } else {
           estimation = (long) (lowerBound + (higherBound - lowerBound) * ndvTuner);
         }
@@ -239,6 +241,8 @@ public class LongColumnStatsAggregator extends ColumnStatsAggregator implements
       }
       extrapolate(columnStatisticsData, partNames.size(), colStatsWithSourceInfo.size(),
           adjustedIndexMap, adjustedStatsMap, densityAvgSum / adjustedStatsMap.size());
+      ndvSource = areAllNDVEstimatorsMergeable ? "merged estimator with extrapolation" :
+          (useDensityFunctionForNDVEstimation ? "density extrapolation" : "ndvTuner extrapolation");
     }
     LOG.debug(
         "Ndv estimation for {} is {}. # of partitions requested: {}. # of partitions found: {}",
@@ -252,6 +256,8 @@ public class LongColumnStatsAggregator extends ColumnStatsAggregator implements
 
     // mutate columnStatisticsData to ensure NDV <= the number of integers in the given range.
     adjustNDV(columnStatisticsData.getLongStats());
+
+    logAggregatedColumnStats(colName, columnStatisticsData.getLongStats(), ndvSource);
 
     statsObj.setStatsData(columnStatisticsData);
 
@@ -370,5 +376,23 @@ public class LongColumnStatsAggregator extends ColumnStatsAggregator implements
           columnStats.getNumDVs(), estimation, columnStats.getLowValue(), columnStats.getHighValue());
       columnStats.setNumDVs(estimation);
     }
+  }
+
+  private void logIncomingPartitionStats(String colName, String partName, LongColumnStatsDataInspector statsData,
+      boolean hasEstimator, int bitVectorBytes) {
+    if (!LOG.isInfoEnabled()) {
+      return;
+    }
+    LOG.info("Aggregating long stats for column {}, partition {}: NDV={}, low={}, high={}, {}", colName,
+        partName, statsData.getNumDVs(), statsData.getLowValue(), statsData.getHighValue(),
+        formatNdvMetadata(hasEstimator, bitVectorBytes));
+  }
+
+  private void logAggregatedColumnStats(String colName, LongColumnStatsData statsData, String ndvSource) {
+    if (!LOG.isInfoEnabled()) {
+      return;
+    }
+    LOG.info("Aggregated long stats for column {}: NDV={}, low={}, high={}, ndvSource={}", colName,
+        statsData.getNumDVs(), statsData.getLowValue(), statsData.getHighValue(), ndvSource);
   }
 }


### PR DESCRIPTION
## Summary
- log column statistics details before sending updates to the metastore
- capture NDV and min/max values per column along with table or partition scope

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69411a4417b08328933c6c2d90ab7792)