### PR TITLE
Add nanoTime task lifecycle logs to Tez processors

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordProcessor.java
@@ -116,7 +116,9 @@ public class ReduceRecordProcessor extends RecordProcessor {
     checkAbortCondition();
     if (shuffleInputs != null) {
       LOG.info("Waiting for ShuffleInputs to become ready");
+      LOG.info("TASK_INIT_WAIT {} {}", processorContext.getTaskAttemptIdStr(), System.nanoTime());
       processorContext.waitForAllInputsReady(new ArrayList<Input>(shuffleInputs));
+      LOG.info("TASK_INIT_FINISH {} {}", processorContext.getTaskAttemptIdStr(), System.nanoTime());
     }
 
     connectOps.clear();

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
@@ -224,6 +224,8 @@ public class TezProcessor extends AbstractLogicalIOProcessor {
       return null;
     }
 
+    LOG.info("TASK_START {} {}", getContext().getTaskAttemptIdStr(), System.nanoTime());
+
     perfLogger.perfLogBegin(CLASS_NAME, PerfLogger.TEZ_RUN_PROCESSOR);
     // in case of broadcast-join read the broadcast edge inputs
     // (possibly asynchronously)
@@ -236,6 +238,7 @@ public class TezProcessor extends AbstractLogicalIOProcessor {
       // This check isn't absolutely mandatory, given the aborted check outside of the
       // Processor creation.
       if (aborted.get()) {
+        LOG.info("TASK_END {} {}", getContext().getTaskAttemptIdStr(), System.nanoTime());
         return null;
       }
 
@@ -263,8 +266,10 @@ public class TezProcessor extends AbstractLogicalIOProcessor {
     if (limitRecords != null) {
       LOG.info("Reporting query limit and # of records: {}, {}, {}",
           processorContext.getTaskAttemptIdStr(), limitRecords._1(), limitRecords._2());
+      LOG.info("TASK_END {} {}", getContext().getTaskAttemptIdStr(), System.nanoTime());
       return limitRecords;
     } else {
+      LOG.info("TASK_END {} {}", getContext().getTaskAttemptIdStr(), System.nanoTime());
       return null;
     }
   }


### PR DESCRIPTION
### Motivation
- Improve visibility into Tez task lifecycle timing (start, input-wait and end) to aid performance debugging and tracing.

### Description
- Add logging statements that emit `TASK_START` and `TASK_END` with `getContext().getTaskAttemptIdStr()` and `System.nanoTime()` to `TezProcessor.run` and additional `TASK_END` logging for early-abort and limit-return paths, and add `TASK_INIT_WAIT` / `TASK_INIT_FINISH` logs around `processorContext.waitForAllInputsReady(...)` in `ReduceRecordProcessor.init`.

### Testing
- No automated tests were run for this instrumentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd6f9cbc18832896956ba3e146850c)