### PR TITLE
Optimize InputByteBuffer byte-array reads in binary sortable deserialization

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/binarysortable/BinarySortableSerDe.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/binarysortable/BinarySortableSerDe.java
@@ -366,18 +366,14 @@ public class BinarySortableSerDe extends AbstractSerDe {
             (TimestampWritableV2) reuse);
         byte[] bytes = new byte[TimestampWritableV2.BINARY_SORTABLE_LENGTH];
 
-        for (int i = 0; i < bytes.length; i++) {
-          bytes[i] = buffer.read(invert);
-        }
+        buffer.readFully(bytes, 0, bytes.length, invert);
         t.setBinarySortable(bytes, 0);
         return t;
       case TIMESTAMPLOCALTZ:
         TimestampLocalTZWritable tstz = (reuse == null ? new TimestampLocalTZWritable() :
             (TimestampLocalTZWritable) reuse);
         byte[] data = new byte[TimestampLocalTZWritable.BINARY_SORTABLE_LENGTH];
-        for (int i = 0; i < data.length; i++) {
-          data[i] = buffer.read(invert);
-        }
+        buffer.readFully(data, 0, data.length, invert);
         // Across MR process boundary tz is normalized and stored in type
         // and is not carried in data for each row.
         tstz.fromBinarySortable(data, 0, ((TimestampLocalTZTypeInfo) type).timeZone());
@@ -435,9 +431,7 @@ public class BinarySortableSerDe extends AbstractSerDe {
         final byte[] decimalBuffer = new byte[length];
 
         buffer.seek(start);
-        for (int i = 0; i < length; ++i) {
-          decimalBuffer[i] = buffer.read(positive ? invert : !invert);
-        }
+        buffer.readFully(decimalBuffer, 0, length, positive ? invert : !invert);
 
         // read the null byte again
         buffer.read(positive ? invert : !invert);

--- a/serde/src/java/org/apache/hadoop/hive/serde2/binarysortable/InputByteBuffer.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/binarysortable/InputByteBuffer.java
@@ -87,6 +87,23 @@ public class InputByteBuffer {
   }
 
   /**
+   * Read bytes into the given array and optionally invert all bits.
+   */
+  public final void readFully(byte[] dest, int offset, int length, boolean invert) throws IOException {
+    if (start + length > end) {
+      throw new EOFException();
+    }
+    if (!invert) {
+      System.arraycopy(data, start, dest, offset, length);
+      start += length;
+      return;
+    }
+    for (int i = 0; i < length; i++) {
+      dest[offset + i] = (byte) (0xff ^ data[start++]);
+    }
+  }
+
+  /**
    * Return the current position. Final method to help inlining.
    */
   public final int tell() {

--- a/serde/src/java/org/apache/hadoop/hive/serde2/binarysortable/fast/BinarySortableDeserializeRead.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/binarysortable/fast/BinarySortableDeserializeRead.java
@@ -293,9 +293,7 @@ public final class BinarySortableDeserializeRead extends DeserializeRead {
           tempTimestampBytes = new byte[TimestampWritableV2.BINARY_SORTABLE_LENGTH];
         }
         final boolean invert = columnSortOrderIsDesc[fieldIndex];
-        for (int i = 0; i < tempTimestampBytes.length; i++) {
-          tempTimestampBytes[i] = inputByteBuffer.read(invert);
-        }
+        inputByteBuffer.readFully(tempTimestampBytes, 0, tempTimestampBytes.length, invert);
         currentTimestampWritable.setBinarySortable(tempTimestampBytes, 0);
       }
       return true;
@@ -458,9 +456,7 @@ public final class BinarySortableDeserializeRead extends DeserializeRead {
         }
 
         inputByteBuffer.seek(decimalStart);
-        for (int i = 0; i < length; ++i) {
-          tempDecimalBuffer[i] = inputByteBuffer.read(positive ? invert : !invert);
-        }
+        inputByteBuffer.readFully(tempDecimalBuffer, 0, length, positive ? invert : !invert);
 
         // read the null byte again
         inputByteBuffer.read(positive ? invert : !invert);


### PR DESCRIPTION
### Motivation
- Several hot deserialization paths read one byte at a time into arrays, causing per-call overhead and preventing bulk-copy optimizations when bytes are not inverted. 
- A bulk read API with optional bit inversion enables faster copies (via `System.arraycopy`) for the common non-inverted case while preserving semantics for inverted reads.

### Description
- Added `InputByteBuffer.readFully(byte[] dest, int offset, int length, boolean invert)` which bounds-checks, uses `System.arraycopy` when `invert == false`, and performs a tight xor loop when `invert == true`.
- Replaced per-byte loops that filled arrays with calls to `readFully` in `BinarySortableSerDe` for `TIMESTAMP`, `TIMESTAMPLOCALTZ`, and decimal digit reads.
- Replaced per-byte loops that filled arrays with calls to `readFully` in `binarysortable/fast/BinarySortableDeserializeRead` for `TIMESTAMP` and decimal digit reads.
- Preserved existing EOF and inversion semantics and kept behavior identical except for performance of bulk reads.

### Testing
- Attempted to compile the `serde` module with `mvn -pl serde -DskipTests compile -q`, which failed due to dependency resolution of the parent POM from Maven Central (HTTP 403) in this environment, so no successful automated build artifacts were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18156dae40832882cccf52c4f66813)