### PR TITLE
Specialize vector hash wrapper for single string keys

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperFactory.java
@@ -51,6 +51,8 @@ public class VectorHashKeyWrapperFactory {
           return new VectorHashKeyWrapperSingleString(ctx);
         } else if (byteValuesCount == 2) {
           return new VectorHashKeyWrapperTwoString(ctx);
+        } else if (byteValuesCount == 3) {
+          return new VectorHashKeyWrapperThreeString(ctx);
         }
       } else if (longValuesCount == 1 && byteValuesCount == 2) {
         return new VectorHashKeyWrapperSingleLongTwoString(ctx);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperFactory.java
@@ -44,8 +44,12 @@ public class VectorHashKeyWrapperFactory {
         } else if (longValuesCount == 0) {
           return VectorHashKeyWrapperEmpty.EMPTY_KEY_WRAPPER;
         }
-      } else if (longValuesCount == 0 && byteValuesCount == 1) {
-        return new VectorHashKeyWrapperSingleString(ctx);
+      } else if (longValuesCount == 0) {
+        if (byteValuesCount == 1) {
+          return new VectorHashKeyWrapperSingleString(ctx);
+        } else if (byteValuesCount == 2) {
+          return new VectorHashKeyWrapperTwoString(ctx);
+        }
       }
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperFactory.java
@@ -41,6 +41,8 @@ public class VectorHashKeyWrapperFactory {
           return new VectorHashKeyWrapperSingleLong();
         } else if (longValuesCount == 2) {
           return new VectorHashKeyWrapperTwoLong();
+        } else if (longValuesCount == 3) {
+          return new VectorHashKeyWrapperThreeLong();
         } else if (longValuesCount == 0) {
           return VectorHashKeyWrapperEmpty.EMPTY_KEY_WRAPPER;
         }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperFactory.java
@@ -54,6 +54,8 @@ public class VectorHashKeyWrapperFactory {
         } else if (byteValuesCount == 3) {
           return new VectorHashKeyWrapperThreeString(ctx);
         }
+      } else if (longValuesCount == 1 && byteValuesCount == 1) {
+        return new VectorHashKeyWrapperSingleLongSingleString(ctx);
       } else if (longValuesCount == 1 && byteValuesCount == 2) {
         return new VectorHashKeyWrapperSingleLongTwoString(ctx);
       } else if (longValuesCount == 2 && byteValuesCount == 1) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperFactory.java
@@ -44,6 +44,8 @@ public class VectorHashKeyWrapperFactory {
         } else if (longValuesCount == 0) {
           return VectorHashKeyWrapperEmpty.EMPTY_KEY_WRAPPER;
         }
+      } else if (longValuesCount == 0 && byteValuesCount == 1) {
+        return new VectorHashKeyWrapperSingleString(ctx);
       }
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperFactory.java
@@ -52,6 +52,10 @@ public class VectorHashKeyWrapperFactory {
         } else if (byteValuesCount == 2) {
           return new VectorHashKeyWrapperTwoString(ctx);
         }
+      } else if (longValuesCount == 1 && byteValuesCount == 2) {
+        return new VectorHashKeyWrapperSingleLongTwoString(ctx);
+      } else if (longValuesCount == 2 && byteValuesCount == 1) {
+        return new VectorHashKeyWrapperTwoLongSingleString(ctx);
       }
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperSingleLong.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperSingleLong.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hive.ql.exec.vector.wrapper;
 
+import org.apache.hadoop.hive.ql.exec.KeyWrapper;
 import org.apache.hadoop.hive.ql.exec.vector.VectorColumnSetInfo;
 import org.apache.hive.common.util.HashCodeUtil;
 
@@ -52,10 +53,20 @@ public class VectorHashKeyWrapperSingleLong extends VectorHashKeyWrapperSingleBa
   @Override
   protected Object clone() {
     VectorHashKeyWrapperSingleLong clone = new VectorHashKeyWrapperSingleLong();
+    copyInto(clone);
+    return clone;
+  }
+
+  @Override
+  public void copyKey(KeyWrapper oldWrapper) {
+    VectorHashKeyWrapperSingleLong clone = (VectorHashKeyWrapperSingleLong) oldWrapper;
+    copyInto(clone);
+  }
+
+  private void copyInto(VectorHashKeyWrapperSingleLong clone) {
     clone.isNull0 = isNull0;
     clone.longValue0 = longValue0;
     clone.hashcode = hashcode;
-    return clone;
   }
 
   public void assignLong(int keyIndex, int index, long v) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperSingleLongSingleString.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperSingleLongSingleString.java
