### PR TITLE
Add detailed logging for partition stats aggregation

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -9327,6 +9327,21 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
         TableName.getQualified(catName, dbName, tblName));
 
     List<String> lowerCaseColNames = new ArrayList<>(request.getColNames().size());
+    if (LOG.isInfoEnabled()) {
+      List<String> partNames = request.getPartNames();
+      String partitionSample = samplePartitionValues(partNames);
+      boolean tryDirectSql = MetastoreConf.getBoolVar(conf, ConfVars.TRY_DIRECT_SQL);
+      LOG.info("Aggregated stats request received: partNamesSize={}, colNamesSize={}, requestedPartsMetadata={}, "
+              + "partitionSample={}, engine={}, validWriteIdListSet={}, tryDirectSql={}, rawStoreClass={}",
+          request.getPartNamesSize(), request.getColNamesSize(), request.getPartNamesSize(),
+          partitionSample, request.getEngine(), request.isSetValidWriteIdList(),
+          tryDirectSql, getMS().getClass().getName());
+      if (partNames != null && partNames.size() > LOG_SAMPLE_PARTITIONS_MAX_SIZE) {
+        LOG.info("First and last partitions in request: first={}, last={}",
+            partNames.subList(0, LOG_SAMPLE_PARTITIONS_HALF_SIZE),
+            partNames.subList(partNames.size() - LOG_SAMPLE_PARTITIONS_HALF_SIZE, partNames.size()));
+      }
+    }
     for (String colName : request.getColNames()) {
       lowerCaseColNames.add(colName.toLowerCase());
     }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -136,6 +136,9 @@ class MetaStoreDirectSql {
   private static final Set<String> ALLOWED_TABLES_TO_LOCK = Set.of("NOTIFICATION_SEQUENCE");
 
   private static final Logger LOG = LoggerFactory.getLogger(MetaStoreDirectSql.class);
+  private static final int LOG_SAMPLE_PARTITIONS_MAX_SIZE = 4;
+  private static final int LOG_SAMPLE_PARTITIONS_HALF_SIZE = 2;
+  private static final String LOG_SAMPLE_PARTITIONS_SEPARATOR = ",";
   private final PersistenceManager pm;
   private final Configuration conf;
   private final String schema;
@@ -176,6 +179,24 @@ class MetaStoreDirectSql {
     return objectIds.stream()
                .map(i -> i.toString())
                .collect(Collectors.joining(","));
+  }
+
+  private static String samplePartitionNames(List<String> partNames) {
+    if (partNames == null || partNames.isEmpty()) {
+      return "[]";
+    }
+    StringBuilder sb = new StringBuilder("[");
+    if (partNames.size() > LOG_SAMPLE_PARTITIONS_MAX_SIZE) {
+      sb.append(String.join(LOG_SAMPLE_PARTITIONS_SEPARATOR,
+          partNames.subList(0, LOG_SAMPLE_PARTITIONS_HALF_SIZE)));
+      sb.append(" .... ");
+      sb.append(String.join(LOG_SAMPLE_PARTITIONS_SEPARATOR,
+          partNames.subList(partNames.size() - LOG_SAMPLE_PARTITIONS_HALF_SIZE, partNames.size())));
+    } else {
+      sb.append(String.join(LOG_SAMPLE_PARTITIONS_SEPARATOR, partNames));
+    }
+    sb.append("]");
+    return sb.toString();
   }
 
   @java.lang.annotation.Target(java.lang.annotation.ElementType.FIELD)
@@ -1767,6 +1788,13 @@ class MetaStoreDirectSql {
     }
     long partsFound = 0;
     List<ColumnStatisticsObj> colStatsList;
+    if (LOG.isInfoEnabled()) {
+      LOG.info("Direct SQL aggregate stats for {}.{}.{}: partitionsRequested={}, columnsRequested={}, "
+              + "partitionSample={}, batchSize={}, useDensityFunctionForNDVEstimation={}, "
+              + "enableBitVector={}, enableKll={}", catName, dbName, tableName, partNames.size(),
+          colNames.size(), samplePartitionNames(partNames), batchSize, useDensityFunctionForNDVEstimation,
+          enableBitVector, enableKll);
+    }
     // Try to read from the cache first
     if (isAggregateStatsCacheEnabled
         && (partNames.size() < aggrStatsCache.getMaxPartsPerCacheNode())) {
@@ -1808,6 +1836,11 @@ class MetaStoreDirectSql {
       colStatsList =
           columnStatisticsObjForPartitions(catName, dbName, tableName, partNames, colNames, engine, partsFound,
               useDensityFunctionForNDVEstimation, ndvTuner, enableBitVector, enableKll);
+    }
+    if (LOG.isInfoEnabled()) {
+      LOG.info("Direct SQL aggregate stats completed for {}.{}.{}: partitionsWithStats={}, totalPartitionsRequested={}, "
+              + "partitionSample={}", catName, dbName, tableName, partsFound, partNames.size(),
+          samplePartitionNames(partNames));
     }
     LOG.debug("useDensityFunctionForNDVEstimation = " + useDensityFunctionForNDVEstimation
         + "\npartsFound = " + partsFound + "\nColumnStatisticsObj = "
@@ -1878,12 +1911,26 @@ class MetaStoreDirectSql {
       List<String> colNames, String engine, long partsFound, final boolean useDensityFunctionForNDVEstimation,
       final double ndvTuner, final boolean enableBitVector, boolean enableKll) throws MetaException {
     final boolean areAllPartsFound = (partsFound == partNames.size());
+    if (LOG.isInfoEnabled()) {
+      LOG.info("Direct SQL fetching column statistics objects: partitionsRequested={}, columnsRequested={}, "
+              + "areAllPartsFound={}, partitionSample={}, batchSize={}", partNames.size(), colNames.size(),
+          areAllPartsFound, samplePartitionNames(partNames), batchSize);
+    }
     return Batchable.runBatched(batchSize, colNames, new Batchable<String, ColumnStatisticsObj>() {
       @Override
       public List<ColumnStatisticsObj> run(final List<String> inputColNames) throws MetaException {
+        if (LOG.isInfoEnabled()) {
+          LOG.info("Processing column batch for aggregation: batchSize={}, columns={}", inputColNames.size(),
+              inputColNames);
+        }
         return Batchable.runBatched(batchSize, partNames, new Batchable<String, ColumnStatisticsObj>() {
           @Override
           public List<ColumnStatisticsObj> run(List<String> inputPartNames) throws MetaException {
+            if (LOG.isInfoEnabled()) {
+              LOG.info("Processing partition batch for columns {}: batchSize={}, partitionSample={}, "
+                      + "resultsAccumulated=true", inputColNames, inputPartNames.size(),
+                  samplePartitionNames(inputPartNames));
+            }
             return columnStatisticsObjForPartitionsBatch(catName, dbName, tableName, inputPartNames,
                 inputColNames, engine, areAllPartsFound, useDensityFunctionForNDVEstimation, ndvTuner,
                 enableBitVector, enableKll);
@@ -1933,6 +1980,11 @@ class MetaStoreDirectSql {
       boolean areAllPartsFound, boolean useDensityFunctionForNDVEstimation, double ndvTuner,
       boolean enableBitVector, boolean enableKll)
       throws MetaException {
+    if (LOG.isInfoEnabled()) {
+      LOG.info("Executing columnStatisticsObjForPartitionsBatch: table={}.{}.{} partitionsInBatch={}, columnsInBatch={}, "
+              + "areAllPartsFound={}, partitionSample={}", catName, dbName, tableName, partNames.size(),
+          colNames.size(), areAllPartsFound, samplePartitionNames(partNames));
+    }
     if (enableBitVector || enableKll) {
       return aggrStatsUseJava(catName, dbName, tableName, partNames, colNames, engine, areAllPartsFound,
           useDensityFunctionForNDVEstimation, ndvTuner, enableBitVector, enableKll);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreServerUtils.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreServerUtils.java
@@ -119,6 +119,9 @@ import org.slf4j.LoggerFactory;
 public class MetaStoreServerUtils {
   private static final Charset ENCODING = StandardCharsets.UTF_8;
   private static final Logger LOG = LoggerFactory.getLogger(MetaStoreServerUtils.class);
+  private static final int LOG_SAMPLE_PARTITIONS_MAX_SIZE = 4;
+  private static final int LOG_SAMPLE_PARTITIONS_HALF_SIZE = 2;
+  private static final String LOG_SAMPLE_PARTITIONS_SEPARATOR = ",";
 
   public static final String JUNIT_DATABASE_PREFIX = "junit_metastore_db";
 
@@ -136,6 +139,24 @@ public class MetaStoreServerUtils {
   private static final String DELEGATION_TOKEN_STORE_CLS = "hive.cluster.delegation.token.store.class";
 
   private static final char DOT = '.';
+
+  private static String samplePartitionNames(List<String> partNames) {
+    if (CollectionUtils.isEmpty(partNames)) {
+      return "[]";
+    }
+    StringBuilder sb = new StringBuilder("[");
+    if (partNames.size() > LOG_SAMPLE_PARTITIONS_MAX_SIZE) {
+      sb.append(String.join(LOG_SAMPLE_PARTITIONS_SEPARATOR,
+          partNames.subList(0, LOG_SAMPLE_PARTITIONS_HALF_SIZE)));
+      sb.append(" .... ");
+      sb.append(String.join(LOG_SAMPLE_PARTITIONS_SEPARATOR,
+          partNames.subList(partNames.size() - LOG_SAMPLE_PARTITIONS_HALF_SIZE, partNames.size())));
+    } else {
+      sb.append(String.join(LOG_SAMPLE_PARTITIONS_SEPARATOR, partNames));
+    }
+    sb.append("]");
+    return sb.toString();
+  }
 
   /**
    * We have a need to sanity-check the map before conversion from persisted objects to
@@ -171,7 +192,12 @@ public class MetaStoreServerUtils {
     // Group stats by colName for each partition
     Map<String, ColumnStatsAggregator> aliasToAggregator =
         new HashMap<String, ColumnStatsAggregator>();
-    LOG.info("xxxxx1 aggrPartitionStats: partStats.size={}", partStats.size());
+    if (LOG.isInfoEnabled()) {
+      LOG.info("Preparing aggregate partition stats for {}: partStats.size={}, partNames.size={}, colNames.size={}, "
+              + "partitionSample={}", TableName.getQualified(catName, dbName, tableName), partStats.size(),
+          partNames == null ? 0 : partNames.size(), colNames == null ? 0 : colNames.size(),
+          samplePartitionNames(partNames));
+    }
     for (ColumnStatistics css : partStats) {
       List<ColumnStatisticsObj> objs = css.getStatsObj();
       for (ColumnStatisticsObj obj : objs) {
@@ -186,6 +212,12 @@ public class MetaStoreServerUtils {
         colStatsMap.get(aliasToAggregator.get(obj.getColName()))
             .add(new ColStatsObjWithSourceInfo(obj, catName, dbName, tableName, partName));
       }
+    }
+    if (LOG.isInfoEnabled()) {
+      int totalColStatsEntries = colStatsMap.values().stream().mapToInt(List::size).sum();
+      LOG.info("Column stats map prepared for aggregation: columns={}, colStatsEntries={}, requestedPartitions={}, "
+              + "partitionSample={}", colStatsMap.size(), totalColStatsEntries,
+          partNames == null ? 0 : partNames.size(), samplePartitionNames(partNames));
     }
     if (colStatsMap.size() < 1) {
       LOG.info("No stats data found for: tblName= {}, partNames= {}, colNames= {}",
@@ -212,12 +244,33 @@ public class MetaStoreServerUtils {
     long start = System.currentTimeMillis();
     for (final Map.Entry<ColumnStatsAggregator, List<ColStatsObjWithSourceInfo>> entry : colStatsMap
         .entrySet()) {
-      LOG.info("xxx inside loop {}, ColStatsObjWithSourceInfo list size={}", entry.getKey(), entry.getValue().size());
+      if (LOG.isInfoEnabled()) {
+        String columnName = entry.getValue().isEmpty() ? "unknown"
+            : entry.getValue().get(0).getColStatsObj().getColName();
+        int partitionsWithStats = (int) entry.getValue().stream()
+            .map(ColStatsObjWithSourceInfo::getPartName).distinct().count();
+        LOG.info("Submitting aggregation task for column {}: colStatsWithSourceInfo.size={}, partitionsWithStats={}, "
+                + "totalRequestedPartitions={}, partitionSample={}, resultsAppended=true",
+            columnName, entry.getValue().size(), partitionsWithStats, partNames.size(),
+            samplePartitionNames(entry.getValue().stream().map(ColStatsObjWithSourceInfo::getPartName)
+                .collect(Collectors.toList())));
+      }
       futures.add(pool.submit(new Callable<ColumnStatisticsObj>() {
         @Override
         public ColumnStatisticsObj call() throws MetaException {
           List<ColStatsObjWithSourceInfo> colStatWithSourceInfo = entry.getValue();
           ColumnStatsAggregator aggregator = entry.getKey();
+          if (LOG.isInfoEnabled()) {
+            List<String> partitionsForColumn = colStatWithSourceInfo.stream()
+                .map(ColStatsObjWithSourceInfo::getPartName).collect(Collectors.toList());
+            int partitionsWithStats = (int) partitionsForColumn.stream().distinct().count();
+            LOG.info("Aggregating column stats for {}: colStatsWithSourceInfo.size={}, partitionsWithStats={}, "
+                    + "totalRequestedPartitions={}, partitionSample={}",
+                colStatWithSourceInfo.isEmpty() ? "unknown"
+                    : colStatWithSourceInfo.get(0).getColStatsObj().getColName(),
+                colStatWithSourceInfo.size(), partitionsWithStats, partNames.size(),
+                samplePartitionNames(partitionsForColumn.isEmpty() ? partNames : partitionsForColumn));
+          }
           try {
             ColumnStatisticsObj statsObj =
                 aggregator.aggregate(colStatWithSourceInfo, partNames, areAllPartsFound);


### PR DESCRIPTION
## Summary
- add request-level logging for aggregate partition stats requests, including partition samples and direct-SQL intent
- log aggregation batch sizes and partition samples while preparing and executing partition stats aggregation utilities
- log direct SQL aggregation batches and partition samples during column statistics retrieval

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694213a3f93c8328911802478aa986a7)