### PR TITLE
Use estimated serialized key length to size Output buffer in VectorKeySeriesSerializedImpl

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/keyseries/VectorKeySeriesBytesSerialized.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/keyseries/VectorKeySeriesBytesSerialized.java
@@ -33,12 +33,14 @@ import com.google.common.base.Preconditions;
 public class VectorKeySeriesBytesSerialized<T extends SerializeWrite>
     extends VectorKeySeriesSerializedImpl<T> implements VectorKeySeriesSerialized {
 
+  private static final int ESTIMATED_SERIALIZED_KEY_LENGTH = 32;
+
   private final int columnNum;
 
   private int outputStartPosition;
 
   public VectorKeySeriesBytesSerialized(int columnNum, T serializeWrite) {
-    super(serializeWrite);
+    super(serializeWrite, ESTIMATED_SERIALIZED_KEY_LENGTH);
     this.columnNum = columnNum;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/keyseries/VectorKeySeriesLongSerialized.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/keyseries/VectorKeySeriesLongSerialized.java
@@ -35,6 +35,8 @@ import com.google.common.base.Preconditions;
 public class VectorKeySeriesLongSerialized<T extends SerializeWrite>
     extends VectorKeySeriesSerializedImpl<T> implements VectorKeySeriesSerialized {
 
+  private static final int ESTIMATED_SERIALIZED_KEY_LENGTH = 10;
+
   private final int columnNum;
   private PrimitiveCategory primitiveCategory;
 
@@ -42,7 +44,7 @@ public class VectorKeySeriesLongSerialized<T extends SerializeWrite>
 
   public VectorKeySeriesLongSerialized(int columnNum, PrimitiveTypeInfo primitiveTypeInfo,
       T serializeWrite) {
-    super(serializeWrite);
+    super(serializeWrite, ESTIMATED_SERIALIZED_KEY_LENGTH);
     this.columnNum = columnNum;
     primitiveCategory = primitiveTypeInfo.getPrimitiveCategory();
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/keyseries/VectorKeySeriesMultiSerialized.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/keyseries/VectorKeySeriesMultiSerialized.java
@@ -41,12 +41,14 @@ public class VectorKeySeriesMultiSerialized<T extends SerializeWrite>
   private static final Logger LOG = LoggerFactory.getLogger(
       VectorKeySeriesMultiSerialized.class.getName());
 
+  private static final int ESTIMATED_SERIALIZED_KEY_LENGTH = 32;
+
   private VectorSerializeRow<T> keySerializeRow;
 
   private boolean[] hasAnyNulls;
 
   public VectorKeySeriesMultiSerialized(T serializeWrite) {
-    super(serializeWrite);
+    super(serializeWrite, ESTIMATED_SERIALIZED_KEY_LENGTH);
   }
 
   public void init(TypeInfo[] typeInfos, int[] columnNums) throws HiveException {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/keyseries/VectorKeySeriesSerializedImpl.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/keyseries/VectorKeySeriesSerializedImpl.java
@@ -45,10 +45,11 @@ public abstract class VectorKeySeriesSerializedImpl<T extends SerializeWrite>
 
   protected final int[] serializedKeyLengths;
 
-  public VectorKeySeriesSerializedImpl(T serializeWrite) {
+  public VectorKeySeriesSerializedImpl(T serializeWrite, int estimatedSerializedKeyLength) {
     super();
+    Preconditions.checkArgument(estimatedSerializedKeyLength > 0);
     this.serializeWrite = serializeWrite;
-    output = new Output();
+    output = new Output(VectorizedRowBatch.DEFAULT_SIZE * estimatedSerializedKeyLength);
     serializedKeyLengths = new int[VectorizedRowBatch.DEFAULT_SIZE];
   }
 


### PR DESCRIPTION
### Motivation

- Reduce memory over-allocation for serialized key buffers by sizing the `Output` buffer based on a per-key estimated serialized length.
- Provide sensible defaults for different key types so vectorized key serialization uses a better initial capacity.
- Fail fast if an invalid estimated length is provided by enforcing a positive argument.

### Description

- Added an `estimatedSerializedKeyLength` parameter to `VectorKeySeriesSerializedImpl` and use it to construct `output` with `new Output(VectorizedRowBatch.DEFAULT_SIZE * estimatedSerializedKeyLength)`.
- Added a `Preconditions.checkArgument(estimatedSerializedKeyLength > 0)` guard in the `VectorKeySeriesSerializedImpl` constructor.
- Introduced per-class estimated length constants and passed them to the superclass in `VectorKeySeriesBytesSerialized` (`32`), `VectorKeySeriesLongSerialized` (`10`), and `VectorKeySeriesMultiSerialized` (`32`).

### Testing

- Built the `ql` module and ran the unit test suite with `mvn -pl ql test`, and the tests completed successfully.
- Ran vectorized/key-series related unit tests and they passed under the modified allocation behavior.
- Performed a full project compile to ensure no API breakage and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a193053b8588328b0068353bb076f6d)