### PR TITLE
Add ColumnVector.resetInit() and use it to combine reset+init across vectorized column classes

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/io/encoded/VectorDeserializeOrcWriter.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/io/encoded/VectorDeserializeOrcWriter.java
@@ -335,8 +335,7 @@ class VectorDeserializeOrcWriter extends EncodingWriter implements Runnable {
         // This resets vectors in both batches.
         ColumnVector colVector = sourceBatch.cols[c];
         if (colVector != null) {
-          colVector.reset();
-          colVector.init();
+          colVector.resetInit();
         }
       }
       sourceBatch.selectedInUse = false;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorMapOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorMapOperator.java
@@ -845,8 +845,7 @@ public class VectorMapOperator extends AbstractMapOperator {
 
   private void resetColumnVector(ColumnVector columnVector) {
     if (columnVector != null) {
-      columnVector.reset();
-      columnVector.init();
+      columnVector.resetInit();
     }
   }
 

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/BytesColumnVector.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/BytesColumnVector.java
@@ -102,6 +102,12 @@ public class BytesColumnVector extends ColumnVector {
     initBuffer(0);
   }
 
+  @Override
+  public void resetInit() {
+    super.resetInit();
+    initBuffer(0);
+  }
+
   /**
    * Set a field by reference.
    *

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/ColumnVector.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/ColumnVector.java
@@ -99,7 +99,7 @@ public abstract class ColumnVector {
    *  - sets noNulls to true
    *  - sets isRepeating to false
    */
-  private void resetBase() {
+  public void reset() {
     assert (refCount.get() == 0);
     if (!noNulls) {
       Arrays.fill(isNull, false);
@@ -110,10 +110,6 @@ public abstract class ColumnVector {
     preFlattenIsRepeating = false;
   }
 
-  public void reset() {
-    resetBase();
-  }
-
   /**
    * Reset and initialize the column vector for callers that would otherwise invoke reset() followed
    * by init(). Subclasses that override reset() or init() should override this method to combine
@@ -121,7 +117,14 @@ public abstract class ColumnVector {
    * no-op, so this method only performs the base reset work.
    */
   public void resetInit() {
-    resetBase();
+    assert (refCount.get() == 0);
+    if (!noNulls) {
+      Arrays.fill(isNull, false);
+    }
+    noNulls = true;
+    isRepeating = false;
+    preFlattenNoNulls = true;
+    preFlattenIsRepeating = false;
   }
 
 

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/ColumnVector.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/ColumnVector.java
@@ -99,7 +99,7 @@ public abstract class ColumnVector {
    *  - sets noNulls to true
    *  - sets isRepeating to false
    */
-  public void reset() {
+  private void resetBase() {
     assert (refCount.get() == 0);
     if (!noNulls) {
       Arrays.fill(isNull, false);
@@ -108,6 +108,20 @@ public abstract class ColumnVector {
     isRepeating = false;
     preFlattenNoNulls = true;
     preFlattenIsRepeating = false;
+  }
+
+  public void reset() {
+    resetBase();
+  }
+
+  /**
+   * Reset and initialize the column vector for callers that would otherwise invoke reset() followed
+   * by init(). Subclasses that override reset() or init() should override this method to combine
+   * their reset and initialization work without duplicate calls. The base init() implementation is a
+   * no-op, so this method only performs the base reset work.
+   */
+  public void resetInit() {
+    resetBase();
   }
 
 

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/ListColumnVector.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/ListColumnVector.java
@@ -150,6 +150,12 @@ public class ListColumnVector extends MultiValuedColumnVector {
   }
 
   @Override
+  public void resetInit() {
+    super.resetInit();
+    child.resetInit();
+  }
+
+  @Override
   public void unFlatten() {
     super.unFlatten();
     if (!isRepeating || noNulls || !isNull[0]) {

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/MapColumnVector.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/MapColumnVector.java
@@ -164,6 +164,13 @@ public class MapColumnVector extends MultiValuedColumnVector {
   }
 
   @Override
+  public void resetInit() {
+    super.resetInit();
+    keys.resetInit();
+    values.resetInit();
+  }
+
+  @Override
   public void unFlatten() {
     super.unFlatten();
     if (!isRepeating || noNulls || !isNull[0]) {

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/MultiValuedColumnVector.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/MultiValuedColumnVector.java
@@ -148,6 +148,12 @@ public abstract class MultiValuedColumnVector extends ColumnVector {
   }
 
   @Override
+  public void resetInit() {
+    super.resetInit();
+    childCount = 0;
+  }
+
+  @Override
   public void shallowCopyTo(ColumnVector otherCv) {
     MultiValuedColumnVector other = (MultiValuedColumnVector)otherCv;
     super.shallowCopyTo(other);

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/StructColumnVector.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/StructColumnVector.java
@@ -154,6 +154,14 @@ public class StructColumnVector extends ColumnVector {
   }
 
   @Override
+  public void resetInit() {
+    super.resetInit();
+    for(int i =0; i < fields.length; ++i) {
+      fields[i].resetInit();
+    }
+  }
+
+  @Override
   public void unFlatten() {
     super.unFlatten();
     for(int i=0; i < fields.length; ++i) {

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/UnionColumnVector.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/UnionColumnVector.java
@@ -163,6 +163,14 @@ public class UnionColumnVector extends ColumnVector {
   }
 
   @Override
+  public void resetInit() {
+    super.resetInit();
+    for(int i =0; i < fields.length; ++i) {
+      fields[i].resetInit();
+    }
+  }
+
+  @Override
   public void unFlatten() {
     super.unFlatten();
     for(int i=0; i < fields.length; ++i) {

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorizedRowBatch.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorizedRowBatch.java
@@ -362,8 +362,7 @@ public class VectorizedRowBatch implements Writable, MutableFilterContext {
     endOfFile = false;
     for (ColumnVector vc : columns) {
       if (vc != null) {
-        vc.reset();
-        vc.init();
+        vc.resetInit();
       }
     }
   }


### PR DESCRIPTION
### Motivation
- Reduce duplicate work and accidental double-initialization by providing a combined reset+init entrypoint for column vectors.
- Ensure subclasses can implement combined reset/initialization logic without calling both `reset()` and `init()` separately.
- Simplify caller code that previously invoked `reset()` followed by `init()` on column vectors.

### Description
- Add `resetInit()` to `ColumnVector` with a `resetBase()` helper, make `reset()` delegate to the base reset, and document `resetInit()` purpose.
- Implement `resetInit()` overrides in `BytesColumnVector`, `ListColumnVector`, `MapColumnVector`, `MultiValuedColumnVector`, `StructColumnVector`, and `UnionColumnVector` to combine their reset and init behaviors.
- Replace paired calls to `reset(); init();` with a single `resetInit()` call in `VectorizedRowBatch.reset`, `VectorMapOperator.resetColumnVector`, and `VectorDeserializeOrcWriter.flushBatch`.

### Testing
- No automated tests were executed locally as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c0af004188328b64369ee553e5f58)