### PR TITLE
Optimize long deserialization in BinarySortableSerDe with Unsafe-backed readLong

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/binarysortable/BinarySortableSerDe.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/binarysortable/BinarySortableSerDe.java
@@ -571,11 +571,7 @@ public class BinarySortableSerDe extends AbstractSerDe {
   }
 
   private static long deserializeLong(InputByteBuffer buffer, boolean invert) throws IOException {
-    long v = buffer.read(invert) ^ 0x80;
-    for (int i = 0; i < 7; i++) {
-      v = (v << 8) + (buffer.read(invert) & 0xff);
-    }
-    return v;
+    return buffer.readLong(invert) ^ (1L << 63);
   }
 
   static int getCharacterMaxLength(TypeInfo type) {

--- a/serde/src/java/org/apache/hadoop/hive/serde2/binarysortable/InputByteBuffer.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/binarysortable/InputByteBuffer.java
@@ -20,6 +20,9 @@ package org.apache.hadoop.hive.serde2.binarysortable;
 import java.io.EOFException;
 import java.io.IOException;
 
+import static org.apache.tez.util.FastByteComparisons.BYTE_ARRAY_BASE_OFFSET;
+import static org.apache.tez.util.FastByteComparisons.theUnsafe;
+
 /**
  * This class is much more efficient than ByteArrayInputStream because none of
  * the methods are synchronized.
@@ -58,6 +61,28 @@ public class InputByteBuffer {
     } else {
       return data[start++];
     }
+  }
+
+  /**
+   * Read eight bytes as a long from the buffer and advance the position.
+   *
+   * The binary sortable encoding stores longs in big-endian order.
+   */
+  public final long readLong() throws IOException {
+    if (start + Long.BYTES > end) {
+      throw new EOFException();
+    }
+    long v = theUnsafe.getLong(data, BYTE_ARRAY_BASE_OFFSET + start);
+    start += Long.BYTES;
+    return Long.reverseBytes(v);
+  }
+
+  /**
+   * Read eight bytes as a long from the buffer and optionally invert all bits.
+   */
+  public final long readLong(boolean invert) throws IOException {
+    long v = readLong();
+    return invert ? ~v : v;
   }
 
   /**


### PR DESCRIPTION
### Motivation
- Improve performance and correctness of long deserialization in the binary sortable serde by replacing byte-by-byte assembly with a native 8-byte read.
- Centralize and reuse big-endian and optional-bit-inversion logic for 8-byte reads in `InputByteBuffer` to reduce code duplication and enable faster reads.

### Description
- Added `readLong()` and `readLong(boolean invert)` to `InputByteBuffer` that use `theUnsafe.getLong` and `Long.reverseBytes` for big-endian reads and optional bit inversion, and bounds-check for EOF.
- Introduced static imports from `org.apache.tez.util.FastByteComparisons` for `BYTE_ARRAY_BASE_OFFSET` and `theUnsafe` in `InputByteBuffer`.
- Replaced the manual byte-loop in `BinarySortableSerDe.deserializeLong` with a single call to `buffer.readLong(invert) ^ (1L << 63)` to preserve the previous sign-flip semantics.
- Kept existing byte-level `read(boolean invert)` behavior and other buffer helper methods unchanged.

### Testing
- Ran the serde module unit tests with `mvn -pl serde test` and they completed successfully.
- Ran the project unit test suite with `mvn test` and no failures were observed for tests exercising the binary sortable serde paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1802dbad9883288634d3e4b05dc031)