@@ -1,0 +1,315 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.vector.wrapper;
+
+import java.sql.Date;
+import java.util.Arrays;
+
+import org.apache.hadoop.hive.ql.exec.KeyWrapper;
+import org.apache.hadoop.hive.ql.exec.vector.VectorColumnSetInfo;
+import org.apache.hadoop.hive.ql.exec.vector.expressions.StringExpr;
+import org.apache.hadoop.hive.ql.util.JavaDataModel;
+import org.apache.hadoop.hive.serde2.io.DateWritableV2;
+import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
+import org.apache.hive.common.util.Murmur3;
+
+import com.google.common.base.Preconditions;
+
+public class VectorHashKeyWrapperSingleLongSingleString extends VectorHashKeyWrapperBase {
+
+  private long longValue0;
+
+  private byte[] bytes0;
+  private int start0;
+  private int length0;
+
+  private boolean isNull0;
+  private boolean isNull1;
+
+  private HashContext hashCtx;
+
+  protected VectorHashKeyWrapperSingleLongSingleString(HashContext ctx) {
+    super();
+    hashCtx = ctx;
+    longValue0 = 0;
+    bytes0 = null;
+    start0 = 0;
+    length0 = 0;
+    isNull0 = false;
+    isNull1 = false;
+  }
+
+  @Override
+  public void setHashKey() {
+    int hash = calculateLongValuesHashCode();
+    hash = 31 * hash + calculateNullsHashCode();
+    if (length0 != -1) {
+      Murmur3.IncrementalHash32 bytesHash = HashContext.getBytesHash(hashCtx);
+      bytesHash.start(hash);
+      bytesHash.add(bytes0, start0, length0);
+      hash = bytesHash.end();
+    }
+    hashcode = hash;
+  }
+
+  private int calculateLongValuesHashCode() {
+    int result = 1;
+    result = 31 * result + (int) (longValue0 ^ (longValue0 >>> 32));
+    return result;
+  }
+
+  private int calculateNullsHashCode() {
+    int result = 1;
+    result = 31 * result + (isNull0 ? 1231 : 1237);
+    result = 31 * result + (isNull1 ? 1231 : 1237);
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object that) {
+    if (that instanceof VectorHashKeyWrapperSingleLongSingleString) {
+      VectorHashKeyWrapperSingleLongSingleString keyThat = (VectorHashKeyWrapperSingleLongSingleString) that;
+      return hashcode == keyThat.hashcode &&
+          longValue0 == keyThat.longValue0 &&
+          isNull0 == keyThat.isNull0 &&
+          isNull1 == keyThat.isNull1 &&
+          (isStringNull() || StringExpr.equal(
+              bytes0, start0, length0,
+              keyThat.bytes0, keyThat.start0, keyThat.length0));
+    }
+    return false;
+  }
+
+  @Override
+  protected Object clone() {
+    VectorHashKeyWrapperSingleLongSingleString clone = new VectorHashKeyWrapperSingleLongSingleString(hashCtx);
+    copyInto(clone);
+    return clone;
+  }
+
+  @Override
+  public void copyKey(KeyWrapper oldWrapper) {
+    VectorHashKeyWrapperSingleLongSingleString clone = (VectorHashKeyWrapperSingleLongSingleString) oldWrapper;
+    clone.hashCtx = hashCtx;
+    copyInto(clone);
+  }
+
+  private void copyInto(VectorHashKeyWrapperSingleLongSingleString clone) {
+    clone.longValue0 = longValue0;
+    clone.isNull0 = isNull0;
+    clone.isNull1 = isNull1;
+    if (isStringNull()) {
+      clone.bytes0 = null;
+      clone.start0 = 0;
+      clone.length0 = -1;
+    } else {
+      clone.bytes0 = copyBytes(bytes0, start0, length0, clone.bytes0);
+      clone.start0 = 0;
+      clone.length0 = length0;
+    }
+    clone.hashcode = hashcode;
+    assert clone.equals(this);
+  }
+
+  private byte[] copyBytes(byte[] bytes, int start, int length, byte[] previousCopy) {
+    if (previousCopy == null || previousCopy.length < length) {
+      return Arrays.copyOfRange(bytes, start, start + length);
+    } else {
+      System.arraycopy(bytes, start, previousCopy, 0, length);
+      return previousCopy;
+    }
+  }
+
+  @Override
+  public void assignLong(int keyIndex, int index, long v) {
+    if (index == 0) {
+      assignNullFlag(keyIndex, false);
+      longValue0 = v;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Deprecated
+  @Override
+  public void assignLong(int index, long v) {
+    if (index == 0) {
+      longValue0 = v;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public void assignNullLong(int keyIndex, int index) {
+    if (index == 0) {
+      assignNullFlag(keyIndex, true);
+      longValue0 = 0;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public void assignString(int index, byte[] bytes, int start, int length) {
+    if (index == 0) {
+      Preconditions.checkState(bytes != null);
+      bytes0 = bytes;
+      start0 = start;
+      length0 = length;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public void assignNullString(int keyIndex, int index) {
+    if (index == 0) {
+      assignNullFlag(keyIndex, true);
+      bytes0 = null;
+      start0 = 0;
+      length0 = -1;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  private void assignNullFlag(int keyIndex, boolean isNull) {
+    if (keyIndex == 0) {
+      isNull0 = isNull;
+    } else if (keyIndex == 1) {
+      isNull1 = isNull;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  private boolean isStringNull() {
+    return length0 == -1;
+  }
+
+  @Override
+  public String stringifyKeys(VectorColumnSetInfo columnSetInfo)
+  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("longs ");
+    appendLong(sb, columnSetInfo);
+    sb.append(", byte lengths ");
+    int stringKeyIndex = columnSetInfo.stringIndices[0];
+    sb.append(isNull(stringKeyIndex) ? "null" : length0);
+    return sb.toString();
+  }
+
+  private void appendLong(StringBuilder sb, VectorColumnSetInfo columnSetInfo) {
+    int keyIndex = columnSetInfo.longIndices[0];
+    if (isNull(keyIndex)) {
+      sb.append("null");
+    } else {
+      sb.append(longValue0);
+      PrimitiveTypeInfo primitiveTypeInfo = (PrimitiveTypeInfo) columnSetInfo.typeInfos[keyIndex];
+      switch (primitiveTypeInfo.getPrimitiveCategory()) {
+      case DATE:
+        Date dt = new Date(0);
+        dt.setTime(DateWritableV2.daysToMillis((int) longValue0));
+        sb.append(" date ");
+        sb.append(dt.toString());
+        break;
+      default:
+        break;
+      }
+    }
+  }
+
+  @Override
+  public String toString()
+  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("longs ");
+    sb.append(Arrays.toString(new long[] { longValue0 }));
+    sb.append(", byte lengths ");
+    sb.append(Arrays.toString(new int[] { length0 }));
+    sb.append(", nulls ");
+    sb.append(Arrays.toString(new boolean[] { isNull0, isNull1 }));
+    return sb.toString();
+  }
+
+  @Override
+  public long getLongValue(int i) {
+    if (i == 0) {
+      return longValue0;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public byte[] getBytes(int i) {
+    if (i == 0) {
+      return bytes0;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public int getByteStart(int i) {
+    if (i == 0) {
+      return start0;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public int getByteLength(int i) {
+    if (i == 0) {
+      return length0;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public int getVariableSize() {
+    return (int) JavaDataModel.get().lengthForByteArrayOfSize(length0);
+  }
+
+  @Override
+  public void clearIsNull() {
+    isNull0 = false;
+    isNull1 = false;
+  }
+
+  @Override
+  public void setNull() {
+    isNull0 = true;
+    isNull1 = true;
+  }
+
+  @Override
+  public boolean isNull(int keyIndex) {
+    if (keyIndex == 0) {
+      return isNull0;
+    } else if (keyIndex == 1) {
+      return isNull1;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperSingleLongTwoString.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperSingleLongTwoString.java
@@ -1,0 +1,377 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.vector.wrapper;
+
+import java.sql.Date;
+import java.util.Arrays;
+
+import org.apache.hadoop.hive.ql.exec.KeyWrapper;
+import org.apache.hadoop.hive.ql.exec.vector.VectorColumnSetInfo;
+import org.apache.hadoop.hive.ql.exec.vector.expressions.StringExpr;
+import org.apache.hadoop.hive.ql.util.JavaDataModel;
+import org.apache.hadoop.hive.serde2.io.DateWritableV2;
+import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
+import org.apache.hive.common.util.Murmur3;
+
+import com.google.common.base.Preconditions;
+
+public class VectorHashKeyWrapperSingleLongTwoString extends VectorHashKeyWrapperBase {
+
+  private long longValue0;
+
+  private byte[] bytes0;
+  private int start0;
+  private int length0;
+
+  private byte[] bytes1;
+  private int start1;
+  private int length1;
+
+  private boolean isNull0;
+  private boolean isNull1;
+  private boolean isNull2;
+
+  private HashContext hashCtx;
+
+  protected VectorHashKeyWrapperSingleLongTwoString(HashContext ctx) {
+    super();
+    hashCtx = ctx;
+    longValue0 = 0;
+    bytes0 = null;
+    start0 = 0;
+    length0 = 0;
+    bytes1 = null;
+    start1 = 0;
+    length1 = 0;
+    isNull0 = false;
+    isNull1 = false;
+    isNull2 = false;
+  }
+
+  @Override
+  public void setHashKey() {
+    int hash = calculateLongValuesHashCode();
+    hash = 31 * hash + calculateNullsHashCode();
+    Murmur3.IncrementalHash32 bytesHash = null;
+    if (length0 != -1) {
+      bytesHash = HashContext.getBytesHash(hashCtx);
+      bytesHash.start(hash);
+      bytesHash.add(bytes0, start0, length0);
+    }
+    if (length1 != -1) {
+      if (bytesHash == null) {
+        bytesHash = HashContext.getBytesHash(hashCtx);
+        bytesHash.start(hash);
+      }
+      bytesHash.add(bytes1, start1, length1);
+    }
+    hashcode = bytesHash == null ? hash : bytesHash.end();
+  }
+
+  private int calculateLongValuesHashCode() {
+    int result = 1;
+    result = 31 * result + (int) (longValue0 ^ (longValue0 >>> 32));
+    return result;
+  }
+
+  private int calculateNullsHashCode() {
+    int result = 1;
+    result = 31 * result + (isNull0 ? 1231 : 1237);
+    result = 31 * result + (isNull1 ? 1231 : 1237);
+    result = 31 * result + (isNull2 ? 1231 : 1237);
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object that) {
+    if (that instanceof VectorHashKeyWrapperSingleLongTwoString) {
+      VectorHashKeyWrapperSingleLongTwoString keyThat = (VectorHashKeyWrapperSingleLongTwoString) that;
+      return hashcode == keyThat.hashcode &&
+          longValue0 == keyThat.longValue0 &&
+          isNull0 == keyThat.isNull0 &&
+          isNull1 == keyThat.isNull1 &&
+          isNull2 == keyThat.isNull2 &&
+          (isStringNull0() || StringExpr.equal(
+              bytes0, start0, length0,
+              keyThat.bytes0, keyThat.start0, keyThat.length0)) &&
+          (isStringNull1() || StringExpr.equal(
+              bytes1, start1, length1,
+              keyThat.bytes1, keyThat.start1, keyThat.length1));
+    }
+    return false;
+  }
+
+  @Override
+  protected Object clone() {
+    VectorHashKeyWrapperSingleLongTwoString clone = new VectorHashKeyWrapperSingleLongTwoString(hashCtx);
+    copyInto(clone);
+    return clone;
+  }
+
+  @Override
+  public void copyKey(KeyWrapper oldWrapper) {
+    VectorHashKeyWrapperSingleLongTwoString clone = (VectorHashKeyWrapperSingleLongTwoString) oldWrapper;
+    clone.hashCtx = hashCtx;
+    copyInto(clone);
+  }
+
+  private void copyInto(VectorHashKeyWrapperSingleLongTwoString clone) {
+    clone.longValue0 = longValue0;
+    clone.isNull0 = isNull0;
+    clone.isNull1 = isNull1;
+    clone.isNull2 = isNull2;
+    if (isStringNull0()) {
+      clone.bytes0 = null;
+      clone.start0 = 0;
+      clone.length0 = -1;
+    } else {
+      clone.bytes0 = copyBytes(bytes0, start0, length0, clone.bytes0);
+      clone.start0 = 0;
+      clone.length0 = length0;
+    }
+    if (isStringNull1()) {
+      clone.bytes1 = null;
+      clone.start1 = 0;
+      clone.length1 = -1;
+    } else {
+      clone.bytes1 = copyBytes(bytes1, start1, length1, clone.bytes1);
+      clone.start1 = 0;
+      clone.length1 = length1;
+    }
+    clone.hashcode = hashcode;
+    assert clone.equals(this);
+  }
+
+  private byte[] copyBytes(byte[] bytes, int start, int length, byte[] previousCopy) {
+    if (previousCopy == null || previousCopy.length < length) {
+      return Arrays.copyOfRange(bytes, start, start + length);
+    } else {
+      System.arraycopy(bytes, start, previousCopy, 0, length);
+      return previousCopy;
+    }
+  }
+
+  @Override
+  public void assignLong(int keyIndex, int index, long v) {
+    if (index == 0) {
+      assignNullFlag(keyIndex, false);
+      longValue0 = v;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Deprecated
+  @Override
+  public void assignLong(int index, long v) {
+    if (index == 0) {
+      longValue0 = v;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public void assignNullLong(int keyIndex, int index) {
+    if (index == 0) {
+      assignNullFlag(keyIndex, true);
+      longValue0 = 0;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public void assignString(int index, byte[] bytes, int start, int length) {
+    Preconditions.checkState(bytes != null);
+    if (index == 0) {
+      bytes0 = bytes;
+      start0 = start;
+      length0 = length;
+    } else if (index == 1) {
+      bytes1 = bytes;
+      start1 = start;
+      length1 = length;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public void assignNullString(int keyIndex, int index) {
+    assignNullFlag(keyIndex, true);
+    if (index == 0) {
+      bytes0 = null;
+      start0 = 0;
+      length0 = -1;
+    } else if (index == 1) {
+      bytes1 = null;
+      start1 = 0;
+      length1 = -1;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  private void assignNullFlag(int keyIndex, boolean isNull) {
+    if (keyIndex == 0) {
+      isNull0 = isNull;
+    } else if (keyIndex == 1) {
+      isNull1 = isNull;
+    } else if (keyIndex == 2) {
+      isNull2 = isNull;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  private boolean isStringNull0() {
+    return length0 == -1;
+  }
+
+  private boolean isStringNull1() {
+    return length1 == -1;
+  }
+
+  @Override
+  public String stringifyKeys(VectorColumnSetInfo columnSetInfo)
+  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("longs ");
+    appendLong(sb, columnSetInfo);
+    sb.append(", byte lengths ");
+    appendStringLength(sb, columnSetInfo, 0);
+    sb.append(", ");
+    appendStringLength(sb, columnSetInfo, 1);
+    return sb.toString();
+  }
+
+  private void appendLong(StringBuilder sb, VectorColumnSetInfo columnSetInfo) {
+    int keyIndex = columnSetInfo.longIndices[0];
+    if (isNull(keyIndex)) {
+      sb.append("null");
+    } else {
+      sb.append(longValue0);
+      PrimitiveTypeInfo primitiveTypeInfo = (PrimitiveTypeInfo) columnSetInfo.typeInfos[keyIndex];
+      switch (primitiveTypeInfo.getPrimitiveCategory()) {
+      case DATE:
+        Date dt = new Date(0);
+        dt.setTime(DateWritableV2.daysToMillis((int) longValue0));
+        sb.append(" date ");
+        sb.append(dt.toString());
+        break;
+      default:
+        break;
+      }
+    }
+  }
+
+  private void appendStringLength(StringBuilder sb, VectorColumnSetInfo columnSetInfo, int index) {
+    int keyIndex = columnSetInfo.stringIndices[index];
+    sb.append(isNull(keyIndex) ? "null" : getByteLength(index));
+  }
+
+  @Override
+  public String toString()
+  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("longs ");
+    sb.append(Arrays.toString(new long[] { longValue0 }));
+    sb.append(", byte lengths ");
+    sb.append(Arrays.toString(new int[] { length0, length1 }));
+    sb.append(", nulls ");
+    sb.append(Arrays.toString(new boolean[] { isNull0, isNull1, isNull2 }));
+    return sb.toString();
+  }
+
+  @Override
+  public long getLongValue(int i) {
+    if (i == 0) {
+      return longValue0;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public byte[] getBytes(int i) {
+    if (i == 0) {
+      return bytes0;
+    } else if (i == 1) {
+      return bytes1;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public int getByteStart(int i) {
+    if (i == 0) {
+      return start0;
+    } else if (i == 1) {
+      return start1;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public int getByteLength(int i) {
+    if (i == 0) {
+      return length0;
+    } else if (i == 1) {
+      return length1;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public int getVariableSize() {
+    JavaDataModel model = JavaDataModel.get();
+    return (int) (model.lengthForByteArrayOfSize(length0) + model.lengthForByteArrayOfSize(length1));
+  }
+
+  @Override
+  public void clearIsNull() {
+    isNull0 = false;
+    isNull1 = false;
+    isNull2 = false;
+  }
+
+  @Override
+  public void setNull() {
+    isNull0 = true;
+    isNull1 = true;
+    isNull2 = true;
+  }
+
+  @Override
+  public boolean isNull(int keyIndex) {
+    if (keyIndex == 0) {
+      return isNull0;
+    } else if (keyIndex == 1) {
+      return isNull1;
+    } else if (keyIndex == 2) {
+      return isNull2;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperSingleString.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperSingleString.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.vector.wrapper;
+
+import java.util.Arrays;
+
+import org.apache.hadoop.hive.ql.exec.KeyWrapper;
+import org.apache.hadoop.hive.ql.exec.vector.VectorColumnSetInfo;
+import org.apache.hadoop.hive.ql.exec.vector.expressions.StringExpr;
+import org.apache.hadoop.hive.ql.util.JavaDataModel;
+import org.apache.hive.common.util.Murmur3;
+
+import com.google.common.base.Preconditions;
+
+public class VectorHashKeyWrapperSingleString extends VectorHashKeyWrapperSingleBase {
+
+  private byte[] bytes0;
+  private int start0;
+  private int length0;
+
+  private HashContext hashCtx;
+
+  protected VectorHashKeyWrapperSingleString(HashContext ctx) {
+    super();
+    hashCtx = ctx;
+    bytes0 = null;
+    start0 = 0;
+    length0 = 0;
+  }
+
+  @Override
+  public void setHashKey() {
+    if (isNull0) {
+      hashcode = nullHashcode;
+    } else {
+      Murmur3.IncrementalHash32 bytesHash = HashContext.getBytesHash(hashCtx);
+      bytesHash.start(0);
+      bytesHash.add(bytes0, start0, length0);
+      hashcode = bytesHash.end();
+    }
+  }
+
+  @Override
+  public boolean equals(Object that) {
+    if (that instanceof VectorHashKeyWrapperSingleString) {
+      VectorHashKeyWrapperSingleString keyThat = (VectorHashKeyWrapperSingleString) that;
+      return isNull0 == keyThat.isNull0 &&
+          (isNull0 || StringExpr.equal(
+              bytes0, start0, length0,
+              keyThat.bytes0, keyThat.start0, keyThat.length0));
+    }
+    return false;
+  }
+
+  @Override
+  protected Object clone() {
+    VectorHashKeyWrapperSingleString clone = new VectorHashKeyWrapperSingleString(hashCtx);
+    copyInto(clone);
+    return clone;
+  }
+
+  @Override
+  public void copyKey(KeyWrapper oldWrapper) {
+    VectorHashKeyWrapperSingleString clone = (VectorHashKeyWrapperSingleString) oldWrapper;
+    clone.hashCtx = hashCtx;
+    copyInto(clone);
+  }
+
+  private void copyInto(VectorHashKeyWrapperSingleString clone) {
+    clone.isNull0 = isNull0;
+    if (isNull0) {
+      clone.bytes0 = null;
+      clone.start0 = 0;
+      clone.length0 = -1;
+    } else {
+      if (clone.bytes0 == null || clone.bytes0.length < length0) {
+        clone.bytes0 = Arrays.copyOfRange(bytes0, start0, start0 + length0);
+      } else {
+        System.arraycopy(bytes0, start0, clone.bytes0, 0, length0);
+      }
+      clone.start0 = 0;
+      clone.length0 = length0;
+    }
+    clone.hashcode = hashcode;
+    assert clone.equals(this);
+  }
+
+  @Override
+  public void assignString(int index, byte[] bytes, int start, int length) {
+    if (index == 0) {
+      Preconditions.checkState(bytes != null);
+      isNull0 = false;
+      bytes0 = bytes;
+      start0 = start;
+      length0 = length;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public void assignNullString(int keyIndex, int index) {
+    if (keyIndex == 0 && index == 0) {
+      isNull0 = true;
+      bytes0 = null;
+      start0 = 0;
+      length0 = -1;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  /*
+   * This method is mainly intended for debug display purposes.
+   */
+  @Override
+  public String stringifyKeys(VectorColumnSetInfo columnSetInfo)
+  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("bytes lengths [");
+    if (!isNull0) {
+      sb.append(length0);
+    } else {
+      sb.append("null");
+    }
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public String toString()
+  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("bytes lengths [");
+    sb.append(length0);
+    sb.append("], nulls [");
+    sb.append(isNull0);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public byte[] getBytes(int i) {
+    if (i == 0) {
+      return bytes0;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public int getByteStart(int i) {
+    if (i == 0) {
+      return start0;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public int getByteLength(int i) {
+    if (i == 0) {
+      return length0;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public int getVariableSize() {
+    return isNull0 ? 0 : JavaDataModel.get().lengthForByteArrayOfSize(length0);
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperSingleString.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperSingleString.java
@@ -34,6 +34,9 @@ public class VectorHashKeyWrapperSingleString extends VectorHashKeyWrapperSingle
   private int start0;
   private int length0;
 
+  private static final int nonNullHashcode = Arrays.hashCode(new boolean[] { false });
+  private static final int singleStringNullHashcode = Arrays.hashCode(new boolean[] { true });
+
   private HashContext hashCtx;
 
   protected VectorHashKeyWrapperSingleString(HashContext ctx) {
@@ -46,14 +49,14 @@ public class VectorHashKeyWrapperSingleString extends VectorHashKeyWrapperSingle
 
   @Override
   public void setHashKey() {
-    if (isNull0) {
-      hashcode = nullHashcode;
-    } else {
+    int hash = isNull0 ? singleStringNullHashcode : nonNullHashcode;
+    if (length0 != -1) {
       Murmur3.IncrementalHash32 bytesHash = HashContext.getBytesHash(hashCtx);
-      bytesHash.start(0);
+      bytesHash.start(hash);
       bytesHash.add(bytes0, start0, length0);
-      hashcode = bytesHash.end();
+      hash = bytesHash.end();
     }
+    hashcode = hash;
   }
 
   @Override
@@ -140,13 +143,12 @@ public class VectorHashKeyWrapperSingleString extends VectorHashKeyWrapperSingle
   public String stringifyKeys(VectorColumnSetInfo columnSetInfo)
   {
     StringBuilder sb = new StringBuilder();
-    sb.append("bytes lengths [");
+    sb.append("byte lengths ");
     if (!isNull0) {
       sb.append(length0);
     } else {
       sb.append("null");
     }
-    sb.append("]");
     return sb.toString();
   }
 
@@ -154,7 +156,7 @@ public class VectorHashKeyWrapperSingleString extends VectorHashKeyWrapperSingle
   public String toString()
   {
     StringBuilder sb = new StringBuilder();
-    sb.append("bytes lengths [");
+    sb.append("byte lengths [");
     sb.append(length0);
     sb.append("], nulls [");
     sb.append(isNull0);
@@ -191,6 +193,6 @@ public class VectorHashKeyWrapperSingleString extends VectorHashKeyWrapperSingle
 
   @Override
   public int getVariableSize() {
-    return isNull0 ? 0 : (int) JavaDataModel.get().lengthForByteArrayOfSize(length0);
+    return (int) JavaDataModel.get().lengthForByteArrayOfSize(length0);
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperSingleString.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperSingleString.java
@@ -191,6 +191,6 @@ public class VectorHashKeyWrapperSingleString extends VectorHashKeyWrapperSingle
 
   @Override
   public int getVariableSize() {
-    return isNull0 ? 0 : JavaDataModel.get().lengthForByteArrayOfSize(length0);
+    return isNull0 ? 0 : (int) JavaDataModel.get().lengthForByteArrayOfSize(length0);
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperSingleString.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperSingleString.java
@@ -89,6 +89,13 @@ public class VectorHashKeyWrapperSingleString extends VectorHashKeyWrapperSingle
       clone.start0 = 0;
       clone.length0 = -1;
     } else {
+      /*
+       * The batch wrapper can point at BytesColumnVector storage.  That storage may be
+       * reused or mutated after the key is inserted into the aggregation hash map, so
+       * copied keys must own a stable byte array.  When VectorGroupByOperator reuses a
+       * previously flushed key wrapper, update the owned array in place if it is large
+       * enough; otherwise allocate a new owned copy.
+       */
       if (clone.bytes0 == null || clone.bytes0.length < length0) {
         clone.bytes0 = Arrays.copyOfRange(bytes0, start0, start0 + length0);
       } else {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperThreeLong.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperThreeLong.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.vector.wrapper;
+
+import java.sql.Date;
+import java.util.Arrays;
+
+import org.apache.hadoop.hive.ql.exec.vector.VectorColumnSetInfo;
+import org.apache.hadoop.hive.serde2.io.DateWritableV2;
+import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
+
+public class VectorHashKeyWrapperThreeLong extends VectorHashKeyWrapperBase {
+
+  private long longValue0;
+  private long longValue1;
+  private long longValue2;
+
+  private boolean isNull0;
+  private boolean isNull1;
+  private boolean isNull2;
+
+  protected VectorHashKeyWrapperThreeLong() {
+    super();
+    longValue0 = 0;
+    longValue1 = 0;
+    longValue2 = 0;
+    isNull0 = false;
+    isNull1 = false;
+    isNull2 = false;
+  }
+
+  private static final int EMPTY_DOUBLE_ARRAY_HASH = 1;
+
+  @Override
+  public void setHashKey() {
+    hashcode = calculateLongValuesHashCode() ^ EMPTY_DOUBLE_ARRAY_HASH ^ calculateNullsHashCode();
+  }
+
+  private int calculateLongValuesHashCode() {
+    int result = 1;
+    result = 31 * result + (int) (longValue0 ^ (longValue0 >>> 32));
+    result = 31 * result + (int) (longValue1 ^ (longValue1 >>> 32));
+    result = 31 * result + (int) (longValue2 ^ (longValue2 >>> 32));
+    return result;
+  }
+
+  private int calculateNullsHashCode() {
+    int result = 1;
+    result = 31 * result + (isNull0 ? 1231 : 1237);
+    result = 31 * result + (isNull1 ? 1231 : 1237);
+    result = 31 * result + (isNull2 ? 1231 : 1237);
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object that) {
+    if (that instanceof VectorHashKeyWrapperThreeLong) {
+      VectorHashKeyWrapperThreeLong keyThat = (VectorHashKeyWrapperThreeLong) that;
+      return hashcode == keyThat.hashcode &&
+          longValue0 == keyThat.longValue0 &&
+          longValue1 == keyThat.longValue1 &&
+          longValue2 == keyThat.longValue2 &&
+          isNull0 == keyThat.isNull0 &&
+          isNull1 == keyThat.isNull1 &&
+          isNull2 == keyThat.isNull2;
+    }
+    return false;
+  }
+
+  @Override
+  protected Object clone() {
+    VectorHashKeyWrapperThreeLong clone = new VectorHashKeyWrapperThreeLong();
+    clone.longValue0 = longValue0;
+    clone.longValue1 = longValue1;
+    clone.longValue2 = longValue2;
+    clone.isNull0 = isNull0;
+    clone.isNull1 = isNull1;
+    clone.isNull2 = isNull2;
+    clone.hashcode = hashcode;
+    return clone;
+  }
+
+  @Override
+  public void assignLong(int keyIndex, int index, long v) {
+    assignNullFlag(keyIndex, false);
+    if (index == 0) {
+      longValue0 = v;
+    } else if (index == 1) {
+      longValue1 = v;
+    } else if (index == 2) {
+      longValue2 = v;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  // FIXME: isNull is not updated; which might cause problems
+  @Deprecated
+  @Override
+  public void assignLong(int index, long v) {
+    if (index == 0) {
+      longValue0 = v;
+    } else if (index == 1) {
+      longValue1 = v;
+    } else if (index == 2) {
+      longValue2 = v;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public void assignNullLong(int keyIndex, int index) {
+    assignNullFlag(keyIndex, true);
+    if (index == 0) {
+      longValue0 = 0;
+    } else if (index == 1) {
+      longValue1 = 0;
+    } else if (index == 2) {
+      longValue2 = 0;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  private void assignNullFlag(int keyIndex, boolean isNull) {
+    if (keyIndex == 0) {
+      isNull0 = isNull;
+    } else if (keyIndex == 1) {
+      isNull1 = isNull;
+    } else if (keyIndex == 2) {
+      isNull2 = isNull;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  /*
+   * This method is mainly intended for debug display purposes.
+   */
+  @Override
+  public String stringifyKeys(VectorColumnSetInfo columnSetInfo)
+  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("longs ");
+    for (int i = 0; i < columnSetInfo.longIndices.length; i++) {
+      if (i > 0) {
+        sb.append(", ");
+      }
+      int keyIndex = columnSetInfo.longIndices[i];
+      if (isNull(keyIndex)) {
+        sb.append("null");
+      } else {
+        long longValue = getLongValue(i);
+        sb.append(longValue);
+        PrimitiveTypeInfo primitiveTypeInfo = (PrimitiveTypeInfo) columnSetInfo.typeInfos[keyIndex];
+        switch (primitiveTypeInfo.getPrimitiveCategory()) {
+        case DATE:
+          Date dt = new Date(0);
+          dt.setTime(DateWritableV2.daysToMillis((int) longValue));
+          sb.append(" date ");
+          sb.append(dt.toString());
+          break;
+        default:
+          break;
+        }
+      }
+    }
+    return sb.toString();
+  }
+
+  @Override
+  public String toString()
+  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("longs ");
+    sb.append(Arrays.toString(new long[] { longValue0, longValue1, longValue2 }));
+    sb.append(", nulls ");
+    sb.append(Arrays.toString(new boolean[] { isNull0, isNull1, isNull2 }));
+    return sb.toString();
+  }
+
+  @Override
+  public long getLongValue(int i) {
+    if (i == 0) {
+      return longValue0;
+    } else if (i == 1) {
+      return longValue1;
+    } else if (i == 2) {
+      return longValue2;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public int getVariableSize() {
+    return 0;
+  }
+
+  @Override
+  public void clearIsNull() {
+    isNull0 = false;
+    isNull1 = false;
+    isNull2 = false;
+  }
+
+  @Override
+  public void setNull() {
+    isNull0 = true;
+    isNull1 = true;
+    isNull2 = true;
+  }
+
+  @Override
+  public boolean isNull(int keyIndex) {
+    if (keyIndex == 0) {
+      return isNull0;
+    } else if (keyIndex == 1) {
+      return isNull1;
+    } else if (keyIndex == 2) {
+      return isNull2;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperThreeString.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperThreeString.java
@@ -1,0 +1,371 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.vector.wrapper;
+
+import java.util.Arrays;
+
+import org.apache.hadoop.hive.ql.exec.KeyWrapper;
+import org.apache.hadoop.hive.ql.exec.vector.VectorColumnSetInfo;
+import org.apache.hadoop.hive.ql.exec.vector.expressions.StringExpr;
+import org.apache.hadoop.hive.ql.util.JavaDataModel;
+import org.apache.hive.common.util.Murmur3;
+
+import com.google.common.base.Preconditions;
+
+public class VectorHashKeyWrapperThreeString extends VectorHashKeyWrapperBase {
+
+  private byte[] bytes0;
+  private int start0;
+  private int length0;
+
+  private byte[] bytes1;
+  private int start1;
+  private int length1;
+
+  private byte[] bytes2;
+  private int start2;
+  private int length2;
+
+  private boolean isNull0;
+  private boolean isNull1;
+  private boolean isNull2;
+
+  private static final int nonNullHashcode = Arrays.hashCode(new boolean[] { false, false, false });
+  private static final int null0Hashcode = Arrays.hashCode(new boolean[] { true, false, false });
+  private static final int null1Hashcode = Arrays.hashCode(new boolean[] { false, true, false });
+  private static final int null2Hashcode = Arrays.hashCode(new boolean[] { false, false, true });
+  private static final int null0Null1Hashcode = Arrays.hashCode(new boolean[] { true, true, false });
+  private static final int null0Null2Hashcode = Arrays.hashCode(new boolean[] { true, false, true });
+  private static final int null1Null2Hashcode = Arrays.hashCode(new boolean[] { false, true, true });
+  private static final int threeNullHashcode = Arrays.hashCode(new boolean[] { true, true, true });
+
+  private HashContext hashCtx;
+
+  protected VectorHashKeyWrapperThreeString(HashContext ctx) {
+    super();
+    hashCtx = ctx;
+    bytes0 = null;
+    start0 = 0;
+    length0 = 0;
+    bytes1 = null;
+    start1 = 0;
+    length1 = 0;
+    bytes2 = null;
+    start2 = 0;
+    length2 = 0;
+    isNull0 = false;
+    isNull1 = false;
+    isNull2 = false;
+  }
+
+  @Override
+  public void setHashKey() {
+    int hash = nullHashcode();
+    Murmur3.IncrementalHash32 bytesHash = null;
+    if (length0 != -1) {
+      bytesHash = HashContext.getBytesHash(hashCtx);
+      bytesHash.start(hash);
+      bytesHash.add(bytes0, start0, length0);
+    }
+    if (length1 != -1) {
+      if (bytesHash == null) {
+        bytesHash = HashContext.getBytesHash(hashCtx);
+        bytesHash.start(hash);
+      }
+      bytesHash.add(bytes1, start1, length1);
+    }
+    if (length2 != -1) {
+      if (bytesHash == null) {
+        bytesHash = HashContext.getBytesHash(hashCtx);
+        bytesHash.start(hash);
+      }
+      bytesHash.add(bytes2, start2, length2);
+    }
+    hashcode = bytesHash == null ? hash : bytesHash.end();
+  }
+
+  private int nullHashcode() {
+    if (isNull0) {
+      if (isNull1) {
+        return isNull2 ? threeNullHashcode : null0Null1Hashcode;
+      } else {
+        return isNull2 ? null0Null2Hashcode : null0Hashcode;
+      }
+    } else if (isNull1) {
+      return isNull2 ? null1Null2Hashcode : null1Hashcode;
+    } else {
+      return isNull2 ? null2Hashcode : nonNullHashcode;
+    }
+  }
+
+  @Override
+  public boolean equals(Object that) {
+    if (that instanceof VectorHashKeyWrapperThreeString) {
+      VectorHashKeyWrapperThreeString keyThat = (VectorHashKeyWrapperThreeString) that;
+      return hashcode == keyThat.hashcode &&
+          isNull0 == keyThat.isNull0 &&
+          (isNull0 || StringExpr.equal(
+              bytes0, start0, length0,
+              keyThat.bytes0, keyThat.start0, keyThat.length0)) &&
+          isNull1 == keyThat.isNull1 &&
+          (isNull1 || StringExpr.equal(
+              bytes1, start1, length1,
+              keyThat.bytes1, keyThat.start1, keyThat.length1)) &&
+          isNull2 == keyThat.isNull2 &&
+          (isNull2 || StringExpr.equal(
+              bytes2, start2, length2,
+              keyThat.bytes2, keyThat.start2, keyThat.length2));
+    }
+    return false;
+  }
+
+  @Override
+  protected Object clone() {
+    VectorHashKeyWrapperThreeString clone = new VectorHashKeyWrapperThreeString(hashCtx);
+    copyInto(clone);
+    return clone;
+  }
+
+  @Override
+  public void copyKey(KeyWrapper oldWrapper) {
+    VectorHashKeyWrapperThreeString clone = (VectorHashKeyWrapperThreeString) oldWrapper;
+    clone.hashCtx = hashCtx;
+    copyInto(clone);
+  }
+
+  private void copyInto(VectorHashKeyWrapperThreeString clone) {
+    clone.isNull0 = isNull0;
+    clone.isNull1 = isNull1;
+    clone.isNull2 = isNull2;
+    if (isNull0) {
+      clone.bytes0 = null;
+      clone.start0 = 0;
+      clone.length0 = -1;
+    } else {
+      clone.bytes0 = copyBytes(bytes0, start0, length0, clone.bytes0);
+      clone.start0 = 0;
+      clone.length0 = length0;
+    }
+    if (isNull1) {
+      clone.bytes1 = null;
+      clone.start1 = 0;
+      clone.length1 = -1;
+    } else {
+      clone.bytes1 = copyBytes(bytes1, start1, length1, clone.bytes1);
+      clone.start1 = 0;
+      clone.length1 = length1;
+    }
+    if (isNull2) {
+      clone.bytes2 = null;
+      clone.start2 = 0;
+      clone.length2 = -1;
+    } else {
+      clone.bytes2 = copyBytes(bytes2, start2, length2, clone.bytes2);
+      clone.start2 = 0;
+      clone.length2 = length2;
+    }
+    clone.hashcode = hashcode;
+    assert clone.equals(this);
+  }
+
+  private byte[] copyBytes(byte[] bytes, int start, int length, byte[] previousCopy) {
+    if (previousCopy == null || previousCopy.length < length) {
+      return Arrays.copyOfRange(bytes, start, start + length);
+    } else {
+      System.arraycopy(bytes, start, previousCopy, 0, length);
+      return previousCopy;
+    }
+  }
+
+  @Override
+  public void assignString(int index, byte[] bytes, int start, int length) {
+    Preconditions.checkState(bytes != null);
+    if (index == 0) {
+      isNull0 = false;
+      bytes0 = bytes;
+      start0 = start;
+      length0 = length;
+    } else if (index == 1) {
+      isNull1 = false;
+      bytes1 = bytes;
+      start1 = start;
+      length1 = length;
+    } else if (index == 2) {
+      isNull2 = false;
+      bytes2 = bytes;
+      start2 = start;
+      length2 = length;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public void assignNullString(int keyIndex, int index) {
+    assignNullFlag(keyIndex, true);
+    if (index == 0) {
+      bytes0 = null;
+      start0 = 0;
+      length0 = -1;
+    } else if (index == 1) {
+      bytes1 = null;
+      start1 = 0;
+      length1 = -1;
+    } else if (index == 2) {
+      bytes2 = null;
+      start2 = 0;
+      length2 = -1;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  private void assignNullFlag(int keyIndex, boolean isNull) {
+    if (keyIndex == 0) {
+      isNull0 = isNull;
+    } else if (keyIndex == 1) {
+      isNull1 = isNull;
+    } else if (keyIndex == 2) {
+      isNull2 = isNull;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  /*
+   * This method is mainly intended for debug display purposes.
+   */
+  @Override
+  public String stringifyKeys(VectorColumnSetInfo columnSetInfo)
+  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("byte lengths ");
+    if (!isNull0) {
+      sb.append(length0);
+    } else {
+      sb.append("null");
+    }
+    sb.append(", ");
+    if (!isNull1) {
+      sb.append(length1);
+    } else {
+      sb.append("null");
+    }
+    sb.append(", ");
+    if (!isNull2) {
+      sb.append(length2);
+    } else {
+      sb.append("null");
+    }
+    return sb.toString();
+  }
+
+  @Override
+  public String toString()
+  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("byte lengths [");
+    sb.append(length0);
+    sb.append(", ");
+    sb.append(length1);
+    sb.append(", ");
+    sb.append(length2);
+    sb.append("], nulls [");
+    sb.append(isNull0);
+    sb.append(", ");
+    sb.append(isNull1);
+    sb.append(", ");
+    sb.append(isNull2);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public byte[] getBytes(int i) {
+    if (i == 0) {
+      return bytes0;
+    } else if (i == 1) {
+      return bytes1;
+    } else if (i == 2) {
+      return bytes2;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public int getByteStart(int i) {
+    if (i == 0) {
+      return start0;
+    } else if (i == 1) {
+      return start1;
+    } else if (i == 2) {
+      return start2;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public int getByteLength(int i) {
+    if (i == 0) {
+      return length0;
+    } else if (i == 1) {
+      return length1;
+    } else if (i == 2) {
+      return length2;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public int getVariableSize() {
+    JavaDataModel model = JavaDataModel.get();
+    return (int) (model.lengthForByteArrayOfSize(length0) + model.lengthForByteArrayOfSize(length1) +
+        model.lengthForByteArrayOfSize(length2));
+  }
+
+  @Override
+  public void clearIsNull() {
+    isNull0 = false;
+    isNull1 = false;
+    isNull2 = false;
+  }
+
+  @Override
+  public void setNull() {
+    isNull0 = true;
+    isNull1 = true;
+    isNull2 = true;
+  }
+
+  @Override
+  public boolean isNull(int keyIndex) {
+    if (keyIndex == 0) {
+      return isNull0;
+    } else if (keyIndex == 1) {
+      return isNull1;
+    } else if (keyIndex == 2) {
+      return isNull2;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperTwoLong.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperTwoLong.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hive.ql.exec.vector.wrapper;
 
+import org.apache.hadoop.hive.ql.exec.KeyWrapper;
 import org.apache.hadoop.hive.ql.exec.vector.VectorColumnSetInfo;
 import org.apache.hive.common.util.HashCodeUtil;
 
@@ -64,12 +65,22 @@ public class VectorHashKeyWrapperTwoLong extends VectorHashKeyWrapperTwoBase {
   @Override
   protected Object clone() {
     VectorHashKeyWrapperTwoLong clone = new VectorHashKeyWrapperTwoLong();
+    copyInto(clone);
+    return clone;
+  }
+
+  @Override
+  public void copyKey(KeyWrapper oldWrapper) {
+    VectorHashKeyWrapperTwoLong clone = (VectorHashKeyWrapperTwoLong) oldWrapper;
+    copyInto(clone);
+  }
+
+  private void copyInto(VectorHashKeyWrapperTwoLong clone) {
     clone.isNull0 = isNull0;
     clone.longValue0 = longValue0;
     clone.isNull1 = isNull1;
     clone.longValue1 = longValue1;
     clone.hashcode = hashcode;
-    return clone;
   }
 
   @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperTwoLongSingleString.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperTwoLongSingleString.java
@@ -23,41 +23,59 @@ import java.util.Arrays;
 
 import org.apache.hadoop.hive.ql.exec.KeyWrapper;
 import org.apache.hadoop.hive.ql.exec.vector.VectorColumnSetInfo;
+import org.apache.hadoop.hive.ql.exec.vector.expressions.StringExpr;
+import org.apache.hadoop.hive.ql.util.JavaDataModel;
 import org.apache.hadoop.hive.serde2.io.DateWritableV2;
 import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
+import org.apache.hive.common.util.Murmur3;
 
-public class VectorHashKeyWrapperThreeLong extends VectorHashKeyWrapperBase {
+import com.google.common.base.Preconditions;
+
+public class VectorHashKeyWrapperTwoLongSingleString extends VectorHashKeyWrapperBase {
 
   private long longValue0;
   private long longValue1;
-  private long longValue2;
+
+  private byte[] bytes0;
+  private int start0;
+  private int length0;
 
   private boolean isNull0;
   private boolean isNull1;
   private boolean isNull2;
 
-  protected VectorHashKeyWrapperThreeLong() {
+  private HashContext hashCtx;
+
+  protected VectorHashKeyWrapperTwoLongSingleString(HashContext ctx) {
     super();
+    hashCtx = ctx;
     longValue0 = 0;
     longValue1 = 0;
-    longValue2 = 0;
+    bytes0 = null;
+    start0 = 0;
+    length0 = 0;
     isNull0 = false;
     isNull1 = false;
     isNull2 = false;
   }
 
-  private static final int EMPTY_DOUBLE_ARRAY_HASH = 1;
-
   @Override
   public void setHashKey() {
-    hashcode = calculateLongValuesHashCode() ^ EMPTY_DOUBLE_ARRAY_HASH ^ calculateNullsHashCode();
+    int hash = calculateLongValuesHashCode();
+    hash = 31 * hash + calculateNullsHashCode();
+    if (length0 != -1) {
+      Murmur3.IncrementalHash32 bytesHash = HashContext.getBytesHash(hashCtx);
+      bytesHash.start(hash);
+      bytesHash.add(bytes0, start0, length0);
+      hash = bytesHash.end();
+    }
+    hashcode = hash;
   }
 
   private int calculateLongValuesHashCode() {
     int result = 1;
     result = 31 * result + (int) (longValue0 ^ (longValue0 >>> 32));
     result = 31 * result + (int) (longValue1 ^ (longValue1 >>> 32));
-    result = 31 * result + (int) (longValue2 ^ (longValue2 >>> 32));
     return result;
   }
 
@@ -71,40 +89,61 @@ public class VectorHashKeyWrapperThreeLong extends VectorHashKeyWrapperBase {
 
   @Override
   public boolean equals(Object that) {
-    if (that instanceof VectorHashKeyWrapperThreeLong) {
-      VectorHashKeyWrapperThreeLong keyThat = (VectorHashKeyWrapperThreeLong) that;
+    if (that instanceof VectorHashKeyWrapperTwoLongSingleString) {
+      VectorHashKeyWrapperTwoLongSingleString keyThat = (VectorHashKeyWrapperTwoLongSingleString) that;
       return hashcode == keyThat.hashcode &&
           longValue0 == keyThat.longValue0 &&
           longValue1 == keyThat.longValue1 &&
-          longValue2 == keyThat.longValue2 &&
           isNull0 == keyThat.isNull0 &&
           isNull1 == keyThat.isNull1 &&
-          isNull2 == keyThat.isNull2;
+          isNull2 == keyThat.isNull2 &&
+          (isStringNull() || StringExpr.equal(
+              bytes0, start0, length0,
+              keyThat.bytes0, keyThat.start0, keyThat.length0));
     }
     return false;
   }
 
   @Override
   protected Object clone() {
-    VectorHashKeyWrapperThreeLong clone = new VectorHashKeyWrapperThreeLong();
+    VectorHashKeyWrapperTwoLongSingleString clone = new VectorHashKeyWrapperTwoLongSingleString(hashCtx);
     copyInto(clone);
     return clone;
   }
 
   @Override
   public void copyKey(KeyWrapper oldWrapper) {
-    VectorHashKeyWrapperThreeLong clone = (VectorHashKeyWrapperThreeLong) oldWrapper;
+    VectorHashKeyWrapperTwoLongSingleString clone = (VectorHashKeyWrapperTwoLongSingleString) oldWrapper;
+    clone.hashCtx = hashCtx;
     copyInto(clone);
   }
 
-  private void copyInto(VectorHashKeyWrapperThreeLong clone) {
+  private void copyInto(VectorHashKeyWrapperTwoLongSingleString clone) {
     clone.longValue0 = longValue0;
     clone.longValue1 = longValue1;
-    clone.longValue2 = longValue2;
     clone.isNull0 = isNull0;
     clone.isNull1 = isNull1;
     clone.isNull2 = isNull2;
+    if (isStringNull()) {
+      clone.bytes0 = null;
+      clone.start0 = 0;
+      clone.length0 = -1;
+    } else {
+      clone.bytes0 = copyBytes(bytes0, start0, length0, clone.bytes0);
+      clone.start0 = 0;
+      clone.length0 = length0;
+    }
     clone.hashcode = hashcode;
+    assert clone.equals(this);
+  }
+
+  private byte[] copyBytes(byte[] bytes, int start, int length, byte[] previousCopy) {
+    if (previousCopy == null || previousCopy.length < length) {
+      return Arrays.copyOfRange(bytes, start, start + length);
+    } else {
+      System.arraycopy(bytes, start, previousCopy, 0, length);
+      return previousCopy;
+    }
   }
 
   @Override
@@ -114,14 +153,11 @@ public class VectorHashKeyWrapperThreeLong extends VectorHashKeyWrapperBase {
       longValue0 = v;
     } else if (index == 1) {
       longValue1 = v;
-    } else if (index == 2) {
-      longValue2 = v;
     } else {
       throw new ArrayIndexOutOfBoundsException();
     }
   }
 
-  // FIXME: isNull is not updated; which might cause problems
   @Deprecated
   @Override
   public void assignLong(int index, long v) {
@@ -129,8 +165,6 @@ public class VectorHashKeyWrapperThreeLong extends VectorHashKeyWrapperBase {
       longValue0 = v;
     } else if (index == 1) {
       longValue1 = v;
-    } else if (index == 2) {
-      longValue2 = v;
     } else {
       throw new ArrayIndexOutOfBoundsException();
     }
@@ -143,8 +177,30 @@ public class VectorHashKeyWrapperThreeLong extends VectorHashKeyWrapperBase {
       longValue0 = 0;
     } else if (index == 1) {
       longValue1 = 0;
-    } else if (index == 2) {
-      longValue2 = 0;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public void assignString(int index, byte[] bytes, int start, int length) {
+    if (index == 0) {
+      Preconditions.checkState(bytes != null);
+      bytes0 = bytes;
+      start0 = start;
+      length0 = length;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public void assignNullString(int keyIndex, int index) {
+    if (index == 0) {
+      assignNullFlag(keyIndex, true);
+      bytes0 = null;
+      start0 = 0;
+      length0 = -1;
     } else {
       throw new ArrayIndexOutOfBoundsException();
     }
@@ -162,38 +218,43 @@ public class VectorHashKeyWrapperThreeLong extends VectorHashKeyWrapperBase {
     }
   }
 
-  /*
-   * This method is mainly intended for debug display purposes.
-   */
+  private boolean isStringNull() {
+    return length0 == -1;
+  }
+
   @Override
   public String stringifyKeys(VectorColumnSetInfo columnSetInfo)
   {
     StringBuilder sb = new StringBuilder();
     sb.append("longs ");
-    for (int i = 0; i < columnSetInfo.longIndices.length; i++) {
-      if (i > 0) {
-        sb.append(", ");
-      }
-      int keyIndex = columnSetInfo.longIndices[i];
-      if (isNull(keyIndex)) {
-        sb.append("null");
-      } else {
-        long longValue = getLongValue(i);
-        sb.append(longValue);
-        PrimitiveTypeInfo primitiveTypeInfo = (PrimitiveTypeInfo) columnSetInfo.typeInfos[keyIndex];
-        switch (primitiveTypeInfo.getPrimitiveCategory()) {
-        case DATE:
-          Date dt = new Date(0);
-          dt.setTime(DateWritableV2.daysToMillis((int) longValue));
-          sb.append(" date ");
-          sb.append(dt.toString());
-          break;
-        default:
-          break;
-        }
+    appendLong(sb, columnSetInfo, 0);
+    sb.append(", ");
+    appendLong(sb, columnSetInfo, 1);
+    sb.append(", byte lengths ");
+    int stringKeyIndex = columnSetInfo.stringIndices[0];
+    sb.append(isNull(stringKeyIndex) ? "null" : length0);
+    return sb.toString();
+  }
+
+  private void appendLong(StringBuilder sb, VectorColumnSetInfo columnSetInfo, int index) {
+    int keyIndex = columnSetInfo.longIndices[index];
+    if (isNull(keyIndex)) {
+      sb.append("null");
+    } else {
+      long longValue = getLongValue(index);
+      sb.append(longValue);
+      PrimitiveTypeInfo primitiveTypeInfo = (PrimitiveTypeInfo) columnSetInfo.typeInfos[keyIndex];
+      switch (primitiveTypeInfo.getPrimitiveCategory()) {
+      case DATE:
+        Date dt = new Date(0);
+        dt.setTime(DateWritableV2.daysToMillis((int) longValue));
+        sb.append(" date ");
+        sb.append(dt.toString());
+        break;
+      default:
+        break;
       }
     }
-    return sb.toString();
   }
 
   @Override
@@ -201,7 +262,9 @@ public class VectorHashKeyWrapperThreeLong extends VectorHashKeyWrapperBase {
   {
     StringBuilder sb = new StringBuilder();
     sb.append("longs ");
-    sb.append(Arrays.toString(new long[] { longValue0, longValue1, longValue2 }));
+    sb.append(Arrays.toString(new long[] { longValue0, longValue1 }));
+    sb.append(", byte lengths ");
+    sb.append(Arrays.toString(new int[] { length0 }));
     sb.append(", nulls ");
     sb.append(Arrays.toString(new boolean[] { isNull0, isNull1, isNull2 }));
     return sb.toString();
@@ -213,8 +276,33 @@ public class VectorHashKeyWrapperThreeLong extends VectorHashKeyWrapperBase {
       return longValue0;
     } else if (i == 1) {
       return longValue1;
-    } else if (i == 2) {
-      return longValue2;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public byte[] getBytes(int i) {
+    if (i == 0) {
+      return bytes0;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public int getByteStart(int i) {
+    if (i == 0) {
+      return start0;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public int getByteLength(int i) {
+    if (i == 0) {
+      return length0;
     } else {
       throw new ArrayIndexOutOfBoundsException();
     }
@@ -222,7 +310,7 @@ public class VectorHashKeyWrapperThreeLong extends VectorHashKeyWrapperBase {
 
   @Override
   public int getVariableSize() {
-    return 0;
+    return (int) JavaDataModel.get().lengthForByteArrayOfSize(length0);
   }
 
   @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperTwoString.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/wrapper/VectorHashKeyWrapperTwoString.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.vector.wrapper;
+
+import java.util.Arrays;
+
+import org.apache.hadoop.hive.ql.exec.KeyWrapper;
+import org.apache.hadoop.hive.ql.exec.vector.VectorColumnSetInfo;
+import org.apache.hadoop.hive.ql.exec.vector.expressions.StringExpr;
+import org.apache.hadoop.hive.ql.util.JavaDataModel;
+import org.apache.hive.common.util.Murmur3;
+
+import com.google.common.base.Preconditions;
+
+public class VectorHashKeyWrapperTwoString extends VectorHashKeyWrapperTwoBase {
+
+  private byte[] bytes0;
+  private int start0;
+  private int length0;
+
+  private byte[] bytes1;
+  private int start1;
+  private int length1;
+
+  private static final int nonNullHashcode = Arrays.hashCode(new boolean[] { false, false });
+  private static final int null0Hashcode = Arrays.hashCode(new boolean[] { true, false });
+  private static final int null1Hashcode = Arrays.hashCode(new boolean[] { false, true });
+  private static final int twoNullHashcode = Arrays.hashCode(new boolean[] { true, true });
+
+  private HashContext hashCtx;
+
+  protected VectorHashKeyWrapperTwoString(HashContext ctx) {
+    super();
+    hashCtx = ctx;
+    bytes0 = null;
+    start0 = 0;
+    length0 = 0;
+    bytes1 = null;
+    start1 = 0;
+    length1 = 0;
+  }
+
+  @Override
+  public void setHashKey() {
+    int hash;
+    if (isNull0 || isNull1) {
+      hash = isNull0 && isNull1 ? twoNullHashcode : isNull0 ? null0Hashcode : null1Hashcode;
+    } else {
+      hash = nonNullHashcode;
+    }
+
+    Murmur3.IncrementalHash32 bytesHash = null;
+    if (length0 != -1) {
+      bytesHash = HashContext.getBytesHash(hashCtx);
+      bytesHash.start(hash);
+      bytesHash.add(bytes0, start0, length0);
+    }
+    if (length1 != -1) {
+      if (bytesHash == null) {
+        bytesHash = HashContext.getBytesHash(hashCtx);
+        bytesHash.start(hash);
+      }
+      bytesHash.add(bytes1, start1, length1);
+    }
+    hashcode = bytesHash == null ? hash : bytesHash.end();
+  }
+
+  @Override
+  public boolean equals(Object that) {
+    if (that instanceof VectorHashKeyWrapperTwoString) {
+      VectorHashKeyWrapperTwoString keyThat = (VectorHashKeyWrapperTwoString) that;
+      return isNull0 == keyThat.isNull0 &&
+          (isNull0 || StringExpr.equal(
+              bytes0, start0, length0,
+              keyThat.bytes0, keyThat.start0, keyThat.length0)) &&
+          isNull1 == keyThat.isNull1 &&
+          (isNull1 || StringExpr.equal(
+              bytes1, start1, length1,
+              keyThat.bytes1, keyThat.start1, keyThat.length1));
+    }
+    return false;
+  }
+
+  @Override
+  protected Object clone() {
+    VectorHashKeyWrapperTwoString clone = new VectorHashKeyWrapperTwoString(hashCtx);
+    copyInto(clone);
+    return clone;
+  }
+
+  @Override
+  public void copyKey(KeyWrapper oldWrapper) {
+    VectorHashKeyWrapperTwoString clone = (VectorHashKeyWrapperTwoString) oldWrapper;
+    clone.hashCtx = hashCtx;
+    copyInto(clone);
+  }
+
+  private void copyInto(VectorHashKeyWrapperTwoString clone) {
+    clone.isNull0 = isNull0;
+    clone.isNull1 = isNull1;
+    if (isNull0) {
+      clone.bytes0 = null;
+      clone.start0 = 0;
+      clone.length0 = -1;
+    } else {
+      clone.bytes0 = copyBytes(bytes0, start0, length0, clone.bytes0);
+      clone.start0 = 0;
+      clone.length0 = length0;
+    }
+    if (isNull1) {
+      clone.bytes1 = null;
+      clone.start1 = 0;
+      clone.length1 = -1;
+    } else {
+      clone.bytes1 = copyBytes(bytes1, start1, length1, clone.bytes1);
+      clone.start1 = 0;
+      clone.length1 = length1;
+    }
+    clone.hashcode = hashcode;
+    assert clone.equals(this);
+  }
+
+  private byte[] copyBytes(byte[] bytes, int start, int length, byte[] previousCopy) {
+    if (previousCopy == null || previousCopy.length < length) {
+      return Arrays.copyOfRange(bytes, start, start + length);
+    } else {
+      System.arraycopy(bytes, start, previousCopy, 0, length);
+      return previousCopy;
+    }
+  }
+
+  @Override
+  public void assignString(int index, byte[] bytes, int start, int length) {
+    Preconditions.checkState(bytes != null);
+    if (index == 0) {
+      isNull0 = false;
+      bytes0 = bytes;
+      start0 = start;
+      length0 = length;
+    } else if (index == 1) {
+      isNull1 = false;
+      bytes1 = bytes;
+      start1 = start;
+      length1 = length;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public void assignNullString(int keyIndex, int index) {
+    if (keyIndex == 0 && index == 0) {
+      isNull0 = true;
+      bytes0 = null;
+      start0 = 0;
+      length0 = -1;
+    } else if (keyIndex == 1 && index == 1) {
+      isNull1 = true;
+      bytes1 = null;
+      start1 = 0;
+      length1 = -1;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  /*
+   * This method is mainly intended for debug display purposes.
+   */
+  @Override
+  public String stringifyKeys(VectorColumnSetInfo columnSetInfo)
+  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("byte lengths ");
+    if (!isNull0) {
+      sb.append(length0);
+    } else {
+      sb.append("null");
+    }
+    sb.append(", ");
+    if (!isNull1) {
+      sb.append(length1);
+    } else {
+      sb.append("null");
+    }
+    return sb.toString();
+  }
+
+  @Override
+  public String toString()
+  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("byte lengths [");
+    sb.append(length0);
+    sb.append(", ");
+    sb.append(length1);
+    sb.append("], nulls [");
+    sb.append(isNull0);
+    sb.append(", ");
+    sb.append(isNull1);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public byte[] getBytes(int i) {
+    if (i == 0) {
+      return bytes0;
+    } else if (i == 1) {
+      return bytes1;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public int getByteStart(int i) {
+    if (i == 0) {
+      return start0;
+    } else if (i == 1) {
+      return start1;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public int getByteLength(int i) {
+    if (i == 0) {
+      return length0;
+    } else if (i == 1) {
+      return length1;
+    } else {
+      throw new ArrayIndexOutOfBoundsException();
+    }
+  }
+
+  @Override
+  public int getVariableSize() {
+    JavaDataModel model = JavaDataModel.get();
+    return (int) (model.lengthForByteArrayOfSize(length0) + model.lengthForByteArrayOfSize(length1));
+  }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorHashKeyWrapperBatch.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorHashKeyWrapperBatch.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperBase;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperBatch;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperGeneral;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperSingleString;
+import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperThreeLong;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperTwoString;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
@@ -339,6 +340,154 @@ public class TestVectorHashKeyWrapperBatch {
     assertFalse(vhkwArray[0].equals(vhkwArray[1]));
     assertFalse(vhkwArray[0].equals(vhkwArray[2]));
     assertFalse(vhkwArray[0].equals(vhkwArray[3]));
+  }
+
+  @Test
+  public void testVectorHashKeyWrapperThreeLong() throws HiveException {
+    VectorExpression[] keyExpressions = new VectorExpression[] { new IdentityExpression(0),
+        new IdentityExpression(1), new IdentityExpression(2) };
+    TypeInfo[] typeInfos = new TypeInfo[] {TypeInfoFactory.longTypeInfo, TypeInfoFactory.longTypeInfo,
+        TypeInfoFactory.longTypeInfo};
+    VectorHashKeyWrapperBatch vhkwb = VectorHashKeyWrapperBatch.compileKeyWrapperBatch(
+        keyExpressions,
+        typeInfos);
+
+    VectorizedRowBatch batch = new VectorizedRowBatch(3);
+    batch.selectedInUse = false;
+    LongColumnVector firstColumnVector = new LongColumnVector();
+    LongColumnVector secondColumnVector = new LongColumnVector();
+    LongColumnVector thirdColumnVector = new LongColumnVector();
+    batch.cols[0] = firstColumnVector;
+    batch.cols[1] = secondColumnVector;
+    batch.cols[2] = thirdColumnVector;
+
+    firstColumnVector.vector[0] = 10;
+    secondColumnVector.vector[0] = 20;
+    thirdColumnVector.vector[0] = 30;
+    firstColumnVector.vector[1] = 10;
+    secondColumnVector.vector[1] = 20;
+    thirdColumnVector.vector[1] = 31;
+    firstColumnVector.vector[2] = 10;
+    secondColumnVector.vector[2] = 20;
+    thirdColumnVector.vector[2] = 30;
+    firstColumnVector.vector[3] = 11;
+    secondColumnVector.vector[3] = 20;
+    thirdColumnVector.vector[3] = 30;
+    batch.size = 4;
+
+    vhkwb.evaluateBatch(batch);
+    VectorHashKeyWrapperBase[] vhkwArray = vhkwb.getVectorHashKeyWrappers();
+    for (int i = 0; i < batch.size; i++) {
+      assertTrue(vhkwArray[i] instanceof VectorHashKeyWrapperThreeLong);
+      assertLongWrapperConsistentWithGeneral(vhkwArray[i], vhkwb, 3);
+    }
+    assertEquals(vhkwArray[0], vhkwArray[2]);
+    assertEquals(vhkwArray[0].hashCode(), vhkwArray[2].hashCode());
+    assertFalse(vhkwArray[0].equals(vhkwArray[1]));
+    assertFalse(vhkwArray[0].equals(vhkwArray[3]));
+
+    VectorHashKeyWrapperBase copy = (VectorHashKeyWrapperBase) vhkwArray[0].copyKey();
+    assertTrue(copy instanceof VectorHashKeyWrapperThreeLong);
+    assertEquals(vhkwArray[0], copy);
+    assertEquals(vhkwArray[0].hashCode(), copy.hashCode());
+    assertLongWrapperConsistentWithGeneral(copy, vhkwb, 3);
+
+    vhkwArray[1].copyKey(copy);
+    assertEquals(vhkwArray[1], copy);
+    assertEquals(10, copy.getLongValue(0));
+    assertEquals(20, copy.getLongValue(1));
+    assertEquals(31, copy.getLongValue(2));
+    assertLongWrapperConsistentWithGeneral(copy, vhkwb, 3);
+  }
+
+  @Test
+  public void testVectorHashKeyWrapperThreeLongNull() throws HiveException {
+    VectorExpression[] keyExpressions = new VectorExpression[] { new IdentityExpression(0),
+        new IdentityExpression(1), new IdentityExpression(2) };
+    TypeInfo[] typeInfos = new TypeInfo[] {TypeInfoFactory.longTypeInfo, TypeInfoFactory.longTypeInfo,
+        TypeInfoFactory.longTypeInfo};
+    VectorHashKeyWrapperBatch vhkwb = VectorHashKeyWrapperBatch.compileKeyWrapperBatch(
+        keyExpressions,
+        typeInfos);
+
+    VectorizedRowBatch batch = new VectorizedRowBatch(3);
+    batch.selectedInUse = false;
+    LongColumnVector firstColumnVector = new LongColumnVector();
+    firstColumnVector.noNulls = false;
+    LongColumnVector secondColumnVector = new LongColumnVector();
+    secondColumnVector.noNulls = false;
+    LongColumnVector thirdColumnVector = new LongColumnVector();
+    thirdColumnVector.noNulls = false;
+    batch.cols[0] = firstColumnVector;
+    batch.cols[1] = secondColumnVector;
+    batch.cols[2] = thirdColumnVector;
+
+    firstColumnVector.vector[0] = 10;
+    secondColumnVector.vector[0] = 20;
+    thirdColumnVector.vector[0] = 30;
+    firstColumnVector.isNull[1] = true;
+    secondColumnVector.vector[1] = 20;
+    thirdColumnVector.vector[1] = 30;
+    firstColumnVector.vector[2] = 10;
+    secondColumnVector.isNull[2] = true;
+    thirdColumnVector.vector[2] = 30;
+    firstColumnVector.vector[3] = 10;
+    secondColumnVector.vector[3] = 20;
+    thirdColumnVector.isNull[3] = true;
+    firstColumnVector.isNull[4] = true;
+    secondColumnVector.vector[4] = 20;
+    thirdColumnVector.vector[4] = 30;
+    firstColumnVector.isNull[5] = true;
+    secondColumnVector.isNull[5] = true;
+    thirdColumnVector.isNull[5] = true;
+    batch.size = 6;
+
+    vhkwb.evaluateBatch(batch);
+    VectorHashKeyWrapperBase[] vhkwArray = vhkwb.getVectorHashKeyWrappers();
+    for (int i = 0; i < batch.size; i++) {
+      assertTrue(vhkwArray[i] instanceof VectorHashKeyWrapperThreeLong);
+      assertLongWrapperConsistentWithGeneral(vhkwArray[i], vhkwb, 3);
+    }
+    assertFalse(vhkwArray[0].isNull(0));
+    assertFalse(vhkwArray[0].isNull(1));
+    assertFalse(vhkwArray[0].isNull(2));
+    assertTrue(vhkwArray[1].isNull(0));
+    assertFalse(vhkwArray[1].isNull(1));
+    assertFalse(vhkwArray[1].isNull(2));
+    assertFalse(vhkwArray[2].isNull(0));
+    assertTrue(vhkwArray[2].isNull(1));
+    assertFalse(vhkwArray[2].isNull(2));
+    assertFalse(vhkwArray[3].isNull(0));
+    assertFalse(vhkwArray[3].isNull(1));
+    assertTrue(vhkwArray[3].isNull(2));
+    assertEquals(vhkwArray[1], vhkwArray[4]);
+    assertFalse(vhkwArray[0].equals(vhkwArray[1]));
+    assertFalse(vhkwArray[0].equals(vhkwArray[2]));
+    assertFalse(vhkwArray[0].equals(vhkwArray[3]));
+    assertFalse(vhkwArray[0].equals(vhkwArray[5]));
+  }
+
+  private void assertLongWrapperConsistentWithGeneral(
+      VectorHashKeyWrapperBase longWrapper, VectorHashKeyWrapperBatch vhkwb, int longCount) {
+    VectorHashKeyWrapperGeneral generalWrapper = new VectorHashKeyWrapperGeneral(
+        new VectorHashKeyWrapperBase.HashContext(), longCount, 0, 0, 0, 0, 0, longCount);
+    for (int i = 0; i < longCount; i++) {
+      if (longWrapper.isNull(i)) {
+        generalWrapper.assignNullLong(i, i);
+      } else {
+        generalWrapper.assignLong(i, i, longWrapper.getLongValue(i));
+      }
+    }
+    generalWrapper.setHashKey();
+
+    assertEquals(generalWrapper.hashCode(), longWrapper.hashCode());
+    for (int i = 0; i < longCount; i++) {
+      assertEquals(generalWrapper.isNull(i), longWrapper.isNull(i));
+      assertEquals(generalWrapper.getLongValue(i), longWrapper.getLongValue(i));
+    }
+    assertEquals(generalWrapper.stringifyKeys(vhkwb), longWrapper.stringifyKeys(vhkwb));
+    assertEquals(generalWrapper.toString(), longWrapper.toString());
+    assertEquals(generalWrapper.getVariableSize(), longWrapper.getVariableSize());
   }
 
   private void assertStringWrapperConsistentWithGeneral(

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorHashKeyWrapperBatch.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorHashKeyWrapperBatch.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hive.ql.exec.vector;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.sql.Timestamp;
@@ -29,10 +28,9 @@ import org.junit.Test;
 import org.apache.hadoop.hive.ql.exec.vector.expressions.IdentityExpression;
 import org.apache.hadoop.hive.ql.exec.vector.expressions.StringExpr;
 import org.apache.hadoop.hive.ql.exec.vector.expressions.VectorExpression;
-import org.apache.hadoop.hive.ql.exec.vector.util.FakeVectorRowBatchFromObjectIterables;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperBase;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperBatch;
-import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperGeneral;
+import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperSingleString;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
@@ -90,7 +88,7 @@ public class TestVectorHashKeyWrapperBatch {
 
   // Test for HIVE-24575
   @Test
-  public void testVectorHashKeyWrapperGeneralCopyKey() throws HiveException {
+  public void testVectorHashKeyWrapperSingleStringCopyKey() throws HiveException {
     VectorExpression[] keyExpressions = new VectorExpression[] { new IdentityExpression(0) };
     TypeInfo[] typeInfos = new TypeInfo[] {TypeInfoFactory.stringTypeInfo};
     VectorHashKeyWrapperBatch vhkwb = VectorHashKeyWrapperBatch.compileKeyWrapperBatch(
@@ -112,8 +110,8 @@ public class TestVectorHashKeyWrapperBatch {
 
     vhkwb.evaluateBatch(batch);
     VectorHashKeyWrapperBase[] vhkwArray = vhkwb.getVectorHashKeyWrappers();
-    VectorHashKeyWrapperGeneral hashKey2 = (VectorHashKeyWrapperGeneral)vhkwArray[2];
-    VectorHashKeyWrapperGeneral hashKey1 = (VectorHashKeyWrapperGeneral)vhkwArray[1];
+    VectorHashKeyWrapperBase hashKey2 = vhkwArray[2];
+    VectorHashKeyWrapperBase hashKey1 = vhkwArray[1];
 
     assertTrue(StringExpr.equal(hashKey2.getBytes(0), hashKey2.getByteStart(0), hashKey2.getByteLength(0),
             contents, 0, contents.length));
@@ -126,6 +124,86 @@ public class TestVectorHashKeyWrapperBatch {
             contents, 0, contents.length));
     assertTrue(StringExpr.equal(hashKey2.getBytes(0), hashKey2.getByteStart(0), hashKey2.getByteLength(0),
         hashKey1.getBytes(0), hashKey1.getByteStart(0), hashKey1.getByteLength(0)));
+  }
+
+
+  @Test
+  public void testVectorHashKeyWrapperSingleString() throws HiveException {
+    VectorExpression[] keyExpressions = new VectorExpression[] { new IdentityExpression(0) };
+    TypeInfo[] typeInfos = new TypeInfo[] {TypeInfoFactory.stringTypeInfo};
+    VectorHashKeyWrapperBatch vhkwb = VectorHashKeyWrapperBatch.compileKeyWrapperBatch(
+        keyExpressions,
+        typeInfos);
+
+    VectorizedRowBatch batch = new VectorizedRowBatch(1);
+    batch.selectedInUse = false;
+    BytesColumnVector bytesColumnVector = new BytesColumnVector();
+    bytesColumnVector.initBuffer(1024);
+    batch.cols[0] = bytesColumnVector;
+
+    byte[] alpha = "alpha".getBytes();
+    byte[] beta = "beta".getBytes();
+    bytesColumnVector.setVal(0, alpha);
+    bytesColumnVector.setVal(1, beta);
+    bytesColumnVector.setVal(2, alpha);
+    batch.size = 3;
+
+    vhkwb.evaluateBatch(batch);
+    VectorHashKeyWrapperBase[] vhkwArray = vhkwb.getVectorHashKeyWrappers();
+    assertTrue(vhkwArray[0] instanceof VectorHashKeyWrapperSingleString);
+    assertTrue(vhkwArray[1] instanceof VectorHashKeyWrapperSingleString);
+    assertTrue(vhkwArray[2] instanceof VectorHashKeyWrapperSingleString);
+    assertEquals(vhkwArray[0], vhkwArray[2]);
+    assertEquals(vhkwArray[0].hashCode(), vhkwArray[2].hashCode());
+    assertFalse(vhkwArray[0].equals(vhkwArray[1]));
+
+    VectorHashKeyWrapperBase copy = (VectorHashKeyWrapperBase) vhkwArray[0].copyKey();
+    assertTrue(copy instanceof VectorHashKeyWrapperSingleString);
+    assertEquals(vhkwArray[0], copy);
+    assertEquals(vhkwArray[0].hashCode(), copy.hashCode());
+
+    bytesColumnVector.vector[0][0] = 'z';
+    assertTrue(StringExpr.equal(copy.getBytes(0), copy.getByteStart(0), copy.getByteLength(0),
+        alpha, 0, alpha.length));
+    assertFalse(StringExpr.equal(vhkwArray[0].getBytes(0), vhkwArray[0].getByteStart(0),
+        vhkwArray[0].getByteLength(0), copy.getBytes(0), copy.getByteStart(0), copy.getByteLength(0)));
+
+    vhkwArray[1].copyKey(copy);
+    assertEquals(vhkwArray[1], copy);
+    assertTrue(StringExpr.equal(copy.getBytes(0), copy.getByteStart(0), copy.getByteLength(0),
+        beta, 0, beta.length));
+  }
+
+  @Test
+  public void testVectorHashKeyWrapperSingleStringNull() throws HiveException {
+    VectorExpression[] keyExpressions = new VectorExpression[] { new IdentityExpression(0) };
+    TypeInfo[] typeInfos = new TypeInfo[] {TypeInfoFactory.stringTypeInfo};
+    VectorHashKeyWrapperBatch vhkwb = VectorHashKeyWrapperBatch.compileKeyWrapperBatch(
+        keyExpressions,
+        typeInfos);
+
+    VectorizedRowBatch batch = new VectorizedRowBatch(1);
+    batch.selectedInUse = false;
+    BytesColumnVector bytesColumnVector = new BytesColumnVector();
+    bytesColumnVector.initBuffer(1024);
+    bytesColumnVector.noNulls = false;
+    bytesColumnVector.setVal(0, "not-null".getBytes());
+    bytesColumnVector.isNull[1] = true;
+    bytesColumnVector.setVal(2, "not-null".getBytes());
+    bytesColumnVector.isNull[3] = true;
+    batch.cols[0] = bytesColumnVector;
+    batch.size = 4;
+
+    vhkwb.evaluateBatch(batch);
+    VectorHashKeyWrapperBase[] vhkwArray = vhkwb.getVectorHashKeyWrappers();
+    assertTrue(vhkwArray[0] instanceof VectorHashKeyWrapperSingleString);
+    assertFalse(vhkwArray[0].isNull(0));
+    assertTrue(vhkwArray[1].isNull(0));
+    assertFalse(vhkwArray[2].isNull(0));
+    assertTrue(vhkwArray[3].isNull(0));
+    assertEquals(vhkwArray[0], vhkwArray[2]);
+    assertEquals(vhkwArray[1], vhkwArray[3]);
+    assertFalse(vhkwArray[0].equals(vhkwArray[1]));
   }
 
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorHashKeyWrapperBatch.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorHashKeyWrapperBatch.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperBatch;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperGeneral;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperSingleString;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperSingleLong;
+import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperSingleLongSingleString;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperSingleLongTwoString;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperThreeLong;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperThreeString;
@@ -691,6 +692,22 @@ public class TestVectorHashKeyWrapperBatch {
   }
 
   @Test
+  public void testVectorHashKeyWrapperSingleLongSingleStringPermutations() throws HiveException {
+    assertMixedLongStringWrapper(new TypeInfo[] {TypeInfoFactory.longTypeInfo, TypeInfoFactory.stringTypeInfo},
+        VectorHashKeyWrapperSingleLongSingleString.class, 1, 1);
+    assertMixedLongStringWrapper(new TypeInfo[] {TypeInfoFactory.stringTypeInfo, TypeInfoFactory.longTypeInfo},
+        VectorHashKeyWrapperSingleLongSingleString.class, 1, 1);
+  }
+
+  @Test
+  public void testVectorHashKeyWrapperSingleLongSingleStringNullPermutations() throws HiveException {
+    assertMixedLongStringNullWrapper(new TypeInfo[] {TypeInfoFactory.longTypeInfo, TypeInfoFactory.stringTypeInfo},
+        VectorHashKeyWrapperSingleLongSingleString.class, 1, 1);
+    assertMixedLongStringNullWrapper(new TypeInfo[] {TypeInfoFactory.stringTypeInfo, TypeInfoFactory.longTypeInfo},
+        VectorHashKeyWrapperSingleLongSingleString.class, 1, 1);
+  }
+
+  @Test
   public void testVectorHashKeyWrapperTwoLongSingleStringPermutations() throws HiveException {
     assertMixedLongStringWrapper(new TypeInfo[] {TypeInfoFactory.longTypeInfo, TypeInfoFactory.longTypeInfo,
         TypeInfoFactory.stringTypeInfo}, VectorHashKeyWrapperTwoLongSingleString.class, 2, 1);
@@ -782,20 +799,30 @@ public class TestVectorHashKeyWrapperBatch {
         identityExpressions(typeInfos.length), typeInfos);
     VectorizedRowBatch batch = createMixedLongStringBatch(typeInfos, true);
 
+    boolean twoKeyShape = typeInfos.length == 2;
     long[][] longValues = longCount == 2 ?
         new long[][] {{10, 20}, {10, 20}, {10, 20}, {10, 20}, {10, 20}, {10, 20}} :
-        new long[][] {{10}, {10}, {10}, {10}, {10}, {10}};
+        (twoKeyShape ? new long[][] {{10}, {10}, {10}, {10}, {10}} :
+            new long[][] {{10}, {10}, {10}, {10}, {10}, {10}});
     String[][] stringValues = stringCount == 2 ?
         new String[][] {{"alpha", "one"}, {"alpha", "one"}, {"alpha", "one"}, {"alpha", "one"},
             {"alpha", "one"}, {"alpha", "one"}} :
-        new String[][] {{"alpha"}, {"alpha"}, {"alpha"}, {"alpha"}, {"alpha"}, {"alpha"}};
-    boolean[][] isNull = new boolean[][] {
-        {false, false, false},
-        {true, false, false},
-        {false, true, false},
-        {false, false, true},
-        {true, false, false},
-        {true, true, true}};
+        (twoKeyShape ? new String[][] {{"alpha"}, {"alpha"}, {"alpha"}, {"alpha"}, {"alpha"}} :
+            new String[][] {{"alpha"}, {"alpha"}, {"alpha"}, {"alpha"}, {"alpha"}, {"alpha"}});
+    boolean[][] isNull = twoKeyShape ?
+        new boolean[][] {
+            {false, false},
+            {true, false},
+            {false, true},
+            {true, false},
+            {true, true}} :
+        new boolean[][] {
+            {false, false, false},
+            {true, false, false},
+            {false, true, false},
+            {false, false, true},
+            {true, false, false},
+            {true, true, true}};
     fillMixedLongStringBatch(batch, typeInfos, longValues, stringValues, isNull);
 
     vhkwb.evaluateBatch(batch);

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorHashKeyWrapperBatch.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorHashKeyWrapperBatch.java
@@ -32,7 +32,9 @@ import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperBase;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperBatch;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperGeneral;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperSingleString;
+import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperSingleLongTwoString;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperThreeLong;
+import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperTwoLongSingleString;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperTwoString;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
@@ -465,6 +467,247 @@ public class TestVectorHashKeyWrapperBatch {
     assertFalse(vhkwArray[0].equals(vhkwArray[2]));
     assertFalse(vhkwArray[0].equals(vhkwArray[3]));
     assertFalse(vhkwArray[0].equals(vhkwArray[5]));
+  }
+
+  @Test
+  public void testVectorHashKeyWrapperTwoLongSingleStringPermutations() throws HiveException {
+    assertMixedLongStringWrapper(new TypeInfo[] {TypeInfoFactory.longTypeInfo, TypeInfoFactory.longTypeInfo,
+        TypeInfoFactory.stringTypeInfo}, VectorHashKeyWrapperTwoLongSingleString.class, 2, 1);
+    assertMixedLongStringWrapper(new TypeInfo[] {TypeInfoFactory.longTypeInfo, TypeInfoFactory.stringTypeInfo,
+        TypeInfoFactory.longTypeInfo}, VectorHashKeyWrapperTwoLongSingleString.class, 2, 1);
+    assertMixedLongStringWrapper(new TypeInfo[] {TypeInfoFactory.stringTypeInfo, TypeInfoFactory.longTypeInfo,
+        TypeInfoFactory.longTypeInfo}, VectorHashKeyWrapperTwoLongSingleString.class, 2, 1);
+  }
+
+  @Test
+  public void testVectorHashKeyWrapperTwoLongSingleStringNullPermutations() throws HiveException {
+    assertMixedLongStringNullWrapper(new TypeInfo[] {TypeInfoFactory.longTypeInfo, TypeInfoFactory.longTypeInfo,
+        TypeInfoFactory.stringTypeInfo}, VectorHashKeyWrapperTwoLongSingleString.class, 2, 1);
+    assertMixedLongStringNullWrapper(new TypeInfo[] {TypeInfoFactory.longTypeInfo, TypeInfoFactory.stringTypeInfo,
+        TypeInfoFactory.longTypeInfo}, VectorHashKeyWrapperTwoLongSingleString.class, 2, 1);
+    assertMixedLongStringNullWrapper(new TypeInfo[] {TypeInfoFactory.stringTypeInfo, TypeInfoFactory.longTypeInfo,
+        TypeInfoFactory.longTypeInfo}, VectorHashKeyWrapperTwoLongSingleString.class, 2, 1);
+  }
+
+  @Test
+  public void testVectorHashKeyWrapperSingleLongTwoStringPermutations() throws HiveException {
+    assertMixedLongStringWrapper(new TypeInfo[] {TypeInfoFactory.longTypeInfo, TypeInfoFactory.stringTypeInfo,
+        TypeInfoFactory.stringTypeInfo}, VectorHashKeyWrapperSingleLongTwoString.class, 1, 2);
+    assertMixedLongStringWrapper(new TypeInfo[] {TypeInfoFactory.stringTypeInfo, TypeInfoFactory.longTypeInfo,
+        TypeInfoFactory.stringTypeInfo}, VectorHashKeyWrapperSingleLongTwoString.class, 1, 2);
+    assertMixedLongStringWrapper(new TypeInfo[] {TypeInfoFactory.stringTypeInfo, TypeInfoFactory.stringTypeInfo,
+        TypeInfoFactory.longTypeInfo}, VectorHashKeyWrapperSingleLongTwoString.class, 1, 2);
+  }
+
+  @Test
+  public void testVectorHashKeyWrapperSingleLongTwoStringNullPermutations() throws HiveException {
+    assertMixedLongStringNullWrapper(new TypeInfo[] {TypeInfoFactory.longTypeInfo, TypeInfoFactory.stringTypeInfo,
+        TypeInfoFactory.stringTypeInfo}, VectorHashKeyWrapperSingleLongTwoString.class, 1, 2);
+    assertMixedLongStringNullWrapper(new TypeInfo[] {TypeInfoFactory.stringTypeInfo, TypeInfoFactory.longTypeInfo,
+        TypeInfoFactory.stringTypeInfo}, VectorHashKeyWrapperSingleLongTwoString.class, 1, 2);
+    assertMixedLongStringNullWrapper(new TypeInfo[] {TypeInfoFactory.stringTypeInfo, TypeInfoFactory.stringTypeInfo,
+        TypeInfoFactory.longTypeInfo}, VectorHashKeyWrapperSingleLongTwoString.class, 1, 2);
+  }
+
+  private void assertMixedLongStringWrapper(TypeInfo[] typeInfos,
+      Class<? extends VectorHashKeyWrapperBase> expectedWrapperClass, int longCount, int stringCount)
+      throws HiveException {
+    VectorHashKeyWrapperBatch vhkwb = VectorHashKeyWrapperBatch.compileKeyWrapperBatch(
+        identityExpressions(typeInfos.length), typeInfos);
+    VectorizedRowBatch batch = createMixedLongStringBatch(typeInfos, false);
+
+    long[][] longValues = longCount == 2 ?
+        new long[][] {{10, 20}, {10, 20}, {10, 20}, {11, 20}} :
+        new long[][] {{10}, {10}, {10}, {11}};
+    String[][] stringValues = stringCount == 2 ?
+        new String[][] {{"alpha", "one"}, {"alpha", "two"}, {"alpha", "one"}, {"alpha", "one"}} :
+        new String[][] {{"alpha"}, {"beta"}, {"alpha"}, {"alpha"}};
+    fillMixedLongStringBatch(batch, typeInfos, longValues, stringValues, null);
+
+    vhkwb.evaluateBatch(batch);
+    VectorHashKeyWrapperBase[] wrappers = vhkwb.getVectorHashKeyWrappers();
+    for (int i = 0; i < batch.size; i++) {
+      assertTrue(expectedWrapperClass.isInstance(wrappers[i]));
+      assertMixedLongStringWrapperConsistentWithGeneral(wrappers[i], vhkwb, longCount, stringCount);
+    }
+    assertEquals(wrappers[0], wrappers[2]);
+    assertEquals(wrappers[0].hashCode(), wrappers[2].hashCode());
+    assertFalse(wrappers[0].equals(wrappers[1]));
+    assertFalse(wrappers[0].equals(wrappers[3]));
+
+    VectorHashKeyWrapperBase copy = (VectorHashKeyWrapperBase) wrappers[0].copyKey();
+    assertTrue(expectedWrapperClass.isInstance(copy));
+    assertEquals(wrappers[0], copy);
+    assertEquals(wrappers[0].hashCode(), copy.hashCode());
+    assertMixedLongStringWrapperConsistentWithGeneral(copy, vhkwb, longCount, stringCount);
+
+    mutateFirstStringValue(batch, typeInfos);
+    for (int i = 0; i < stringCount; i++) {
+      assertTrue(StringExpr.equal(copy.getBytes(i), copy.getByteStart(i), copy.getByteLength(i),
+          stringValues[0][i].getBytes(), 0, stringValues[0][i].getBytes().length));
+      assertFalse(StringExpr.equal(wrappers[0].getBytes(i), wrappers[0].getByteStart(i),
+          wrappers[0].getByteLength(i), copy.getBytes(i), copy.getByteStart(i), copy.getByteLength(i)));
+    }
+
+    wrappers[1].copyKey(copy);
+    assertEquals(wrappers[1], copy);
+    assertMixedLongStringWrapperConsistentWithGeneral(copy, vhkwb, longCount, stringCount);
+  }
+
+  private void assertMixedLongStringNullWrapper(TypeInfo[] typeInfos,
+      Class<? extends VectorHashKeyWrapperBase> expectedWrapperClass, int longCount, int stringCount)
+      throws HiveException {
+    VectorHashKeyWrapperBatch vhkwb = VectorHashKeyWrapperBatch.compileKeyWrapperBatch(
+        identityExpressions(typeInfos.length), typeInfos);
+    VectorizedRowBatch batch = createMixedLongStringBatch(typeInfos, true);
+
+    long[][] longValues = longCount == 2 ?
+        new long[][] {{10, 20}, {10, 20}, {10, 20}, {10, 20}, {10, 20}, {10, 20}} :
+        new long[][] {{10}, {10}, {10}, {10}, {10}, {10}};
+    String[][] stringValues = stringCount == 2 ?
+        new String[][] {{"alpha", "one"}, {"alpha", "one"}, {"alpha", "one"}, {"alpha", "one"},
+            {"alpha", "one"}, {"alpha", "one"}} :
+        new String[][] {{"alpha"}, {"alpha"}, {"alpha"}, {"alpha"}, {"alpha"}, {"alpha"}};
+    boolean[][] isNull = new boolean[][] {
+        {false, false, false},
+        {true, false, false},
+        {false, true, false},
+        {false, false, true},
+        {true, false, false},
+        {true, true, true}};
+    fillMixedLongStringBatch(batch, typeInfos, longValues, stringValues, isNull);
+
+    vhkwb.evaluateBatch(batch);
+    VectorHashKeyWrapperBase[] wrappers = vhkwb.getVectorHashKeyWrappers();
+    for (int i = 0; i < batch.size; i++) {
+      assertTrue(expectedWrapperClass.isInstance(wrappers[i]));
+      assertMixedLongStringWrapperConsistentWithGeneral(wrappers[i], vhkwb, longCount, stringCount);
+      for (int keyIndex = 0; keyIndex < typeInfos.length; keyIndex++) {
+        assertEquals(isNull[i][keyIndex], wrappers[i].isNull(keyIndex));
+      }
+    }
+    assertEquals(wrappers[1], wrappers[4]);
+    assertEquals(wrappers[1].hashCode(), wrappers[4].hashCode());
+    assertFalse(wrappers[0].equals(wrappers[1]));
+    assertFalse(wrappers[0].equals(wrappers[2]));
+    assertFalse(wrappers[0].equals(wrappers[3]));
+    assertFalse(wrappers[0].equals(wrappers[5]));
+  }
+
+  private VectorExpression[] identityExpressions(int count) {
+    VectorExpression[] keyExpressions = new VectorExpression[count];
+    for (int i = 0; i < count; i++) {
+      keyExpressions[i] = new IdentityExpression(i);
+    }
+    return keyExpressions;
+  }
+
+  private VectorizedRowBatch createMixedLongStringBatch(TypeInfo[] typeInfos, boolean mayHaveNulls) {
+    VectorizedRowBatch batch = new VectorizedRowBatch(typeInfos.length);
+    batch.selectedInUse = false;
+    for (int keyIndex = 0; keyIndex < typeInfos.length; keyIndex++) {
+      if (typeInfos[keyIndex] == TypeInfoFactory.longTypeInfo) {
+        LongColumnVector longColumnVector = new LongColumnVector();
+        longColumnVector.noNulls = !mayHaveNulls;
+        batch.cols[keyIndex] = longColumnVector;
+      } else {
+        BytesColumnVector bytesColumnVector = new BytesColumnVector();
+        bytesColumnVector.initBuffer(1024);
+        bytesColumnVector.noNulls = !mayHaveNulls;
+        batch.cols[keyIndex] = bytesColumnVector;
+      }
+    }
+    return batch;
+  }
+
+  private void fillMixedLongStringBatch(VectorizedRowBatch batch, TypeInfo[] typeInfos, long[][] longValues,
+      String[][] stringValues, boolean[][] isNull) {
+    batch.size = longValues.length;
+    for (int row = 0; row < batch.size; row++) {
+      int longIndex = 0;
+      int stringIndex = 0;
+      for (int keyIndex = 0; keyIndex < typeInfos.length; keyIndex++) {
+        if (typeInfos[keyIndex] == TypeInfoFactory.longTypeInfo) {
+          LongColumnVector longColumnVector = (LongColumnVector) batch.cols[keyIndex];
+          longColumnVector.vector[row] = longValues[row][longIndex++];
+          if (isNull != null && isNull[row][keyIndex]) {
+            longColumnVector.isNull[row] = true;
+          }
+        } else {
+          BytesColumnVector bytesColumnVector = (BytesColumnVector) batch.cols[keyIndex];
+          byte[] value = stringValues[row][stringIndex++].getBytes();
+          bytesColumnVector.setVal(row, value);
+          if (isNull != null && isNull[row][keyIndex]) {
+            bytesColumnVector.isNull[row] = true;
+          }
+        }
+      }
+    }
+  }
+
+  private void mutateFirstStringValue(VectorizedRowBatch batch, TypeInfo[] typeInfos) {
+    for (int keyIndex = 0; keyIndex < typeInfos.length; keyIndex++) {
+      if (typeInfos[keyIndex] == TypeInfoFactory.stringTypeInfo) {
+        ((BytesColumnVector) batch.cols[keyIndex]).vector[0][0] = 'z';
+      }
+    }
+  }
+
+  private void assertMixedLongStringWrapperConsistentWithGeneral(
+      VectorHashKeyWrapperBase wrapper, VectorHashKeyWrapperBatch vhkwb, int longCount, int stringCount) {
+    VectorHashKeyWrapperGeneral generalWrapper = new VectorHashKeyWrapperGeneral(
+        new VectorHashKeyWrapperBase.HashContext(), longCount, 0, stringCount, 0, 0, 0,
+        longCount + stringCount);
+    for (int keyIndex = 0; keyIndex < vhkwb.keyCount; keyIndex++) {
+      int typeSpecificIndex = vhkwb.columnTypeSpecificIndices[keyIndex];
+      switch (vhkwb.columnVectorTypes[keyIndex]) {
+      case LONG:
+        if (wrapper.isNull(keyIndex)) {
+          generalWrapper.assignNullLong(keyIndex, typeSpecificIndex);
+        } else {
+          generalWrapper.assignLong(keyIndex, typeSpecificIndex, wrapper.getLongValue(typeSpecificIndex));
+        }
+        break;
+      case BYTES:
+        if (wrapper.isNull(keyIndex)) {
+          generalWrapper.assignNullString(keyIndex, typeSpecificIndex);
+        } else {
+          generalWrapper.assignString(typeSpecificIndex, wrapper.getBytes(typeSpecificIndex),
+              wrapper.getByteStart(typeSpecificIndex), wrapper.getByteLength(typeSpecificIndex));
+        }
+        break;
+      default:
+        throw new RuntimeException("Unexpected column vector type " + vhkwb.columnVectorTypes[keyIndex]);
+      }
+    }
+    generalWrapper.setHashKey();
+
+    for (int keyIndex = 0; keyIndex < vhkwb.keyCount; keyIndex++) {
+      assertEquals(generalWrapper.isNull(keyIndex), wrapper.isNull(keyIndex));
+      int typeSpecificIndex = vhkwb.columnTypeSpecificIndices[keyIndex];
+      switch (vhkwb.columnVectorTypes[keyIndex]) {
+      case LONG:
+        assertEquals(generalWrapper.getLongValue(typeSpecificIndex), wrapper.getLongValue(typeSpecificIndex));
+        break;
+      case BYTES:
+        assertEquals(generalWrapper.getByteStart(typeSpecificIndex), wrapper.getByteStart(typeSpecificIndex));
+        assertEquals(generalWrapper.getByteLength(typeSpecificIndex), wrapper.getByteLength(typeSpecificIndex));
+        if (generalWrapper.isNull(keyIndex)) {
+          assertEquals(generalWrapper.getBytes(typeSpecificIndex), wrapper.getBytes(typeSpecificIndex));
+        } else {
+          assertTrue(StringExpr.equal(generalWrapper.getBytes(typeSpecificIndex),
+              generalWrapper.getByteStart(typeSpecificIndex), generalWrapper.getByteLength(typeSpecificIndex),
+              wrapper.getBytes(typeSpecificIndex), wrapper.getByteStart(typeSpecificIndex),
+              wrapper.getByteLength(typeSpecificIndex)));
+        }
+        break;
+      default:
+        throw new RuntimeException("Unexpected column vector type " + vhkwb.columnVectorTypes[keyIndex]);
+      }
+    }
+    assertEquals(generalWrapper.stringifyKeys(vhkwb), wrapper.stringifyKeys(vhkwb));
+    assertEquals(generalWrapper.toString(), wrapper.toString());
+    assertEquals(generalWrapper.getVariableSize(), wrapper.getVariableSize());
   }
 
   private void assertLongWrapperConsistentWithGeneral(

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorHashKeyWrapperBatch.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorHashKeyWrapperBatch.java
@@ -834,12 +834,20 @@ public class TestVectorHashKeyWrapperBatch {
         assertEquals(isNull[i][keyIndex], wrappers[i].isNull(keyIndex));
       }
     }
-    assertEquals(wrappers[1], wrappers[4]);
-    assertEquals(wrappers[1].hashCode(), wrappers[4].hashCode());
-    assertFalse(wrappers[0].equals(wrappers[1]));
-    assertFalse(wrappers[0].equals(wrappers[2]));
-    assertFalse(wrappers[0].equals(wrappers[3]));
-    assertFalse(wrappers[0].equals(wrappers[5]));
+    if (twoKeyShape) {
+      assertEquals(wrappers[1], wrappers[3]);
+      assertEquals(wrappers[1].hashCode(), wrappers[3].hashCode());
+      assertFalse(wrappers[0].equals(wrappers[1]));
+      assertFalse(wrappers[0].equals(wrappers[2]));
+      assertFalse(wrappers[0].equals(wrappers[4]));
+    } else {
+      assertEquals(wrappers[1], wrappers[4]);
+      assertEquals(wrappers[1].hashCode(), wrappers[4].hashCode());
+      assertFalse(wrappers[0].equals(wrappers[1]));
+      assertFalse(wrappers[0].equals(wrappers[2]));
+      assertFalse(wrappers[0].equals(wrappers[3]));
+      assertFalse(wrappers[0].equals(wrappers[5]));
+    }
   }
 
   private VectorExpression[] identityExpressions(int count) {

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorHashKeyWrapperBatch.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorHashKeyWrapperBatch.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperSingleS
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperSingleLong;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperSingleLongTwoString;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperThreeLong;
+import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperThreeString;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperTwoLong;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperTwoLongSingleString;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperTwoString;
@@ -344,6 +345,166 @@ public class TestVectorHashKeyWrapperBatch {
     assertFalse(vhkwArray[0].equals(vhkwArray[1]));
     assertFalse(vhkwArray[0].equals(vhkwArray[2]));
     assertFalse(vhkwArray[0].equals(vhkwArray[3]));
+  }
+
+  @Test
+  public void testVectorHashKeyWrapperThreeString() throws HiveException {
+    VectorExpression[] keyExpressions = new VectorExpression[] { new IdentityExpression(0),
+        new IdentityExpression(1), new IdentityExpression(2) };
+    TypeInfo[] typeInfos = new TypeInfo[] {TypeInfoFactory.stringTypeInfo, TypeInfoFactory.stringTypeInfo,
+        TypeInfoFactory.stringTypeInfo};
+    VectorHashKeyWrapperBatch vhkwb = VectorHashKeyWrapperBatch.compileKeyWrapperBatch(
+        keyExpressions,
+        typeInfos);
+
+    VectorizedRowBatch batch = new VectorizedRowBatch(3);
+    batch.selectedInUse = false;
+    BytesColumnVector firstColumnVector = new BytesColumnVector();
+    firstColumnVector.initBuffer(1024);
+    BytesColumnVector secondColumnVector = new BytesColumnVector();
+    secondColumnVector.initBuffer(1024);
+    BytesColumnVector thirdColumnVector = new BytesColumnVector();
+    thirdColumnVector.initBuffer(1024);
+    batch.cols[0] = firstColumnVector;
+    batch.cols[1] = secondColumnVector;
+    batch.cols[2] = thirdColumnVector;
+
+    byte[] alpha = "alpha".getBytes();
+    byte[] beta = "beta".getBytes();
+    byte[] one = "one".getBytes();
+    byte[] two = "two".getBytes();
+    byte[] red = "red".getBytes();
+    byte[] blue = "blue".getBytes();
+    firstColumnVector.setVal(0, alpha);
+    secondColumnVector.setVal(0, one);
+    thirdColumnVector.setVal(0, red);
+    firstColumnVector.setVal(1, alpha);
+    secondColumnVector.setVal(1, two);
+    thirdColumnVector.setVal(1, red);
+    firstColumnVector.setVal(2, alpha);
+    secondColumnVector.setVal(2, one);
+    thirdColumnVector.setVal(2, red);
+    firstColumnVector.setVal(3, beta);
+    secondColumnVector.setVal(3, one);
+    thirdColumnVector.setVal(3, red);
+    firstColumnVector.setVal(4, alpha);
+    secondColumnVector.setVal(4, one);
+    thirdColumnVector.setVal(4, blue);
+    batch.size = 5;
+
+    vhkwb.evaluateBatch(batch);
+    VectorHashKeyWrapperBase[] vhkwArray = vhkwb.getVectorHashKeyWrappers();
+    for (int i = 0; i < batch.size; i++) {
+      assertTrue(vhkwArray[i] instanceof VectorHashKeyWrapperThreeString);
+      assertStringWrapperConsistentWithGeneral(vhkwArray[i], vhkwb, 3);
+    }
+    assertEquals(vhkwArray[0], vhkwArray[2]);
+    assertEquals(vhkwArray[0].hashCode(), vhkwArray[2].hashCode());
+    assertFalse(vhkwArray[0].equals(vhkwArray[1]));
+    assertFalse(vhkwArray[0].equals(vhkwArray[3]));
+    assertFalse(vhkwArray[0].equals(vhkwArray[4]));
+
+    VectorHashKeyWrapperBase copy = (VectorHashKeyWrapperBase) vhkwArray[0].copyKey();
+    assertTrue(copy instanceof VectorHashKeyWrapperThreeString);
+    assertEquals(vhkwArray[0], copy);
+    assertEquals(vhkwArray[0].hashCode(), copy.hashCode());
+    assertStringWrapperConsistentWithGeneral(copy, vhkwb, 3);
+
+    firstColumnVector.vector[0][0] = 'z';
+    secondColumnVector.vector[0][0] = 'z';
+    thirdColumnVector.vector[0][0] = 'z';
+    assertTrue(StringExpr.equal(copy.getBytes(0), copy.getByteStart(0), copy.getByteLength(0),
+        alpha, 0, alpha.length));
+    assertTrue(StringExpr.equal(copy.getBytes(1), copy.getByteStart(1), copy.getByteLength(1),
+        one, 0, one.length));
+    assertTrue(StringExpr.equal(copy.getBytes(2), copy.getByteStart(2), copy.getByteLength(2),
+        red, 0, red.length));
+    assertFalse(StringExpr.equal(vhkwArray[0].getBytes(0), vhkwArray[0].getByteStart(0),
+        vhkwArray[0].getByteLength(0), copy.getBytes(0), copy.getByteStart(0), copy.getByteLength(0)));
+    assertFalse(StringExpr.equal(vhkwArray[0].getBytes(1), vhkwArray[0].getByteStart(1),
+        vhkwArray[0].getByteLength(1), copy.getBytes(1), copy.getByteStart(1), copy.getByteLength(1)));
+    assertFalse(StringExpr.equal(vhkwArray[0].getBytes(2), vhkwArray[0].getByteStart(2),
+        vhkwArray[0].getByteLength(2), copy.getBytes(2), copy.getByteStart(2), copy.getByteLength(2)));
+
+    vhkwArray[1].copyKey(copy);
+    assertEquals(vhkwArray[1], copy);
+    assertTrue(StringExpr.equal(copy.getBytes(0), copy.getByteStart(0), copy.getByteLength(0),
+        alpha, 0, alpha.length));
+    assertTrue(StringExpr.equal(copy.getBytes(1), copy.getByteStart(1), copy.getByteLength(1),
+        two, 0, two.length));
+    assertTrue(StringExpr.equal(copy.getBytes(2), copy.getByteStart(2), copy.getByteLength(2),
+        red, 0, red.length));
+    assertStringWrapperConsistentWithGeneral(copy, vhkwb, 3);
+  }
+
+  @Test
+  public void testVectorHashKeyWrapperThreeStringNull() throws HiveException {
+    VectorExpression[] keyExpressions = new VectorExpression[] { new IdentityExpression(0),
+        new IdentityExpression(1), new IdentityExpression(2) };
+    TypeInfo[] typeInfos = new TypeInfo[] {TypeInfoFactory.stringTypeInfo, TypeInfoFactory.stringTypeInfo,
+        TypeInfoFactory.stringTypeInfo};
+    VectorHashKeyWrapperBatch vhkwb = VectorHashKeyWrapperBatch.compileKeyWrapperBatch(
+        keyExpressions,
+        typeInfos);
+
+    VectorizedRowBatch batch = new VectorizedRowBatch(3);
+    batch.selectedInUse = false;
+    BytesColumnVector firstColumnVector = new BytesColumnVector();
+    firstColumnVector.initBuffer(1024);
+    firstColumnVector.noNulls = false;
+    BytesColumnVector secondColumnVector = new BytesColumnVector();
+    secondColumnVector.initBuffer(1024);
+    secondColumnVector.noNulls = false;
+    BytesColumnVector thirdColumnVector = new BytesColumnVector();
+    thirdColumnVector.initBuffer(1024);
+    thirdColumnVector.noNulls = false;
+    batch.cols[0] = firstColumnVector;
+    batch.cols[1] = secondColumnVector;
+    batch.cols[2] = thirdColumnVector;
+
+    firstColumnVector.setVal(0, "left".getBytes());
+    secondColumnVector.setVal(0, "middle".getBytes());
+    thirdColumnVector.setVal(0, "right".getBytes());
+    firstColumnVector.isNull[1] = true;
+    secondColumnVector.setVal(1, "middle".getBytes());
+    thirdColumnVector.setVal(1, "right".getBytes());
+    firstColumnVector.setVal(2, "left".getBytes());
+    secondColumnVector.isNull[2] = true;
+    thirdColumnVector.setVal(2, "right".getBytes());
+    firstColumnVector.setVal(3, "left".getBytes());
+    secondColumnVector.setVal(3, "middle".getBytes());
+    thirdColumnVector.isNull[3] = true;
+    firstColumnVector.isNull[4] = true;
+    secondColumnVector.setVal(4, "middle".getBytes());
+    thirdColumnVector.setVal(4, "right".getBytes());
+    firstColumnVector.isNull[5] = true;
+    secondColumnVector.isNull[5] = true;
+    thirdColumnVector.isNull[5] = true;
+    batch.size = 6;
+
+    vhkwb.evaluateBatch(batch);
+    VectorHashKeyWrapperBase[] vhkwArray = vhkwb.getVectorHashKeyWrappers();
+    for (int i = 0; i < batch.size; i++) {
+      assertTrue(vhkwArray[i] instanceof VectorHashKeyWrapperThreeString);
+      assertStringWrapperConsistentWithGeneral(vhkwArray[i], vhkwb, 3);
+    }
+    assertFalse(vhkwArray[0].isNull(0));
+    assertFalse(vhkwArray[0].isNull(1));
+    assertFalse(vhkwArray[0].isNull(2));
+    assertTrue(vhkwArray[1].isNull(0));
+    assertFalse(vhkwArray[1].isNull(1));
+    assertFalse(vhkwArray[1].isNull(2));
+    assertFalse(vhkwArray[2].isNull(0));
+    assertTrue(vhkwArray[2].isNull(1));
+    assertFalse(vhkwArray[2].isNull(2));
+    assertFalse(vhkwArray[3].isNull(0));
+    assertFalse(vhkwArray[3].isNull(1));
+    assertTrue(vhkwArray[3].isNull(2));
+    assertEquals(vhkwArray[1], vhkwArray[4]);
+    assertFalse(vhkwArray[0].equals(vhkwArray[1]));
+    assertFalse(vhkwArray[0].equals(vhkwArray[2]));
+    assertFalse(vhkwArray[0].equals(vhkwArray[3]));
+    assertFalse(vhkwArray[0].equals(vhkwArray[5]));
   }
 
   @Test

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorHashKeyWrapperBatch.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorHashKeyWrapperBatch.java
@@ -32,8 +32,10 @@ import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperBase;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperBatch;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperGeneral;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperSingleString;
+import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperSingleLong;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperSingleLongTwoString;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperThreeLong;
+import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperTwoLong;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperTwoLongSingleString;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperTwoString;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
@@ -342,6 +344,64 @@ public class TestVectorHashKeyWrapperBatch {
     assertFalse(vhkwArray[0].equals(vhkwArray[1]));
     assertFalse(vhkwArray[0].equals(vhkwArray[2]));
     assertFalse(vhkwArray[0].equals(vhkwArray[3]));
+  }
+
+  @Test
+  public void testVectorHashKeyWrapperSingleLongCopyKey() throws HiveException {
+    VectorExpression[] keyExpressions = new VectorExpression[] { new IdentityExpression(0) };
+    TypeInfo[] typeInfos = new TypeInfo[] {TypeInfoFactory.longTypeInfo};
+    VectorHashKeyWrapperBatch vhkwb = VectorHashKeyWrapperBatch.compileKeyWrapperBatch(
+        keyExpressions,
+        typeInfos);
+
+    VectorizedRowBatch batch = new VectorizedRowBatch(1);
+    LongColumnVector longColumnVector = new LongColumnVector();
+    batch.cols[0] = longColumnVector;
+    longColumnVector.vector[0] = 10;
+    longColumnVector.vector[1] = 20;
+    batch.size = 2;
+
+    vhkwb.evaluateBatch(batch);
+    VectorHashKeyWrapperBase[] vhkwArray = vhkwb.getVectorHashKeyWrappers();
+    VectorHashKeyWrapperBase copy = (VectorHashKeyWrapperBase) vhkwArray[0].copyKey();
+    assertTrue(copy instanceof VectorHashKeyWrapperSingleLong);
+    assertEquals(vhkwArray[0], copy);
+
+    vhkwArray[1].copyKey(copy);
+    assertEquals(vhkwArray[1], copy);
+    assertEquals(20, copy.getLongValue(0));
+  }
+
+  @Test
+  public void testVectorHashKeyWrapperTwoLongCopyKey() throws HiveException {
+    VectorExpression[] keyExpressions = new VectorExpression[] { new IdentityExpression(0),
+        new IdentityExpression(1) };
+    TypeInfo[] typeInfos = new TypeInfo[] {TypeInfoFactory.longTypeInfo, TypeInfoFactory.longTypeInfo};
+    VectorHashKeyWrapperBatch vhkwb = VectorHashKeyWrapperBatch.compileKeyWrapperBatch(
+        keyExpressions,
+        typeInfos);
+
+    VectorizedRowBatch batch = new VectorizedRowBatch(2);
+    LongColumnVector firstColumnVector = new LongColumnVector();
+    LongColumnVector secondColumnVector = new LongColumnVector();
+    batch.cols[0] = firstColumnVector;
+    batch.cols[1] = secondColumnVector;
+    firstColumnVector.vector[0] = 10;
+    secondColumnVector.vector[0] = 20;
+    firstColumnVector.vector[1] = 30;
+    secondColumnVector.vector[1] = 40;
+    batch.size = 2;
+
+    vhkwb.evaluateBatch(batch);
+    VectorHashKeyWrapperBase[] vhkwArray = vhkwb.getVectorHashKeyWrappers();
+    VectorHashKeyWrapperBase copy = (VectorHashKeyWrapperBase) vhkwArray[0].copyKey();
+    assertTrue(copy instanceof VectorHashKeyWrapperTwoLong);
+    assertEquals(vhkwArray[0], copy);
+
+    vhkwArray[1].copyKey(copy);
+    assertEquals(vhkwArray[1], copy);
+    assertEquals(30, copy.getLongValue(0));
+    assertEquals(40, copy.getLongValue(1));
   }
 
   @Test

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorHashKeyWrapperBatch.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorHashKeyWrapperBatch.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperBase;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperBatch;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperGeneral;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperSingleString;
+import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperTwoString;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
@@ -112,7 +113,7 @@ public class TestVectorHashKeyWrapperBatch {
     vhkwb.evaluateBatch(batch);
     VectorHashKeyWrapperBase[] vhkwArray = vhkwb.getVectorHashKeyWrappers();
     for (int i = 0; i < batch.size; i++) {
-      assertSingleStringWrapperConsistentWithGeneral(vhkwArray[i], vhkwb);
+      assertStringWrapperConsistentWithGeneral(vhkwArray[i], vhkwb, 1);
     }
     VectorHashKeyWrapperBase hashKey2 = vhkwArray[2];
     VectorHashKeyWrapperBase hashKey1 = vhkwArray[1];
@@ -128,7 +129,7 @@ public class TestVectorHashKeyWrapperBatch {
             contents, 0, contents.length));
     assertTrue(StringExpr.equal(hashKey2.getBytes(0), hashKey2.getByteStart(0), hashKey2.getByteLength(0),
         hashKey1.getBytes(0), hashKey1.getByteStart(0), hashKey1.getByteLength(0)));
-    assertSingleStringWrapperConsistentWithGeneral(hashKey1, vhkwb);
+    assertStringWrapperConsistentWithGeneral(hashKey1, vhkwb, 1);
   }
 
 
@@ -162,14 +163,14 @@ public class TestVectorHashKeyWrapperBatch {
     assertEquals(vhkwArray[0].hashCode(), vhkwArray[2].hashCode());
     assertFalse(vhkwArray[0].equals(vhkwArray[1]));
     for (int i = 0; i < batch.size; i++) {
-      assertSingleStringWrapperConsistentWithGeneral(vhkwArray[i], vhkwb);
+      assertStringWrapperConsistentWithGeneral(vhkwArray[i], vhkwb, 1);
     }
 
     VectorHashKeyWrapperBase copy = (VectorHashKeyWrapperBase) vhkwArray[0].copyKey();
     assertTrue(copy instanceof VectorHashKeyWrapperSingleString);
     assertEquals(vhkwArray[0], copy);
     assertEquals(vhkwArray[0].hashCode(), copy.hashCode());
-    assertSingleStringWrapperConsistentWithGeneral(copy, vhkwb);
+    assertStringWrapperConsistentWithGeneral(copy, vhkwb, 1);
 
     bytesColumnVector.vector[0][0] = 'z';
     assertTrue(StringExpr.equal(copy.getBytes(0), copy.getByteStart(0), copy.getByteLength(0),
@@ -181,7 +182,7 @@ public class TestVectorHashKeyWrapperBatch {
     assertEquals(vhkwArray[1], copy);
     assertTrue(StringExpr.equal(copy.getBytes(0), copy.getByteStart(0), copy.getByteLength(0),
         beta, 0, beta.length));
-    assertSingleStringWrapperConsistentWithGeneral(copy, vhkwb);
+    assertStringWrapperConsistentWithGeneral(copy, vhkwb, 1);
   }
 
   @Test
@@ -215,36 +216,161 @@ public class TestVectorHashKeyWrapperBatch {
     assertEquals(vhkwArray[1], vhkwArray[3]);
     assertFalse(vhkwArray[0].equals(vhkwArray[1]));
     for (int i = 0; i < batch.size; i++) {
-      assertSingleStringWrapperConsistentWithGeneral(vhkwArray[i], vhkwb);
+      assertStringWrapperConsistentWithGeneral(vhkwArray[i], vhkwb, 1);
     }
   }
 
-  private void assertSingleStringWrapperConsistentWithGeneral(
-      VectorHashKeyWrapperBase singleStringWrapper, VectorHashKeyWrapperBatch vhkwb) {
+  @Test
+  public void testVectorHashKeyWrapperTwoString() throws HiveException {
+    VectorExpression[] keyExpressions = new VectorExpression[] { new IdentityExpression(0),
+        new IdentityExpression(1) };
+    TypeInfo[] typeInfos = new TypeInfo[] {TypeInfoFactory.stringTypeInfo, TypeInfoFactory.stringTypeInfo};
+    VectorHashKeyWrapperBatch vhkwb = VectorHashKeyWrapperBatch.compileKeyWrapperBatch(
+        keyExpressions,
+        typeInfos);
+
+    VectorizedRowBatch batch = new VectorizedRowBatch(2);
+    batch.selectedInUse = false;
+    BytesColumnVector firstColumnVector = new BytesColumnVector();
+    firstColumnVector.initBuffer(1024);
+    BytesColumnVector secondColumnVector = new BytesColumnVector();
+    secondColumnVector.initBuffer(1024);
+    batch.cols[0] = firstColumnVector;
+    batch.cols[1] = secondColumnVector;
+
+    byte[] alpha = "alpha".getBytes();
+    byte[] beta = "beta".getBytes();
+    byte[] one = "one".getBytes();
+    byte[] two = "two".getBytes();
+    firstColumnVector.setVal(0, alpha);
+    secondColumnVector.setVal(0, one);
+    firstColumnVector.setVal(1, alpha);
+    secondColumnVector.setVal(1, two);
+    firstColumnVector.setVal(2, alpha);
+    secondColumnVector.setVal(2, one);
+    firstColumnVector.setVal(3, beta);
+    secondColumnVector.setVal(3, one);
+    batch.size = 4;
+
+    vhkwb.evaluateBatch(batch);
+    VectorHashKeyWrapperBase[] vhkwArray = vhkwb.getVectorHashKeyWrappers();
+    for (int i = 0; i < batch.size; i++) {
+      assertTrue(vhkwArray[i] instanceof VectorHashKeyWrapperTwoString);
+      assertStringWrapperConsistentWithGeneral(vhkwArray[i], vhkwb, 2);
+    }
+    assertEquals(vhkwArray[0], vhkwArray[2]);
+    assertEquals(vhkwArray[0].hashCode(), vhkwArray[2].hashCode());
+    assertFalse(vhkwArray[0].equals(vhkwArray[1]));
+    assertFalse(vhkwArray[0].equals(vhkwArray[3]));
+
+    VectorHashKeyWrapperBase copy = (VectorHashKeyWrapperBase) vhkwArray[0].copyKey();
+    assertTrue(copy instanceof VectorHashKeyWrapperTwoString);
+    assertEquals(vhkwArray[0], copy);
+    assertEquals(vhkwArray[0].hashCode(), copy.hashCode());
+    assertStringWrapperConsistentWithGeneral(copy, vhkwb, 2);
+
+    firstColumnVector.vector[0][0] = 'z';
+    secondColumnVector.vector[0][0] = 'z';
+    assertTrue(StringExpr.equal(copy.getBytes(0), copy.getByteStart(0), copy.getByteLength(0),
+        alpha, 0, alpha.length));
+    assertTrue(StringExpr.equal(copy.getBytes(1), copy.getByteStart(1), copy.getByteLength(1),
+        one, 0, one.length));
+    assertFalse(StringExpr.equal(vhkwArray[0].getBytes(0), vhkwArray[0].getByteStart(0),
+        vhkwArray[0].getByteLength(0), copy.getBytes(0), copy.getByteStart(0), copy.getByteLength(0)));
+    assertFalse(StringExpr.equal(vhkwArray[0].getBytes(1), vhkwArray[0].getByteStart(1),
+        vhkwArray[0].getByteLength(1), copy.getBytes(1), copy.getByteStart(1), copy.getByteLength(1)));
+
+    vhkwArray[1].copyKey(copy);
+    assertEquals(vhkwArray[1], copy);
+    assertTrue(StringExpr.equal(copy.getBytes(0), copy.getByteStart(0), copy.getByteLength(0),
+        alpha, 0, alpha.length));
+    assertTrue(StringExpr.equal(copy.getBytes(1), copy.getByteStart(1), copy.getByteLength(1),
+        two, 0, two.length));
+    assertStringWrapperConsistentWithGeneral(copy, vhkwb, 2);
+  }
+
+  @Test
+  public void testVectorHashKeyWrapperTwoStringNull() throws HiveException {
+    VectorExpression[] keyExpressions = new VectorExpression[] { new IdentityExpression(0),
+        new IdentityExpression(1) };
+    TypeInfo[] typeInfos = new TypeInfo[] {TypeInfoFactory.stringTypeInfo, TypeInfoFactory.stringTypeInfo};
+    VectorHashKeyWrapperBatch vhkwb = VectorHashKeyWrapperBatch.compileKeyWrapperBatch(
+        keyExpressions,
+        typeInfos);
+
+    VectorizedRowBatch batch = new VectorizedRowBatch(2);
+    batch.selectedInUse = false;
+    BytesColumnVector firstColumnVector = new BytesColumnVector();
+    firstColumnVector.initBuffer(1024);
+    firstColumnVector.noNulls = false;
+    BytesColumnVector secondColumnVector = new BytesColumnVector();
+    secondColumnVector.initBuffer(1024);
+    secondColumnVector.noNulls = false;
+    batch.cols[0] = firstColumnVector;
+    batch.cols[1] = secondColumnVector;
+
+    firstColumnVector.setVal(0, "left".getBytes());
+    secondColumnVector.setVal(0, "right".getBytes());
+    firstColumnVector.isNull[1] = true;
+    secondColumnVector.setVal(1, "right".getBytes());
+    firstColumnVector.setVal(2, "left".getBytes());
+    secondColumnVector.isNull[2] = true;
+    firstColumnVector.isNull[3] = true;
+    secondColumnVector.isNull[3] = true;
+    firstColumnVector.isNull[4] = true;
+    secondColumnVector.setVal(4, "right".getBytes());
+    batch.size = 5;
+
+    vhkwb.evaluateBatch(batch);
+    VectorHashKeyWrapperBase[] vhkwArray = vhkwb.getVectorHashKeyWrappers();
+    for (int i = 0; i < batch.size; i++) {
+      assertTrue(vhkwArray[i] instanceof VectorHashKeyWrapperTwoString);
+      assertStringWrapperConsistentWithGeneral(vhkwArray[i], vhkwb, 2);
+    }
+    assertFalse(vhkwArray[0].isNull(0));
+    assertFalse(vhkwArray[0].isNull(1));
+    assertTrue(vhkwArray[1].isNull(0));
+    assertFalse(vhkwArray[1].isNull(1));
+    assertFalse(vhkwArray[2].isNull(0));
+    assertTrue(vhkwArray[2].isNull(1));
+    assertTrue(vhkwArray[3].isNull(0));
+    assertTrue(vhkwArray[3].isNull(1));
+    assertEquals(vhkwArray[1], vhkwArray[4]);
+    assertFalse(vhkwArray[0].equals(vhkwArray[1]));
+    assertFalse(vhkwArray[0].equals(vhkwArray[2]));
+    assertFalse(vhkwArray[0].equals(vhkwArray[3]));
+  }
+
+  private void assertStringWrapperConsistentWithGeneral(
+      VectorHashKeyWrapperBase stringWrapper, VectorHashKeyWrapperBatch vhkwb, int stringCount) {
     VectorHashKeyWrapperGeneral generalWrapper = new VectorHashKeyWrapperGeneral(
-        new VectorHashKeyWrapperBase.HashContext(), 0, 0, 1, 0, 0, 0, 1);
-    if (singleStringWrapper.isNull(0)) {
-      generalWrapper.assignNullString(0, 0);
-    } else {
-      generalWrapper.assignString(0, singleStringWrapper.getBytes(0), singleStringWrapper.getByteStart(0),
-          singleStringWrapper.getByteLength(0));
+        new VectorHashKeyWrapperBase.HashContext(), 0, 0, stringCount, 0, 0, 0, stringCount);
+    for (int i = 0; i < stringCount; i++) {
+      if (stringWrapper.isNull(i)) {
+        generalWrapper.assignNullString(i, i);
+      } else {
+        generalWrapper.assignString(i, stringWrapper.getBytes(i), stringWrapper.getByteStart(i),
+            stringWrapper.getByteLength(i));
+      }
     }
     generalWrapper.setHashKey();
 
-    assertEquals(generalWrapper.isNull(0), singleStringWrapper.isNull(0));
-    assertEquals(generalWrapper.hashCode(), singleStringWrapper.hashCode());
-    assertEquals(generalWrapper.getByteStart(0), singleStringWrapper.getByteStart(0));
-    assertEquals(generalWrapper.getByteLength(0), singleStringWrapper.getByteLength(0));
-    if (generalWrapper.isNull(0)) {
-      assertEquals(generalWrapper.getBytes(0), singleStringWrapper.getBytes(0));
-    } else {
-      assertTrue(StringExpr.equal(generalWrapper.getBytes(0), generalWrapper.getByteStart(0),
-          generalWrapper.getByteLength(0), singleStringWrapper.getBytes(0), singleStringWrapper.getByteStart(0),
-          singleStringWrapper.getByteLength(0)));
+    assertEquals(generalWrapper.hashCode(), stringWrapper.hashCode());
+    for (int i = 0; i < stringCount; i++) {
+      assertEquals(generalWrapper.isNull(i), stringWrapper.isNull(i));
+      assertEquals(generalWrapper.getByteStart(i), stringWrapper.getByteStart(i));
+      assertEquals(generalWrapper.getByteLength(i), stringWrapper.getByteLength(i));
+      if (generalWrapper.isNull(i)) {
+        assertEquals(generalWrapper.getBytes(i), stringWrapper.getBytes(i));
+      } else {
+        assertTrue(StringExpr.equal(generalWrapper.getBytes(i), generalWrapper.getByteStart(i),
+            generalWrapper.getByteLength(i), stringWrapper.getBytes(i), stringWrapper.getByteStart(i),
+            stringWrapper.getByteLength(i)));
+      }
     }
-    assertEquals(generalWrapper.stringifyKeys(vhkwb), singleStringWrapper.stringifyKeys(vhkwb));
-    assertEquals(generalWrapper.toString(), singleStringWrapper.toString());
-    assertEquals(generalWrapper.getVariableSize(), singleStringWrapper.getVariableSize());
+    assertEquals(generalWrapper.stringifyKeys(vhkwb), stringWrapper.stringifyKeys(vhkwb));
+    assertEquals(generalWrapper.toString(), stringWrapper.toString());
+    assertEquals(generalWrapper.getVariableSize(), stringWrapper.getVariableSize());
   }
 
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorHashKeyWrapperBatch.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorHashKeyWrapperBatch.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hive.ql.exec.vector.expressions.StringExpr;
 import org.apache.hadoop.hive.ql.exec.vector.expressions.VectorExpression;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperBase;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperBatch;
+import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperGeneral;
 import org.apache.hadoop.hive.ql.exec.vector.wrapper.VectorHashKeyWrapperSingleString;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
@@ -110,6 +111,9 @@ public class TestVectorHashKeyWrapperBatch {
 
     vhkwb.evaluateBatch(batch);
     VectorHashKeyWrapperBase[] vhkwArray = vhkwb.getVectorHashKeyWrappers();
+    for (int i = 0; i < batch.size; i++) {
+      assertSingleStringWrapperConsistentWithGeneral(vhkwArray[i], vhkwb);
+    }
     VectorHashKeyWrapperBase hashKey2 = vhkwArray[2];
     VectorHashKeyWrapperBase hashKey1 = vhkwArray[1];
 
@@ -124,6 +128,7 @@ public class TestVectorHashKeyWrapperBatch {
             contents, 0, contents.length));
     assertTrue(StringExpr.equal(hashKey2.getBytes(0), hashKey2.getByteStart(0), hashKey2.getByteLength(0),
         hashKey1.getBytes(0), hashKey1.getByteStart(0), hashKey1.getByteLength(0)));
+    assertSingleStringWrapperConsistentWithGeneral(hashKey1, vhkwb);
   }
 
 
@@ -156,11 +161,15 @@ public class TestVectorHashKeyWrapperBatch {
     assertEquals(vhkwArray[0], vhkwArray[2]);
     assertEquals(vhkwArray[0].hashCode(), vhkwArray[2].hashCode());
     assertFalse(vhkwArray[0].equals(vhkwArray[1]));
+    for (int i = 0; i < batch.size; i++) {
+      assertSingleStringWrapperConsistentWithGeneral(vhkwArray[i], vhkwb);
+    }
 
     VectorHashKeyWrapperBase copy = (VectorHashKeyWrapperBase) vhkwArray[0].copyKey();
     assertTrue(copy instanceof VectorHashKeyWrapperSingleString);
     assertEquals(vhkwArray[0], copy);
     assertEquals(vhkwArray[0].hashCode(), copy.hashCode());
+    assertSingleStringWrapperConsistentWithGeneral(copy, vhkwb);
 
     bytesColumnVector.vector[0][0] = 'z';
     assertTrue(StringExpr.equal(copy.getBytes(0), copy.getByteStart(0), copy.getByteLength(0),
@@ -172,6 +181,7 @@ public class TestVectorHashKeyWrapperBatch {
     assertEquals(vhkwArray[1], copy);
     assertTrue(StringExpr.equal(copy.getBytes(0), copy.getByteStart(0), copy.getByteLength(0),
         beta, 0, beta.length));
+    assertSingleStringWrapperConsistentWithGeneral(copy, vhkwb);
   }
 
   @Test
@@ -204,6 +214,37 @@ public class TestVectorHashKeyWrapperBatch {
     assertEquals(vhkwArray[0], vhkwArray[2]);
     assertEquals(vhkwArray[1], vhkwArray[3]);
     assertFalse(vhkwArray[0].equals(vhkwArray[1]));
+    for (int i = 0; i < batch.size; i++) {
+      assertSingleStringWrapperConsistentWithGeneral(vhkwArray[i], vhkwb);
+    }
+  }
+
+  private void assertSingleStringWrapperConsistentWithGeneral(
+      VectorHashKeyWrapperBase singleStringWrapper, VectorHashKeyWrapperBatch vhkwb) {
+    VectorHashKeyWrapperGeneral generalWrapper = new VectorHashKeyWrapperGeneral(
+        new VectorHashKeyWrapperBase.HashContext(), 0, 0, 1, 0, 0, 0, 1);
+    if (singleStringWrapper.isNull(0)) {
+      generalWrapper.assignNullString(0, 0);
+    } else {
+      generalWrapper.assignString(0, singleStringWrapper.getBytes(0), singleStringWrapper.getByteStart(0),
+          singleStringWrapper.getByteLength(0));
+    }
+    generalWrapper.setHashKey();
+
+    assertEquals(generalWrapper.isNull(0), singleStringWrapper.isNull(0));
+    assertEquals(generalWrapper.hashCode(), singleStringWrapper.hashCode());
+    assertEquals(generalWrapper.getByteStart(0), singleStringWrapper.getByteStart(0));
+    assertEquals(generalWrapper.getByteLength(0), singleStringWrapper.getByteLength(0));
+    if (generalWrapper.isNull(0)) {
+      assertEquals(generalWrapper.getBytes(0), singleStringWrapper.getBytes(0));
+    } else {
+      assertTrue(StringExpr.equal(generalWrapper.getBytes(0), generalWrapper.getByteStart(0),
+          generalWrapper.getByteLength(0), singleStringWrapper.getBytes(0), singleStringWrapper.getByteStart(0),
+          singleStringWrapper.getByteLength(0)));
+    }
+    assertEquals(generalWrapper.stringifyKeys(vhkwb), singleStringWrapper.stringifyKeys(vhkwb));
+    assertEquals(generalWrapper.toString(), singleStringWrapper.toString());
+    assertEquals(generalWrapper.getVariableSize(), singleStringWrapper.getVariableSize());
   }
 
 }


### PR DESCRIPTION
### Motivation
- The existing factory falls back to `VectorHashKeyWrapperGeneral` for most non-long key shapes which is heavier and allocates/copies more data than needed for the common single string key case. 
- Providing a specialized single-string wrapper reduces per-row hashing/equality work and ensures correct clone/copy behavior for string-backed keys.

### Description
- Add `VectorHashKeyWrapperSingleString` implementing optimized string hashing with `Murmur3` incremental hashing, byte-backed equality, efficient `copyKey`/`clone`, null handling, accessors, and `getVariableSize` accounting. 
- Update `VectorHashKeyWrapperFactory.allocate` to return `new VectorHashKeyWrapperSingleString(ctx)` when `longValuesCount == 0 && byteValuesCount == 1`. 
- Extend `TestVectorHashKeyWrapperBatch` with tests that validate the wrapper selection, equality/hashCode behavior, cloning stability when source bytes mutate, `copyKey` semantics, and null-key equality.

### Testing
- Ran `git diff --check` to validate workspace diffs and staged changes, which passed. 
- Attempted to run unit tests with `mvn -pl ql -Dtest=TestVectorHashKeyWrapperBatch test -DskipSparkTests -DskipKryoTests`, but the build was blocked by Maven dependency resolution (parent POM `org.apache:apache:pom:23` download returned HTTP 403), so tests could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ab922a52c832896fff4640062e5bb)