### PR TITLE
Use array-backed stacks and generation-based field reset in fast serde readers/writers

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/binarysortable/fast/BinarySortableDeserializeRead.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/binarysortable/fast/BinarySortableDeserializeRead.java
@@ -19,9 +19,7 @@
 package org.apache.hadoop.hive.serde2.binarysortable.fast;
 
 import java.io.IOException;
-import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.Deque;
 import java.util.List;
 import java.util.Properties;
 
@@ -114,8 +112,12 @@ public final class BinarySortableDeserializeRead extends DeserializeRead {
 
   private InputByteBuffer inputByteBuffer = new InputByteBuffer();
 
+  private static final int INITIAL_STACK_SIZE = 16;
+
   private Field root;
-  private Deque<Field> stack;
+  private Field[] stack;
+  private int stackDepth;
+  private int currentGeneration;
 
   private class Field {
     Field[] children;
@@ -128,6 +130,7 @@ public final class BinarySortableDeserializeRead extends DeserializeRead {
     int count;
     int start;
     int tag;
+    int generation;
   }
 
   public BinarySortableDeserializeRead(TypeInfo[] typeInfos, boolean useExternalBuffer,
@@ -145,7 +148,7 @@ public final class BinarySortableDeserializeRead extends DeserializeRead {
     root.category = Category.STRUCT;
     root.children = createFields(typeInfos);
     root.count = count;
-    stack = new ArrayDeque<>();
+    stack = new Field[INITIAL_STACK_SIZE];
     this.columnSortOrderIsDesc = columnSortOrderIsDesc;
     this.columnNullMarker = columnNullMarker;
     this.columnNotNullMarker = columnNotNullMarker;
@@ -166,20 +169,55 @@ public final class BinarySortableDeserializeRead extends DeserializeRead {
     start = offset;
     end = offset + length;
     inputByteBuffer.reset(bytes, start, end);
-    root.index = -1;
-    stack.clear();
-    stack.push(root);
-    clearIndex(root);
+    nextGeneration();
+    prepareField(root);
+    resetStack();
   }
 
-  private void clearIndex(Field field) {
-    field.index = -1;
+  private void nextGeneration() {
+    currentGeneration++;
+    if (currentGeneration == 0) {
+      clearGeneration(root);
+      currentGeneration = 1;
+    }
+  }
+
+  private void clearGeneration(Field field) {
+    field.generation = 0;
     if (field.children == null) {
       return;
     }
     for (Field child : field.children) {
-      clearIndex(child);
+      clearGeneration(child);
     }
+  }
+
+  private void prepareField(Field field) {
+    if (field.generation != currentGeneration) {
+      field.generation = currentGeneration;
+      field.index = -1;
+      field.tag = 0;
+    }
+  }
+
+  private void resetStack() {
+    stackDepth = 1;
+    stack[0] = root;
+  }
+
+  private Field peekStack() {
+    return stack[stackDepth - 1];
+  }
+
+  private void pushStack(Field field) {
+    if (stackDepth == stack.length) {
+      stack = Arrays.copyOf(stack, stack.length * 2);
+    }
+    stack[stackDepth++] = field;
+  }
+
+  private void popStack() {
+    stackDepth--;
   }
 
   /*
@@ -497,7 +535,8 @@ public final class BinarySortableDeserializeRead extends DeserializeRead {
    * Designed for skipping columns that are not included.
    */
   public void skipNextField() throws IOException {
-    final Field current = stack.peek();
+    final Field current = peekStack();
+    prepareField(current);
     current.index++;
 
     if (root.index >= root.count) {
@@ -523,7 +562,8 @@ public final class BinarySortableDeserializeRead extends DeserializeRead {
     if (child.category == Category.PRIMITIVE) {
       readPrimitive(child);
     } else {
-      stack.push(child);
+      prepareField(child);
+      pushStack(child);
       switch (child.category) {
       case LIST:
       case MAP:
@@ -654,7 +694,8 @@ public final class BinarySortableDeserializeRead extends DeserializeRead {
 
   @Override
   public boolean readComplexField() throws IOException {
-    final Field current = stack.peek();
+    final Field current = peekStack();
+    prepareField(current);
     current.index++;
 
     if (root.index >= root.count) {
@@ -684,7 +725,8 @@ public final class BinarySortableDeserializeRead extends DeserializeRead {
     if (child.category == Category.PRIMITIVE) {
       isNull = !readPrimitive(child);
     } else {
-      stack.push(child);
+      prepareField(child);
+      pushStack(child);
     }
     return !isNull;
   }
@@ -708,18 +750,16 @@ public final class BinarySortableDeserializeRead extends DeserializeRead {
     }
 
     if (isEnded) {
-      stack.pop();
-      stack.peek();
+      popStack();
     }
     return !isEnded;
   }
 
   @Override
   public void finishComplexVariableFieldsType() {
-    stack.pop();
-    if (stack.peek() == null) {
+    popStack();
+    if (stackDepth == 0) {
       throw new RuntimeException();
     }
-    stack.peek();
   }
 }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/fast/LazyBinaryDeserializeRead.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/fast/LazyBinaryDeserializeRead.java
@@ -20,9 +20,7 @@ package org.apache.hadoop.hive.serde2.lazybinary.fast;
 
 import java.io.EOFException;
 import java.io.IOException;
-import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.Deque;
 import java.util.List;
 
 import org.apache.hadoop.hive.common.type.DataTypePhysicalVariation;
@@ -73,7 +71,11 @@ public final class LazyBinaryDeserializeRead extends DeserializeRead {
   private VInt tempVInt;
   private VLong tempVLong;
 
-  private Deque<Field> stack = new ArrayDeque<>();
+  private static final int INITIAL_STACK_SIZE = 16;
+
+  private Field[] stack;
+  private int stackDepth;
+  private int currentGeneration;
   private Field root;
 
   private class Field {
@@ -91,6 +93,7 @@ public final class LazyBinaryDeserializeRead extends DeserializeRead {
     int nullByteStart;
     byte nullByte;
     byte tag;
+    int generation;
   }
 
   public LazyBinaryDeserializeRead(TypeInfo[] typeInfos, boolean useExternalBuffer) {
@@ -103,6 +106,8 @@ public final class LazyBinaryDeserializeRead extends DeserializeRead {
     tempVInt = new VInt();
     tempVLong = new VLong();
     currentExternalBufferNeeded = false;
+
+    stack = new Field[INITIAL_STACK_SIZE];
 
     root = new Field();
     root.category = Category.STRUCT;
@@ -162,19 +167,60 @@ public final class LazyBinaryDeserializeRead extends DeserializeRead {
     start = offset;
     end = offset + length;
 
-    stack.clear();
-    stack.push(root);
-    clearIndex(root);
+    nextGeneration();
+    prepareField(root);
+    resetStack();
   }
 
-  private void clearIndex(Field field) {
-    field.index = 0;
+  private void nextGeneration() {
+    currentGeneration++;
+    if (currentGeneration == 0) {
+      clearGeneration(root);
+      currentGeneration = 1;
+    }
+  }
+
+  private void clearGeneration(Field field) {
+    field.generation = 0;
     if (field.children == null) {
       return;
     }
     for (Field child : field.children) {
-      clearIndex(child);
+      clearGeneration(child);
     }
+  }
+
+  private void prepareField(Field field) {
+    if (field.generation != currentGeneration) {
+      field.generation = currentGeneration;
+      field.index = 0;
+      field.tag = 0;
+      field.nullByte = 0;
+    }
+  }
+
+  private void resetStack() {
+    stackDepth = 1;
+    stack[0] = root;
+  }
+
+  private Field peekStack() {
+    return stack[stackDepth - 1];
+  }
+
+  private void pushStack(Field field) {
+    if (stackDepth == stack.length) {
+      stack = Arrays.copyOf(stack, stack.length * 2);
+    }
+    stack[stackDepth++] = field;
+  }
+
+  private Field popStack() {
+    stackDepth--;
+    if (stackDepth == 0) {
+      throw new RuntimeException();
+    }
+    return stack[stackDepth - 1];
   }
 
   /*
@@ -415,7 +461,8 @@ public final class LazyBinaryDeserializeRead extends DeserializeRead {
    * Designed for skipping columns that are not included.
    */
   public void skipNextField() throws IOException {
-    final Field current = stack.peek();
+    final Field current = peekStack();
+    prepareField(current);
     final boolean isNull = isNull(current);
 
     if (isNull) {
@@ -435,7 +482,8 @@ public final class LazyBinaryDeserializeRead extends DeserializeRead {
       current.index++;
     } else {
       parseHeader(child);
-      stack.push(child);
+      prepareField(child);
+      pushStack(child);
 
       for (int i = 0; i < child.count; i++) {
         skipNextField();
@@ -549,7 +597,8 @@ public final class LazyBinaryDeserializeRead extends DeserializeRead {
   // Push or next
   @Override
   public boolean readComplexField() throws IOException {
-    final Field current = stack.peek();
+    final Field current = peekStack();
+    prepareField(current);
     boolean isNull = isNull(current);
 
     if (isNull) {
@@ -569,7 +618,8 @@ public final class LazyBinaryDeserializeRead extends DeserializeRead {
       current.index++;
     } else {
       parseHeader(child);
-      stack.push(child);
+      prepareField(child);
+      pushStack(child);
     }
 
     if (offset > end) {
@@ -581,11 +631,11 @@ public final class LazyBinaryDeserializeRead extends DeserializeRead {
   // Pop (list, map)
   @Override
   public boolean isNextComplexMultiValue() {
-    Field current = stack.peek();
+    Field current = peekStack();
+    prepareField(current);
     final boolean isNext = current.index < current.count;
     if (!isNext) {
-      stack.pop();
-      stack.peek().index++;
+      popStack().index++;
     }
     return isNext;
   }
@@ -593,10 +643,6 @@ public final class LazyBinaryDeserializeRead extends DeserializeRead {
   // Pop (struct, union)
   @Override
   public void finishComplexVariableFieldsType() {
-    stack.pop();
-    if (stack.peek() == null) {
-      throw new RuntimeException();
-    }
-    stack.peek().index++;
+    popStack().index++;
   }
 }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/fast/LazyBinarySerializeWrite.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/fast/LazyBinarySerializeWrite.java
@@ -19,8 +19,7 @@
 package org.apache.hadoop.hive.serde2.lazybinary.fast;
 
 import java.io.IOException;
-import java.util.ArrayDeque;
-import java.util.Deque;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -74,8 +73,11 @@ public class LazyBinarySerializeWrite implements SerializeWrite {
   private byte[] scratchBuffer;
   private byte[] scratchLongBytes;
 
+  private static final int INITIAL_STACK_SIZE = 16;
+
   private final Field root;
-  private Deque<Field> stack = new ArrayDeque<>();
+  private Field[] stack;
+  private int stackDepth;
   private LazyBinarySerDe.BooleanRef warnedOnceNullMapKey;
 
   private static class Field {
@@ -113,6 +115,7 @@ public class LazyBinarySerializeWrite implements SerializeWrite {
   // Not public since we must have the field count and other information.
   private LazyBinarySerializeWrite() {
     this.root = new Field(STRUCT);
+    this.stack = new Field[INITIAL_STACK_SIZE];
   }
 
   /*
@@ -147,9 +150,32 @@ public class LazyBinarySerializeWrite implements SerializeWrite {
   private void resetWithoutOutput() {
     root.clean();
     root.fieldCount = rootFieldCount;
-    stack.clear();
-    stack.push(root);
+    resetStack();
     warnedOnceNullMapKey = null;
+  }
+
+
+  private void resetStack() {
+    stackDepth = 1;
+    stack[0] = root;
+  }
+
+  private Field peekStack() {
+    return stack[stackDepth - 1];
+  }
+
+  private void pushStack(Field field) {
+    if (stackDepth == stack.length) {
+      stack = Arrays.copyOf(stack, stack.length * 2);
+    }
+    stack[stackDepth++] = field;
+  }
+
+  private void popStack() {
+    stackDepth--;
+    if (stackDepth == 0) {
+      throw new RuntimeException();
+    }
   }
 
   /*
@@ -157,7 +183,7 @@ public class LazyBinarySerializeWrite implements SerializeWrite {
    */
   @Override
   public void writeNull() throws IOException {
-    final Field current = stack.peek();
+    final Field current = peekStack();
 
     if (current.type == STRUCT) {
       // Every 8 fields we write a NULL byte.
@@ -490,7 +516,7 @@ public class LazyBinarySerializeWrite implements SerializeWrite {
 
   @Override
   public void finishList() {
-    final Field current = stack.peek();
+    final Field current = peekStack();
 
     if (!skipLengthPrefix) {
       // 5/ update the list byte size
@@ -558,7 +584,7 @@ public class LazyBinarySerializeWrite implements SerializeWrite {
 
   @Override
   public void finishMap() {
-    final Field current = stack.peek();
+    final Field current = peekStack();
 
     if (!skipLengthPrefix) {
       // 5/ update the byte size of the map
@@ -593,7 +619,7 @@ public class LazyBinarySerializeWrite implements SerializeWrite {
 
   @Override
   public void finishStruct() {
-    final Field current = stack.peek();
+    final Field current = peekStack();
 
     if (!skipLengthPrefix) {
       // 3/ update the byte size of the struct
@@ -626,7 +652,7 @@ public class LazyBinarySerializeWrite implements SerializeWrite {
 
   @Override
   public void finishUnion() {
-    final Field current = stack.peek();
+    final Field current = peekStack();
 
     if (!skipLengthPrefix) {
       // 3/ update the byte size of the struct
@@ -639,7 +665,7 @@ public class LazyBinarySerializeWrite implements SerializeWrite {
   }
 
   private void beginElement() {
-    final Field current = stack.peek();
+    final Field current = peekStack();
 
     if (current.type == STRUCT) {
       // Every 8 fields we write a NULL byte.
@@ -660,7 +686,7 @@ public class LazyBinarySerializeWrite implements SerializeWrite {
   }
 
   private void finishElement() {
-    final Field current = stack.peek();
+    final Field current = peekStack();
 
     if (current.type == STRUCT) {
       current.fieldIndex++;
@@ -674,11 +700,11 @@ public class LazyBinarySerializeWrite implements SerializeWrite {
 
   private void beginComplex(Field field) {
     beginElement();
-    stack.push(field);
+    pushStack(field);
   }
 
   private void finishComplex() {
-    stack.pop();
+    popStack();
     finishElement();
   }
 


### PR DESCRIPTION
### Motivation
- Reduce allocations and improve throughput in the fast serde codepaths by replacing `ArrayDeque` with a compact array-backed stack and simpler stack operations.
- Avoid costly recursive traversal to clear per-field state on every `set` by adding a generation counter to lazily initialize per-`Field` state.
- Lower GC pressure and simplify stack handling for high-frequency serialization/deserialization operations.

### Description
- Replaced `Deque<Field>` / `ArrayDeque` with an array-backed `Field[]` stack and `stackDepth`, and added `pushStack`, `popStack`, `peekStack`, `resetStack` and dynamic resizing via `Arrays.copyOf` with `INITIAL_STACK_SIZE` in `LazyBinaryDeserializeRead`, `BinarySortableDeserializeRead`, and `LazyBinarySerializeWrite`.
- Added a per-`Field` `generation` integer and a `currentGeneration` counter plus helper methods `nextGeneration`, `prepareField`, and `clearGeneration` to lazily reset `index`, `tag`, and related state instead of traversing the tree on every `set` call.
- Updated all call sites to use the new stack API and to `prepareField` where appropriate, removed `ArrayDeque`/`Deque` imports, and adjusted control flow to match the new push/pop semantics.

### Testing
- Ran the serde module unit tests (including fast `lazybinary` and `binarysortable` tests) via the project test suite and they completed successfully.
- Executed serialization/deserialization round-trip tests for `LazyBinary` and `BinarySortable` fast paths and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199da7e4cc8328beca8440d30201c1)