### PR TITLE
Bulk-append sortable primitives in BinarySortableSerDe; add write(byte[]) override and align RandomAccessOutput signature

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/io/NonSyncByteArrayOutputStream.java
+++ b/common/src/java/org/apache/hadoop/hive/common/io/NonSyncByteArrayOutputStream.java
@@ -115,6 +115,14 @@ public class NonSyncByteArrayOutputStream extends ByteArrayOutputStream {
    * {@inheritDoc}
    */
   @Override
+  public void write(byte b[]) {
+    write(b, 0, b.length);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
   public void write(byte b[], int off, int len) {
     if ((off < 0) || (off > b.length) || (len < 0) || ((off + len) > b.length)
         || ((off + len) < 0)) {

--- a/serde/src/java/org/apache/hadoop/hive/serde2/ByteStream.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/ByteStream.java
@@ -127,7 +127,7 @@ public class ByteStream {
 
     // append with write-position advance
     public void write(int b);
-    public void write(byte b[]) throws IOException;
+    public void write(byte b[]);
     public void write(byte b[], int off, int len);
 
     // append with write-position advance

--- a/serde/src/java/org/apache/hadoop/hive/serde2/binarysortable/BinarySortableSerDe.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/binarysortable/BinarySortableSerDe.java
@@ -873,55 +873,49 @@ public class BinarySortableSerDe extends AbstractSerDe {
   }
 
   public static void serializeInt(ByteStream.Output buffer, int v, boolean invert) {
-    writeByte(buffer, (byte) ((v >> 24) ^ 0x80), invert);
-    writeByte(buffer, (byte) (v >> 16), invert);
-    writeByte(buffer, (byte) (v >> 8), invert);
-    writeByte(buffer, (byte) v, invert);
+    int sortable = v ^ 0x80000000;
+    if (invert) {
+      sortable = ~sortable;
+    }
+    buffer.appendInt(sortable);
   }
 
   public static void serializeLong(ByteStream.Output buffer, long v, boolean invert) {
-    writeByte(buffer, (byte) ((v >> 56) ^ 0x80), invert);
-    writeByte(buffer, (byte) (v >> 48), invert);
-    writeByte(buffer, (byte) (v >> 40), invert);
-    writeByte(buffer, (byte) (v >> 32), invert);
-    writeByte(buffer, (byte) (v >> 24), invert);
-    writeByte(buffer, (byte) (v >> 16), invert);
-    writeByte(buffer, (byte) (v >> 8), invert);
-    writeByte(buffer, (byte) v, invert);
+    long sortable = v ^ 0x8000000000000000L;
+    if (invert) {
+      sortable = ~sortable;
+    }
+    buffer.appendLong(sortable);
   }
 
   public static void serializeFloat(ByteStream.Output buffer, float vf, boolean invert) {
-    int v = Float.floatToIntBits(vf);
-    if ((v & (1 << 31)) != 0) {
+    int sortable = Float.floatToIntBits(vf);
+    if ((sortable & (1 << 31)) != 0) {
       // negative number, flip all bits
-      v = ~v;
+      sortable = ~sortable;
     } else {
       // positive number, flip the first bit
-      v = v ^ (1 << 31);
+      sortable = sortable ^ (1 << 31);
     }
-    writeByte(buffer, (byte) (v >> 24), invert);
-    writeByte(buffer, (byte) (v >> 16), invert);
-    writeByte(buffer, (byte) (v >> 8), invert);
-    writeByte(buffer, (byte) v, invert);
+    if (invert) {
+      sortable = ~sortable;
+    }
+    buffer.appendInt(sortable);
   }
 
   public static void serializeDouble(ByteStream.Output buffer, double vd, boolean invert) {
-    long v = Double.doubleToLongBits(vd);
-    if ((v & (1L << 63)) != 0) {
+    long sortable = Double.doubleToLongBits(vd);
+    if ((sortable & (1L << 63)) != 0) {
       // negative number, flip all bits
-      v = ~v;
+      sortable = ~sortable;
     } else {
       // positive number, flip the first bit
-      v = v ^ (1L << 63);
+      sortable = sortable ^ (1L << 63);
     }
-    writeByte(buffer, (byte) (v >> 56), invert);
-    writeByte(buffer, (byte) (v >> 48), invert);
-    writeByte(buffer, (byte) (v >> 40), invert);
-    writeByte(buffer, (byte) (v >> 32), invert);
-    writeByte(buffer, (byte) (v >> 24), invert);
-    writeByte(buffer, (byte) (v >> 16), invert);
-    writeByte(buffer, (byte) (v >> 8), invert);
-    writeByte(buffer, (byte) v, invert);
+    if (invert) {
+      sortable = ~sortable;
+    }
+    buffer.appendLong(sortable);
   }
 
   public static void serializeTimestampWritable(ByteStream.Output buffer, TimestampWritableV2 t, boolean invert) {
@@ -934,8 +928,14 @@ public class BinarySortableSerDe extends AbstractSerDe {
   public static void serializeTimestampTZWritable(
       ByteStream.Output buffer, TimestampLocalTZWritable t, boolean invert) {
     byte[] data = t.toBinarySortable();
-    for (byte b : data) {
-      writeByte(buffer, b, invert);
+    if (invert) {
+      byte[] inverted = new byte[data.length];
+      for (int i = 0; i < data.length; i++) {
+        inverted[i] = (byte) (0xff ^ data[i]);
+      }
+      buffer.write(inverted);
+    } else {
+      buffer.write(data);
     }
   }
 
@@ -1038,10 +1038,11 @@ public class BinarySortableSerDe extends AbstractSerDe {
      * Finally write out the pieces (sign, power, digits)
      */
     writeByte(buffer, (byte) ( signum + 1), invert);
-    writeByte(buffer, (byte) ((factor >> 24) ^ 0x80), invert);
-    writeByte(buffer, (byte) ( factor >> 16), invert);
-    writeByte(buffer, (byte) ( factor >> 8), invert);
-    writeByte(buffer, (byte)   factor, invert);
+    int sortableFactor = factor ^ 0x80000000;
+    if (invert) {
+      sortableFactor = ~sortableFactor;
+    }
+    buffer.appendInt(sortableFactor);
 
     // The toDigitsOnlyBytes stores digits at the end of the scratch buffer.
     serializeBytes(
@@ -1081,10 +1082,11 @@ public class BinarySortableSerDe extends AbstractSerDe {
        * Finally write out the pieces (sign, power, digits)
        */
       writeByte(buffer, (byte) ( signum + 1), invert);
-      writeByte(buffer, (byte) ((factor >> 24) ^ 0x80), invert);
-      writeByte(buffer, (byte) ( factor >> 16), invert);
-      writeByte(buffer, (byte) ( factor >> 8), invert);
-      writeByte(buffer, (byte)   factor, invert);
+      int sortableFactor = factor ^ 0x80000000;
+      if (invert) {
+        sortableFactor = ~sortableFactor;
+      }
+      buffer.appendInt(sortableFactor);
 
       // The toDigitsOnlyBytes stores digits at the end of the scratch buffer.
       serializeBytes(

--- a/serde/src/java/org/apache/hadoop/hive/serde2/binarysortable/BinarySortableSerDe.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/binarysortable/BinarySortableSerDe.java
@@ -929,14 +929,11 @@ public class BinarySortableSerDe extends AbstractSerDe {
       ByteStream.Output buffer, TimestampLocalTZWritable t, boolean invert) {
     byte[] data = t.toBinarySortable();
     if (invert) {
-      byte[] inverted = new byte[data.length];
       for (int i = 0; i < data.length; i++) {
-        inverted[i] = (byte) (0xff ^ data[i]);
+        data[i] = (byte) (0xff ^ data[i]);
       }
-      buffer.write(inverted);
-    } else {
-      buffer.write(data);
     }
+    buffer.write(data);
   }
 
   public static void serializeHiveIntervalYearMonth(ByteStream.Output buffer,


### PR DESCRIPTION
### Motivation

- Reduce per-byte writes and improve performance/clarity when serializing sortable numeric types by emitting native-sized values when possible.
- Provide a convenience `write(byte[])` override on the byte-array output to simplify callers.
- Align interface signatures to remove an unnecessary `throws IOException` from `RandomAccessOutput.write(byte[])`.

### Description

- Added `@Override public void write(byte b[])` to `NonSyncByteArrayOutputStream` which delegates to `write(b, 0, b.length)`.
- Removed `throws IOException` from the `RandomAccessOutput.write(byte b[])` method signature in `ByteStream` to match the non-throwing implementation.
- Reworked `BinarySortableSerDe` serialization methods to compute sortable representations and use bulk appends instead of emitting bytes one-by-one, including `serializeInt`, `serializeLong`, `serializeFloat`, `serializeDouble`, and decimal factor encoding using `buffer.appendInt`/`appendLong`.
- Optimized `serializeTimestampTZWritable` to write the byte array in bulk and apply inversion in a single pass when `invert` is true.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17bf5e183c8328a32af5bcc099ce2b)