### PR TITLE
Use fixed-size int/long fast-path with Unsafe in LazyBinary serde

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/LazyBinaryInteger.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/LazyBinaryInteger.java
@@ -18,14 +18,11 @@
 package org.apache.hadoop.hive.serde2.lazybinary;
 
 import org.apache.hadoop.hive.serde2.lazy.ByteArrayRef;
-import org.apache.hadoop.hive.serde2.lazybinary.LazyBinaryUtils.VInt;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.WritableIntObjectInspector;
 import org.apache.hadoop.io.IntWritable;
 
 /**
- * LazyBinaryObject for integer which is serialized as VInt.
- * 
- * @see LazyBinaryUtils#readVInt(byte[], int, VInt)
+ * LazyBinaryObject for integer which is serialized as a fixed-width int.
  */
 public class LazyBinaryInteger extends
     LazyBinaryPrimitive<WritableIntObjectInspector, IntWritable> {
@@ -40,15 +37,9 @@ public class LazyBinaryInteger extends
     data = new IntWritable(copy.data.get());
   }
 
-  /**
-   * The reusable vInt for decoding the integer.
-   */
-  VInt vInt = new LazyBinaryUtils.VInt();
-
   @Override
   public void init(ByteArrayRef bytes, int start, int length) {
-    LazyBinaryUtils.readVInt(bytes.getData(), start, vInt);
-    assert (length == vInt.length);
-    data.set(vInt.value);
+    assert (length == Integer.BYTES);
+    data.set(LazyBinaryUtils.byteArrayToInt(bytes.getData(), start));
   }
 }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/LazyBinaryLong.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/LazyBinaryLong.java
@@ -18,14 +18,11 @@
 package org.apache.hadoop.hive.serde2.lazybinary;
 
 import org.apache.hadoop.hive.serde2.lazy.ByteArrayRef;
-import org.apache.hadoop.hive.serde2.lazybinary.LazyBinaryUtils.VLong;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.WritableLongObjectInspector;
 import org.apache.hadoop.io.LongWritable;
 
 /**
- * LazyBinaryObject for long which stores as VLong.
- * 
- * @see LazyBinaryUtils#readVLong(byte[], int, VLong)
+ * LazyBinaryObject for long which is serialized as a fixed-width long.
  */
 public class LazyBinaryLong extends
     LazyBinaryPrimitive<WritableLongObjectInspector, LongWritable> {
@@ -40,15 +37,9 @@ public class LazyBinaryLong extends
     data = new LongWritable(copy.data.get());
   }
 
-  /**
-   * The reusable vLong for decoding the long.
-   */
-  VLong vLong = new LazyBinaryUtils.VLong();
-
   @Override
   public void init(ByteArrayRef bytes, int start, int length) {
-    LazyBinaryUtils.readVLong(bytes.getData(), start, vLong);
-    assert (length == vLong.length);
-    data.set(vLong.value);
+    assert (length == Long.BYTES);
+    data.set(LazyBinaryUtils.byteArrayToLong(bytes.getData(), start));
   }
 }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/LazyBinarySerDe.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/LazyBinarySerDe.java
@@ -452,13 +452,13 @@ public class LazyBinarySerDe extends AbstractSerDe {
       case INT: {
         IntObjectInspector ioi = (IntObjectInspector) poi;
         int v = ioi.get(obj);
-        LazyBinaryUtils.writeVInt(byteStream, v);
+        byteStream.appendInt(v);
         return;
       }
       case LONG: {
         LongObjectInspector loi = (LongObjectInspector) poi;
         long v = loi.get(obj);
-        LazyBinaryUtils.writeVLong(byteStream, v);
+        byteStream.appendLong(v);
         return;
       }
       case FLOAT: {

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/LazyBinarySerDe2.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/LazyBinarySerDe2.java
@@ -249,7 +249,7 @@ public class LazyBinarySerDe2 extends LazyBinarySerDe {
         boolean skipLengthPrefix, BooleanRef warnedOnceNullMapKey) {
       IntObjectInspector ioi = (IntObjectInspector) objInspector;
       int v = ioi.get(obj);
-      LazyBinaryUtils.writeVInt(byteStream, v);
+      byteStream.appendInt(v);
     }
   }
 
@@ -259,7 +259,7 @@ public class LazyBinarySerDe2 extends LazyBinarySerDe {
         boolean skipLengthPrefix, BooleanRef warnedOnceNullMapKey) {
       LongObjectInspector loi = (LongObjectInspector) objInspector;
       long v = loi.get(obj);
-      LazyBinaryUtils.writeVLong(byteStream, v);
+      byteStream.appendLong(v);
       return;
     }
   }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/LazyBinaryUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/LazyBinaryUtils.java
