### PR TITLE
Fix vectorized consumeAll group-boundary handling for KeyValueReader edges

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordProcessor.java
@@ -301,8 +301,18 @@ public class ReduceRecordProcessor extends RecordProcessor {
 
     // run the operator pipeline
     startAbortChecks();
-    while (sources[bigTablePosition].pushRecord()) {
-      addRowAndMaybeCheckAbort();
+    ReduceRecordSource bigTableSource = sources[bigTablePosition];
+    if (bigTableSource.canConsumeAll()) {
+      bigTableSource.consumeAll(new ReduceRecordSource.RecordProgress() {
+        @Override
+        public void onRecord() throws InterruptedException {
+          addRowAndMaybeCheckAbort();
+        }
+      });
+    } else {
+      while (bigTableSource.pushRecord()) {
+        addRowAndMaybeCheckAbort();
+      }
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
@@ -403,8 +403,33 @@ public class ReduceRecordSource implements RecordSource {
   }
 
   private boolean pushRecordVector() {
-    assert !isKeyValueReader;
+    if (isKeyValueReader) {
+      return pushRecordVectorFromKeyValue();
+    }
     return pushRecordVectorFromKeyValues();
+  }
+
+  private boolean pushRecordVectorFromKeyValue() {
+    try {
+      if (!keyValueReader.next()) {
+        return false;
+      }
+
+      BytesWritable keyWritable = keyValueReader.getCurrentKey();
+      BytesWritable valueWritable = keyValueReader.getCurrentValue();
+
+      processVectorRecord(keyWritable, valueWritable, tag);
+      return true;
+    } catch (Throwable e) {
+      abort = true;
+      if (e instanceof OutOfMemoryError) {
+        // Don't create a new object if we are already out of memory
+        throw (OutOfMemoryError) e;
+      } else {
+        l4j.error(StringUtils.stringifyException(e));
+        throw new RuntimeException(e);
+      }
+    }
   }
 
   private boolean pushRecordVectorFromKeyValues() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import org.apache.tez.runtime.library.api.KeyValueReaderEdge;
 import org.apache.tez.runtime.library.api.KeyValuesReaderEdge;
@@ -107,6 +108,9 @@ public class ReduceRecordSource implements RecordSource {
   private StructObjectInspector valueStructInspectors;
 
   private KeyValuesAdapter reader;
+  private KeyValueReaderEdge keyValueReader;
+  private KeyValuesReaderEdge keyValuesReader;
+  private boolean isKeyValueReader;
 
   private boolean handleGroupKey;
 
@@ -144,9 +148,17 @@ public class ReduceRecordSource implements RecordSource {
     this.vectorized = vectorized;
     this.keyTableDesc = keyTableDesc;
     if (reader instanceof KeyValueReaderEdge) {
-      this.reader = new KeyValuesFromKeyValue((KeyValueReaderEdge) reader);
+      this.isKeyValueReader = true;
+      this.keyValueReader = (KeyValueReaderEdge) reader;
+      if (!vectorized) {
+        this.reader = new KeyValuesFromKeyValue((KeyValueReaderEdge) reader);
+      }
     } else {
-      this.reader = new KeyValuesFromKeyValues((KeyValuesReaderEdge) reader);
+      this.isKeyValueReader = false;
+      this.keyValuesReader = (KeyValuesReaderEdge) reader;
+      if (!vectorized) {
+        this.reader = new KeyValuesFromKeyValues((KeyValuesReaderEdge) reader);
+      }
     }
     this.handleGroupKey = handleGroupKey;
     this.tag = tag;
@@ -253,7 +265,6 @@ public class ReduceRecordSource implements RecordSource {
 
   @Override
   public boolean pushRecord() throws HiveException {
-
     if (vectorized) {
       return pushRecordVector();
     }
@@ -392,13 +403,18 @@ public class ReduceRecordSource implements RecordSource {
   }
 
   private boolean pushRecordVector() {
+    assert !isKeyValueReader;
+    return pushRecordVectorFromKeyValues();
+  }
+
+  private boolean pushRecordVectorFromKeyValues() {
     try {
-      if (!reader.next()) {
+      if (!keyValuesReader.next()) {
         return false;
       }
 
-      BytesWritable keyWritable = reader.getCurrentKey();
-      valueWritables = reader.getCurrentValues();
+      BytesWritable keyWritable = keyValuesReader.getCurrentKey();
+      valueWritables = keyValuesReader.getCurrentValues();
 
       processVectorGroup(keyWritable, valueWritables, tag);
       return true;
@@ -414,6 +430,111 @@ public class ReduceRecordSource implements RecordSource {
     }
   }
 
+  @FunctionalInterface
+  interface RecordProgress {
+    void onRecord() throws InterruptedException;
+  }
+
+  boolean canConsumeAll() {
+    return vectorized && keyValueReader != null;
+  }
+
+  long consumeAll(RecordProgress progress) throws HiveException, InterruptedException {
+    try {
+      long records = keyValueReader.consumeAll(new BiConsumer<BytesWritable, BytesWritable>() {
+        @Override
+        public void accept(BytesWritable keyWritable, BytesWritable valueWritable) {
+          try {
+            processVectorRecord(keyWritable, valueWritable, tag);
+            progress.onRecord();
+          } catch (OutOfMemoryError e) {
+            throw e;
+          } catch (HiveException | InterruptedException e) {
+            throw new RuntimeException(e);
+          } catch (Throwable t) {
+            throw new RuntimeException(new HiveException(t));
+          }
+        }
+      });
+      return records;
+    } catch (OutOfMemoryError e) {
+      abort = true;
+      throw e;
+    } catch (RuntimeException e) {
+      abort = true;
+      Throwable cause = e.getCause();
+      if (cause instanceof HiveException) {
+        throw (HiveException) cause;
+      } else if (cause instanceof InterruptedException) {
+        throw (InterruptedException) cause;
+      }
+      throw new HiveException(e);
+    } catch (Exception e) {
+      abort = true;
+      throw new HiveException(e);
+    }
+  }
+
+  private void processVectorRecord(BytesWritable keyWritable, BytesWritable valueWritable, byte tag)
+      throws HiveException, IOException {
+    if (reducer.batchNeedsClone()) {
+      batch = batchContext.createVectorizedRowBatch();
+    }
+    Preconditions.checkState(batch.size == 0);
+
+    // Deserialize key into vector row columns.
+    byte[] keyBytes = keyWritable.getBytesRaw();
+    int keyOffset = keyWritable.getOffset();
+    int keyLength = keyWritable.getLength();
+
+    keyBinarySortableDeserializeToRow.setBytes(keyBytes, keyOffset, keyLength);
+    try {
+      keyBinarySortableDeserializeToRow.deserialize(batch, 0);
+    } catch (Exception e) {
+      throw new HiveException(
+          "\nDeserializeRead details: " +
+              keyBinarySortableDeserializeToRow.getDetailedReadPositionString(),
+          e);
+    }
+    for (int i = 0; i < firstValueColumnOffset; i++) {
+      VectorizedBatchUtil.setRepeatingColumn(batch, i);
+    }
+
+    try {
+      if (valueLazyBinaryDeserializeToRow != null) {
+        // Deserialize value into vector row columns.
+        byte[] valueBytes = valueWritable.getBytesRaw();
+        int valueOffset = valueWritable.getOffset();
+        int valueLength = valueWritable.getLength();
+
+        valueLazyBinaryDeserializeToRow.setBytes(valueBytes, valueOffset, valueLength);
+        valueLazyBinaryDeserializeToRow.deserialize(batch, 0);
+      }
+      batch.size = 1;
+      if (handleGroupKey) {
+        reducer.setNextVectorBatchGroupStatus(/* isLastGroupBatch */ true);
+      }
+      reducer.process(batch, tag);
+
+      // reset only when we reuse the batch
+      if (!reducer.batchNeedsClone()) {
+        batch.reset();
+      }
+    } catch (Exception e) {
+      String rowString = null;
+      try {
+        rowString = batch.toString();
+      } catch (Exception e2) {
+        rowString = "[Error getting row data with exception "
+            + StringUtils.stringifyException(e2) + " ]";
+      }
+      l4j.error("Hive Runtime Error while processing vector batch (tag=" + tag
+          + ") (vectorizedVertexNum " + vectorizedVertexNum + ") " + rowString, e);
+      throw new HiveException("Hive Runtime Error while processing vector batch (tag="
+          + tag + ") (vectorizedVertexNum " + vectorizedVertexNum + ")", e);
+    }
+  }
+
   /**
    *
    * @param keyWritable
@@ -424,6 +545,11 @@ public class ReduceRecordSource implements RecordSource {
    */
   private void processVectorGroup(BytesWritable keyWritable,
           Iterable<? extends BytesWritable> values, byte tag) throws HiveException, IOException {
+    // NOTE: This method must consume the full value iterable for one reduce key in a single call.
+    // Some downstream operators (e.g. vector group by / PTF) rely on
+    // setNextVectorBatchGroupStatus(true) being sent only for the real final batch of that key.
+    // Splitting values into multiple disjoint iterables and invoking this method multiple times for
+    // the same key can make an intermediate batch look like the last group batch and break semantics.
 
     if (reducer.batchNeedsClone()) {
       batch = batchContext.createVectorizedRowBatch();

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
@@ -477,7 +477,12 @@ public class ReduceRecordSource implements RecordSource {
               pendingKey[0] = copyBytesWritable(keyWritable);
               pendingValue[0] = copyBytesWritable(valueWritable);
               return;
-            }
+    processVectorRecord(keyWritable, valueWritable, tag, true);
+  }
+
+  private void processVectorRecord(BytesWritable keyWritable, BytesWritable valueWritable, byte tag,
+      boolean isLastGroupBatch) throws HiveException, IOException {
+        reducer.setNextVectorBatchGroupStatus(isLastGroupBatch);
 
             final boolean isLastGroupBatch = !pendingKey[0].equals(keyWritable);
             processVectorRecord(pendingKey[0], pendingValue[0], tag, isLastGroupBatch);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
@@ -441,12 +441,25 @@ public class ReduceRecordSource implements RecordSource {
 
   long consumeAll(RecordProgress progress) throws HiveException, InterruptedException {
     try {
+      final BytesWritable[] pendingKey = new BytesWritable[1];
+      final BytesWritable[] pendingValue = new BytesWritable[1];
+
       long records = keyValueReader.consumeAll(new BiConsumer<BytesWritable, BytesWritable>() {
         @Override
         public void accept(BytesWritable keyWritable, BytesWritable valueWritable) {
           try {
-            processVectorRecord(keyWritable, valueWritable, tag);
+            if (pendingKey[0] == null) {
+              pendingKey[0] = copyBytesWritable(keyWritable);
+              pendingValue[0] = copyBytesWritable(valueWritable);
+              return;
+            }
+
+            final boolean isLastGroupBatch = !pendingKey[0].equals(keyWritable);
+            processVectorRecord(pendingKey[0], pendingValue[0], tag, isLastGroupBatch);
             progress.onRecord();
+
+            pendingKey[0] = copyBytesWritable(keyWritable);
+            pendingValue[0] = copyBytesWritable(valueWritable);
           } catch (OutOfMemoryError e) {
             throw e;
           } catch (HiveException | InterruptedException e) {
@@ -456,6 +469,11 @@ public class ReduceRecordSource implements RecordSource {
           }
         }
       });
+
+      if (pendingKey[0] != null) {
+        processVectorRecord(pendingKey[0], pendingValue[0], tag, true);
+        progress.onRecord();
+      }
       return records;
     } catch (OutOfMemoryError e) {
       abort = true;
@@ -475,8 +493,15 @@ public class ReduceRecordSource implements RecordSource {
     }
   }
 
-  private void processVectorRecord(BytesWritable keyWritable, BytesWritable valueWritable, byte tag)
-      throws HiveException, IOException {
+  private BytesWritable copyBytesWritable(BytesWritable writable) {
+    final int offset = writable.getOffset();
+    final int length = writable.getLength();
+    final byte[] rawBytes = writable.getBytesRaw();
+    return new BytesWritable(Arrays.copyOfRange(rawBytes, offset, offset + length));
+  }
+
+  private void processVectorRecord(BytesWritable keyWritable, BytesWritable valueWritable, byte tag,
+      boolean isLastGroupBatch) throws HiveException, IOException {
     if (reducer.batchNeedsClone()) {
       batch = batchContext.createVectorizedRowBatch();
     }
@@ -512,7 +537,7 @@ public class ReduceRecordSource implements RecordSource {
       }
       batch.size = 1;
       if (handleGroupKey) {
-        reducer.setNextVectorBatchGroupStatus(/* isLastGroupBatch */ true);
+        reducer.setNextVectorBatchGroupStatus(isLastGroupBatch);
       }
       reducer.process(batch, tag);
 


### PR DESCRIPTION
### Motivation
- A vectorized fast-path (`consumeAll`) for `KeyValueReaderEdge` was added to speed up reduce input consumption, but it always marked each processed row as the last batch of its group which can break downstream grouped vector operators when adjacent rows share the same key. 
- The change aims to preserve reduce-group semantics for vectorized processing without adding new defensive checks. 

### Description
- Update `ReduceRecordSource.consumeAll` to buffer a pending key/value pair and only emit the pending row when the next key is seen or on flush, so the `isLastGroupBatch` flag reflects true group boundaries. 
- Add `copyBytesWritable` helper to copy reader-owned `BytesWritable` payloads before storing them in the pending slot to avoid relying on reader reuse semantics. 
- Change `processVectorRecord` signature to accept an explicit `isLastGroupBatch` parameter and use it when calling `reducer.setNextVectorBatchGroupStatus(...)`. 
- Preserve the existing fast-path and integration with `ReduceRecordProcessor.run()` (which invokes `consumeAll` when `canConsumeAll()` returns true). 

### Testing
- Attempted to compile the `ql` module with `mvn -pl ql -DskipTests -DskipITs compile`, but the build failed in this environment because Maven could not resolve the parent POM from Maven Central (HTTP 403), so a full compile could not be completed. 
- Performed code inspection and grep-based verification that `canConsumeAll()`/`consumeAll()` are used from `ReduceRecordProcessor` and that `processVectorRecord` was updated appropriately, and those checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd926e30c8328a9ee079b641a83d1)