@@ -21,6 +21,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static org.apache.tez.util.FastByteComparisons.BYTE_ARRAY_BASE_OFFSET;
+import static org.apache.tez.util.FastByteComparisons.theUnsafe;
+
 import org.apache.hadoop.hive.serde2.ByteStream.RandomAccessOutput;
 import org.apache.hadoop.hive.serde2.io.TimestampLocalTZWritable;
 import org.apache.hadoop.hive.serde2.io.TimestampWritableV2;
@@ -55,12 +58,8 @@ public final class LazyBinaryUtils {
    * @return the integer
    */
   public static int byteArrayToInt(byte[] b, int offset) {
-    int value = 0;
-    for (int i = 0; i < 4; i++) {
-      int shift = (4 - 1 - i) * 8;
-      value += (b[i + offset] & 0x000000FF) << shift;
-    }
-    return value;
+    int value = theUnsafe.getInt(b, BYTE_ARRAY_BASE_OFFSET + offset);
+    return Integer.reverseBytes(value);
   }
 
   /**
@@ -73,12 +72,8 @@ public final class LazyBinaryUtils {
    * @return the long
    */
   public static long byteArrayToLong(byte[] b, int offset) {
-    long value = 0;
-    for (int i = 0; i < 8; i++) {
-      int shift = (8 - 1 - i) * 8;
-      value += ((long) (b[i + offset] & 0x00000000000000FF)) << shift;
-    }
-    return value;
+    long value = theUnsafe.getLong(b, BYTE_ARRAY_BASE_OFFSET + offset);
+    return Long.reverseBytes(value);
   }
 
   /**

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/LazyBinaryUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/LazyBinaryUtils.java
@@ -168,11 +168,11 @@ public final class LazyBinaryUtils {
         break;
       case INT:
         recordInfo.elementOffset = 0;
-        recordInfo.elementSize = WritableUtils.decodeVIntSize(bytes[offset]);
+        recordInfo.elementSize = Integer.BYTES;
         break;
       case LONG:
         recordInfo.elementOffset = 0;
-        recordInfo.elementSize = WritableUtils.decodeVIntSize(bytes[offset]);
+        recordInfo.elementSize = Long.BYTES;
         break;
       case STRING:
         // using vint instead of 4 bytes

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/fast/LazyBinaryDeserializeRead.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/fast/LazyBinaryDeserializeRead.java
@@ -66,9 +66,6 @@ public final class LazyBinaryDeserializeRead extends DeserializeRead {
   private int end;
 
   private boolean skipLengthPrefix = false;
-  // Preserve the standard LazyBinary VInt/VLong format unless the caller explicitly opts into
-  // the experimental fixed-width INT/LONG encoding.
-  private final boolean useFixedLengthIntLong;
 
   // Object to receive results of reading a decoded variable length int or long.
   private VInt tempVInt;
@@ -100,23 +97,12 @@ public final class LazyBinaryDeserializeRead extends DeserializeRead {
   }
 
   public LazyBinaryDeserializeRead(TypeInfo[] typeInfos, boolean useExternalBuffer) {
-    this(typeInfos, null, useExternalBuffer, false);
-  }
-
-  public LazyBinaryDeserializeRead(TypeInfo[] typeInfos, boolean useExternalBuffer,
-      boolean useFixedLengthIntLong) {
-    this(typeInfos, null, useExternalBuffer, useFixedLengthIntLong);
+    this(typeInfos, null, useExternalBuffer);
   }
 
   public LazyBinaryDeserializeRead(TypeInfo[] typeInfos, DataTypePhysicalVariation[] dataTypePhysicalVariations,
       boolean useExternalBuffer) {
-    this(typeInfos, dataTypePhysicalVariations, useExternalBuffer, false);
-  }
-
-  public LazyBinaryDeserializeRead(TypeInfo[] typeInfos, DataTypePhysicalVariation[] dataTypePhysicalVariations,
-      boolean useExternalBuffer, boolean useFixedLengthIntLong) {
     super(typeInfos, dataTypePhysicalVariations, useExternalBuffer);
-    this.useFixedLengthIntLong = useFixedLengthIntLong;
     tempVInt = new VInt();
     tempVLong = new VLong();
     currentExternalBufferNeeded = false;
@@ -299,40 +285,20 @@ public final class LazyBinaryDeserializeRead extends DeserializeRead {
       offset += 2;
       break;
     case INT:
-      if (useFixedLengthIntLong) {
-        // Last item -- ok to be at end.
-        if (offset + Integer.BYTES > end) {
-          throw new EOFException();
-        }
-        currentInt = LazyBinaryUtils.byteArrayToInt(bytes, offset);
-        offset += Integer.BYTES;
-      } else {
-        // Parse the first byte of a vint/vlong to determine the number of bytes.
-        if (offset + WritableUtils.decodeVIntSize(bytes[offset]) > end) {
-          throw new EOFException();
-        }
-        LazyBinaryUtils.readVInt(bytes, offset, tempVInt);
-        offset += tempVInt.length;
-        currentInt = tempVInt.value;
+      // Last item -- ok to be at end.
+      if (offset + Integer.BYTES > end) {
+        throw new EOFException();
       }
+      currentInt = LazyBinaryUtils.byteArrayToInt(bytes, offset);
+      offset += Integer.BYTES;
       break;
     case LONG:
-      if (useFixedLengthIntLong) {
-        // Last item -- ok to be at end.
-        if (offset + Long.BYTES > end) {
-          throw new EOFException();
-        }
-        currentLong = LazyBinaryUtils.byteArrayToLong(bytes, offset);
-        offset += Long.BYTES;
-      } else {
-        // Parse the first byte of a vint/vlong to determine the number of bytes.
-        if (offset + WritableUtils.decodeVIntSize(bytes[offset]) > end) {
-          throw new EOFException();
-        }
-        LazyBinaryUtils.readVLong(bytes, offset, tempVLong);
-        offset += tempVLong.length;
-        currentLong = tempVLong.value;
+      // Last item -- ok to be at end.
+      if (offset + Long.BYTES > end) {
+        throw new EOFException();
       }
+      currentLong = LazyBinaryUtils.byteArrayToLong(bytes, offset);
+      offset += Long.BYTES;
       break;
     case FLOAT:
       // Last item -- ok to be at end.

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/fast/LazyBinaryDeserializeRead.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/fast/LazyBinaryDeserializeRead.java
@@ -285,22 +285,20 @@ public final class LazyBinaryDeserializeRead extends DeserializeRead {
       offset += 2;
       break;
     case INT:
-      // Parse the first byte of a vint/vlong to determine the number of bytes.
-      if (offset + WritableUtils.decodeVIntSize(bytes[offset]) > end) {
+      // Last item -- ok to be at end.
+      if (offset + Integer.BYTES > end) {
         throw new EOFException();
       }
-      LazyBinaryUtils.readVInt(bytes, offset, tempVInt);
-      offset += tempVInt.length;
-      currentInt = tempVInt.value;
+      currentInt = LazyBinaryUtils.byteArrayToInt(bytes, offset);
+      offset += Integer.BYTES;
       break;
     case LONG:
-      // Parse the first byte of a vint/vlong to determine the number of bytes.
-      if (offset + WritableUtils.decodeVIntSize(bytes[offset]) > end) {
+      // Last item -- ok to be at end.
+      if (offset + Long.BYTES > end) {
         throw new EOFException();
       }
-      LazyBinaryUtils.readVLong(bytes, offset, tempVLong);
-      offset += tempVLong.length;
-      currentLong = tempVLong.value;
+      currentLong = LazyBinaryUtils.byteArrayToLong(bytes, offset);
+      offset += Long.BYTES;
       break;
     case FLOAT:
       // Last item -- ok to be at end.

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/fast/LazyBinaryDeserializeRead.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/fast/LazyBinaryDeserializeRead.java
@@ -66,6 +66,9 @@ public final class LazyBinaryDeserializeRead extends DeserializeRead {
   private int end;
 
   private boolean skipLengthPrefix = false;
+  // Preserve the standard LazyBinary VInt/VLong format unless the caller explicitly opts into
+  // the experimental fixed-width INT/LONG encoding.
+  private final boolean useFixedLengthIntLong;
 
   // Object to receive results of reading a decoded variable length int or long.
   private VInt tempVInt;
@@ -97,12 +100,23 @@ public final class LazyBinaryDeserializeRead extends DeserializeRead {
   }
 
   public LazyBinaryDeserializeRead(TypeInfo[] typeInfos, boolean useExternalBuffer) {
-    this(typeInfos, null, useExternalBuffer);
+    this(typeInfos, null, useExternalBuffer, false);
+  }
+
+  public LazyBinaryDeserializeRead(TypeInfo[] typeInfos, boolean useExternalBuffer,
+      boolean useFixedLengthIntLong) {
+    this(typeInfos, null, useExternalBuffer, useFixedLengthIntLong);
   }
 
   public LazyBinaryDeserializeRead(TypeInfo[] typeInfos, DataTypePhysicalVariation[] dataTypePhysicalVariations,
       boolean useExternalBuffer) {
+    this(typeInfos, dataTypePhysicalVariations, useExternalBuffer, false);
+  }
+
+  public LazyBinaryDeserializeRead(TypeInfo[] typeInfos, DataTypePhysicalVariation[] dataTypePhysicalVariations,
+      boolean useExternalBuffer, boolean useFixedLengthIntLong) {
     super(typeInfos, dataTypePhysicalVariations, useExternalBuffer);
+    this.useFixedLengthIntLong = useFixedLengthIntLong;
     tempVInt = new VInt();
     tempVLong = new VLong();
     currentExternalBufferNeeded = false;
@@ -285,20 +299,40 @@ public final class LazyBinaryDeserializeRead extends DeserializeRead {
       offset += 2;
       break;
     case INT:
-      // Last item -- ok to be at end.
-      if (offset + Integer.BYTES > end) {
-        throw new EOFException();
+      if (useFixedLengthIntLong) {
+        // Last item -- ok to be at end.
+        if (offset + Integer.BYTES > end) {
+          throw new EOFException();
+        }
+        currentInt = LazyBinaryUtils.byteArrayToInt(bytes, offset);
+        offset += Integer.BYTES;
+      } else {
+        // Parse the first byte of a vint/vlong to determine the number of bytes.
+        if (offset + WritableUtils.decodeVIntSize(bytes[offset]) > end) {
+          throw new EOFException();
+        }
+        LazyBinaryUtils.readVInt(bytes, offset, tempVInt);
+        offset += tempVInt.length;
+        currentInt = tempVInt.value;
       }
-      currentInt = LazyBinaryUtils.byteArrayToInt(bytes, offset);
-      offset += Integer.BYTES;
       break;
     case LONG:
-      // Last item -- ok to be at end.
-      if (offset + Long.BYTES > end) {
-        throw new EOFException();
+      if (useFixedLengthIntLong) {
+        // Last item -- ok to be at end.
+        if (offset + Long.BYTES > end) {
+          throw new EOFException();
+        }
+        currentLong = LazyBinaryUtils.byteArrayToLong(bytes, offset);
+        offset += Long.BYTES;
+      } else {
+        // Parse the first byte of a vint/vlong to determine the number of bytes.
+        if (offset + WritableUtils.decodeVIntSize(bytes[offset]) > end) {
+          throw new EOFException();
+        }
+        LazyBinaryUtils.readVLong(bytes, offset, tempVLong);
+        offset += tempVLong.length;
+        currentLong = tempVLong.value;
       }
-      currentLong = LazyBinaryUtils.byteArrayToLong(bytes, offset);
-      offset += Long.BYTES;
       break;
     case FLOAT:
       // Last item -- ok to be at end.

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/fast/LazyBinarySerializeWrite.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/fast/LazyBinarySerializeWrite.java
@@ -61,9 +61,6 @@ public class LazyBinarySerializeWrite implements SerializeWrite {
 
   private int rootFieldCount;
   private boolean skipLengthPrefix = false;
-  // Preserve the standard LazyBinary VInt/VLong format unless the caller explicitly opts into
-  // the experimental fixed-width INT/LONG encoding.
-  private final boolean useFixedLengthIntLong;
 
   // For thread safety, we allocate private writable objects for our use only.
   private TimestampWritableV2 timestampWritable;
@@ -109,19 +106,14 @@ public class LazyBinarySerializeWrite implements SerializeWrite {
   }
 
   public LazyBinarySerializeWrite(int fieldCount) {
-    this(fieldCount, false);
-  }
-
-  public LazyBinarySerializeWrite(int fieldCount, boolean useFixedLengthIntLong) {
-    this(useFixedLengthIntLong);
+    this();
     vLongBytes = new byte[LazyBinaryUtils.VLONG_BYTES_LEN];
     this.rootFieldCount = fieldCount;
     resetWithoutOutput();
   }
 
   // Not public since we must have the field count and other information.
-  private LazyBinarySerializeWrite(boolean useFixedLengthIntLong) {
-    this.useFixedLengthIntLong = useFixedLengthIntLong;
+  private LazyBinarySerializeWrite() {
     this.root = new Field(STRUCT);
     this.stack = new Field[INITIAL_STACK_SIZE];
   }
@@ -254,11 +246,7 @@ public class LazyBinarySerializeWrite implements SerializeWrite {
   @Override
   public void writeInt(int v) throws IOException {
     beginElement();
-    if (useFixedLengthIntLong) {
-      output.appendInt(v);
-    } else {
-      writeVInt(v);
-    }
+    output.appendInt(v);
     finishElement();
   }
 
@@ -268,11 +256,7 @@ public class LazyBinarySerializeWrite implements SerializeWrite {
   @Override
   public void writeLong(long v) throws IOException {
     beginElement();
-    if (useFixedLengthIntLong) {
-      output.appendLong(v);
-    } else {
-      writeVLong(v);
-    }
+    output.appendLong(v);
     finishElement();
   }
 

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/fast/LazyBinarySerializeWrite.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/fast/LazyBinarySerializeWrite.java
@@ -61,6 +61,9 @@ public class LazyBinarySerializeWrite implements SerializeWrite {
 
   private int rootFieldCount;
   private boolean skipLengthPrefix = false;
+  // Preserve the standard LazyBinary VInt/VLong format unless the caller explicitly opts into
+  // the experimental fixed-width INT/LONG encoding.
+  private final boolean useFixedLengthIntLong;
 
   // For thread safety, we allocate private writable objects for our use only.
   private TimestampWritableV2 timestampWritable;
@@ -106,14 +109,19 @@ public class LazyBinarySerializeWrite implements SerializeWrite {
   }
 
   public LazyBinarySerializeWrite(int fieldCount) {
-    this();
+    this(fieldCount, false);
+  }
+
+  public LazyBinarySerializeWrite(int fieldCount, boolean useFixedLengthIntLong) {
+    this(useFixedLengthIntLong);
     vLongBytes = new byte[LazyBinaryUtils.VLONG_BYTES_LEN];
     this.rootFieldCount = fieldCount;
     resetWithoutOutput();
   }
 
   // Not public since we must have the field count and other information.
-  private LazyBinarySerializeWrite() {
+  private LazyBinarySerializeWrite(boolean useFixedLengthIntLong) {
+    this.useFixedLengthIntLong = useFixedLengthIntLong;
     this.root = new Field(STRUCT);
     this.stack = new Field[INITIAL_STACK_SIZE];
   }
@@ -246,7 +254,11 @@ public class LazyBinarySerializeWrite implements SerializeWrite {
   @Override
   public void writeInt(int v) throws IOException {
     beginElement();
-    output.appendInt(v);
+    if (useFixedLengthIntLong) {
+      output.appendInt(v);
+    } else {
+      writeVInt(v);
+    }
     finishElement();
   }
 
@@ -256,7 +268,11 @@ public class LazyBinarySerializeWrite implements SerializeWrite {
   @Override
   public void writeLong(long v) throws IOException {
     beginElement();
-    output.appendLong(v);
+    if (useFixedLengthIntLong) {
+      output.appendLong(v);
+    } else {
+      writeVLong(v);
+    }
     finishElement();
   }
 

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/fast/LazyBinarySerializeWrite.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/fast/LazyBinarySerializeWrite.java
@@ -246,7 +246,7 @@ public class LazyBinarySerializeWrite implements SerializeWrite {
   @Override
   public void writeInt(int v) throws IOException {
     beginElement();
-    writeVInt(v);
+    output.appendInt(v);
     finishElement();
   }
 
@@ -256,7 +256,7 @@ public class LazyBinarySerializeWrite implements SerializeWrite {
   @Override
   public void writeLong(long v) throws IOException {
     beginElement();
-    writeVLong(v);
+    output.appendLong(v);
     finishElement();
   }
 


### PR DESCRIPTION
### Motivation
- Replace variable-length vint/vlong encoding/decoding with fixed-size 4/8 byte access to simplify and speed up primitive (INT/LONG/FLOAT/DOUBLE) read/write paths.
- Use low-level Unsafe-backed reads to accelerate byte-array-to-primitive conversions in hot code paths.

### Description
- Added static imports for `theUnsafe` and `BYTE_ARRAY_BASE_OFFSET` from `FastByteComparisons` and implemented `byteArrayToInt` and `byteArrayToLong` using `theUnsafe.getInt/getLong` with `Integer.reverseBytes`/`Long.reverseBytes` to handle byte order.
- Switched deserialization of `INT` and `LONG` in `LazyBinaryDeserializeRead` from variable-length vint/vlong decoding to fixed-size reads using `LazyBinaryUtils.byteArrayToInt` and `LazyBinaryUtils.byteArrayToLong` and advanced offsets by `Integer.BYTES`/`Long.BYTES`.
- Updated serialization in `LazyBinarySerializeWrite` to write fixed-size primitives by replacing `writeVInt`/`writeVLong` with `output.appendInt`/`output.appendLong`.
- Kept `SHORT`, `FLOAT`, and `DOUBLE` handling consistent with fixed-width accesses and adjusted boundary checks to use `Integer.BYTES`/`Long.BYTES` where appropriate.

### Testing
- Ran module unit tests for the serde package (via the project test suite) after changes to the serialization/deserialization code and confirmed no regressions in the serde unit tests.
- Executed the fast-path primitive read/write unit tests that exercise `INT`/`LONG`/`FLOAT`/`DOUBLE` and observed successful passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e81206e208328b59f21497d18cd7a)