### PR TITLE
Use Arrays.fill to replace manual array initialization loops

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/CommonJoinOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/CommonJoinOperator.java
@@ -739,9 +739,7 @@ public abstract class CommonJoinOperator<T extends JoinDesc> extends
         // results, we need to take that record, replace the right side with NULL
         // values, and produce the records
         int i = numAliases - 1;
-        for (int j = offsets[i]; j < offsets[i + 1]; j++) {
-          forwardCache[j] = null;
-        }
+        Arrays.fill(forwardCache, offsets[i], offsets[i + 1], null);
         internalForward(forwardCache, outputObjInspector);
         countAfterReport = 0;
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/DDLPlanUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/DDLPlanUtils.java
@@ -24,6 +24,7 @@ import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.CTAS_
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import java.util.Arrays;
 import java.util.Comparator;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.common.StatsSetupConst;
@@ -393,9 +394,7 @@ public class DDLPlanUtils {
     for (int i = 0; i < arr.length; i++) {
       temp[i] = arr[i];
     }
-    for (int i = arr.length; i < 8; i++) {
-      temp[i] = (byte) 0;
-    }
+    Arrays.fill(temp, arr.length, temp.length, (byte) 0);
     return temp;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/MuxOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/MuxOperator.java
@@ -281,9 +281,7 @@ public class MuxOperator extends Operator<MuxDesc> implements Serializable{
 
   @Override
   public void startGroup() throws HiveException{
-    for (int i = 0; i < numParents; i++) {
-      processGroupCalled[i] = false;
-    }
+    Arrays.fill(processGroupCalled, 0, numParents, false);
     super.startGroup();
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/tools/KeyValuesInputMerger.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/tools/KeyValuesInputMerger.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hive.ql.exec.tez.tools;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -68,9 +69,7 @@ public class KeyValuesInputMerger extends KeyValuesReader {
     }
 
     public void init(List<KeyValuesReader> readerList) {
-      for (int i = 0; i < readerList.size(); i++) {
-        readerArray[i] = null;
-      }
+      Arrays.fill(readerArray, 0, readerList.size(), null);
       loadedSize = 0;
       for (KeyValuesReader kvsReader : readerList) {
         readerArray[loadedSize] = kvsReader;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorExpressionDescriptor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorExpressionDescriptor.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.hive.ql.exec.vector;
 
+import java.util.Arrays;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.ql.exec.vector.expressions.VectorExpression;
@@ -212,10 +214,8 @@ public class VectorExpressionDescriptor {
     private int argCount = 0;
 
     public Builder() {
-      for (int i = 0 ; i < MAX_NUM_ARGUMENTS; i++) {
-        argTypes[i] = ArgumentType.NONE;
-        exprTypes[i] = InputExpressionType.NONE;
-      }
+      Arrays.fill(argTypes, ArgumentType.NONE);
+      Arrays.fill(exprTypes, InputExpressionType.NONE);
     }
 
     public Builder setMode(Mode m) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/RCFile.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/RCFile.java
@@ -642,9 +642,7 @@ public class RCFile {
         skippedColIDs = skippedCols;
       } else {
         skippedColIDs = new boolean[columnNumber];
-        for (int i = 0; i < skippedColIDs.length; i++) {
-          skippedColIDs[i] = false;
-        }
+        Arrays.fill(skippedColIDs, false);
       }
 
       int skipped = 0;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/reloperators/HiveBetween.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/reloperators/HiveBetween.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hive.ql.optimizer.calcite.reloperators;
 
+import java.util.Arrays;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.SqlCall;
@@ -90,9 +91,7 @@ public class HiveBetween extends SqlSpecialOperator {
 
           RelDataTypeFactory typeFactory = callBinding.getTypeFactory();
           operandTypes[0] = typeFactory.createSqlType(SqlTypeName.BOOLEAN);
-          for (int i = 1; i < operandTypes.length; ++i) {
-            operandTypes[i] = knownType;
-          }
+          Arrays.fill(operandTypes, 1, operandTypes.length, knownType);
         }
       };
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveFilterJoinRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveFilterJoinRule.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.ql.optimizer.calcite.rules;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
 
@@ -467,9 +468,7 @@ public abstract class HiveFilterJoinRule extends FilterJoinRule {
       List<RelDataTypeField> rightFields,
       RexNode filter) {
     int[] adjustments = new int[nTotalFields];
-    for (int i = start; i < end; i++) {
-      adjustments[i] = offset;
-    }
+    Arrays.fill(adjustments, start, end, offset);
     return filter.accept(
         new RexInputConverter(
             rexBuilder,

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveJoinSwapConstraintsRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveJoinSwapConstraintsRule.java
@@ -17,6 +17,7 @@
 package org.apache.hadoop.hive.ql.optimizer.calcite.rules;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import org.apache.calcite.plan.RelOptRule;
@@ -213,17 +214,9 @@ public class HiveJoinSwapConstraintsRule extends RelOptRule {
       int nFieldsZ,
       int adjustY,
       int adjustZ) {
-    for (int i = 0; i < nFieldsX; i++) {
-      adjustments[i] = 0;
-    }
-    for (int i = nFieldsX; i < (nFieldsX + nFieldsY); i++) {
-      adjustments[i] = adjustY;
-    }
-    for (int i = nFieldsX + nFieldsY;
-         i < (nFieldsX + nFieldsY + nFieldsZ);
-         i++) {
-      adjustments[i] = adjustZ;
-    }
+    Arrays.fill(adjustments, 0, nFieldsX, 0);
+    Arrays.fill(adjustments, nFieldsX, nFieldsX + nFieldsY, adjustY);
+    Arrays.fill(adjustments, nFieldsX + nFieldsY, nFieldsX + nFieldsY + nFieldsZ, adjustZ);
   }
 
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/BitSetCheckedAuthorizationProvider.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/BitSetCheckedAuthorizationProvider.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hive.ql.security.authorization;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -48,15 +49,11 @@ public abstract class BitSetCheckedAuthorizationProvider extends
       BitSetChecker checker = new BitSetChecker();
       if (inputRequiredPriv != null) {
         checker.inputCheck = new boolean[inputRequiredPriv.length];
-        for (int i = 0; i < checker.inputCheck.length; i++) {
-          checker.inputCheck[i] = false;
-        }
+        Arrays.fill(checker.inputCheck, false);
       }
       if (outputRequiredPriv != null) {
         checker.outputCheck = new boolean[outputRequiredPriv.length];
-        for (int i = 0; i < checker.outputCheck.length; i++) {
-          checker.outputCheck[i] = false;
-        }
+        Arrays.fill(checker.outputCheck, false);
       }
 
       return checker;
@@ -440,9 +437,7 @@ public abstract class BitSetCheckedAuthorizationProvider extends
   }
 
   private static void setBooleanArray(boolean[] check, boolean b) {
-    for (int i = 0; i < check.length; i++) {
-      check[i] = b;
-    }
+    Arrays.fill(check, b);
   }
 
   private static void booleanArrayOr(boolean[] output, boolean[] input) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFUtils.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
@@ -358,9 +359,7 @@ public final class GenericUDFUtils {
           ObjectInspector oi = ObjectInspectorFactory
               .getReflectionObjectInspector(lastParaElementType,
               ObjectInspectorOptions.JAVA);
-          for (int i = methodParameterTypes.length - 1; i < parameterOIs.length; i++) {
-            methodParameterOIs[i] = oi;
-          }
+          Arrays.fill(methodParameterOIs, methodParameterTypes.length - 1, parameterOIs.length, oi);
         }
 
       } else {

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/BytesColumnVector.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/BytesColumnVector.java
@@ -144,10 +144,8 @@ public class BytesColumnVector extends ColumnVector {
     if (sharedBuffer != null) {
       // Free up any previously allocated buffers that are referenced by vector
       if (bufferAllocationCount > 0) {
-        for (int idx = 0; idx < vector.length; ++idx) {
-          vector[idx] = null;
-          length[idx] = 0;
-        }
+        Arrays.fill(vector, null);
+        Arrays.fill(length, 0);
       }
     } else {
       // allocate a little extra space to limit need to re-allocate

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/StringExpr.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/StringExpr.java
@@ -87,9 +87,7 @@ public class StringExpr {
     final int resultStart = outV.getValPreallocatedStart();
     System.arraycopy(bytes, start, resultBytes, resultStart, length);
     final int padEnd = resultStart + resultLength;
-    for (int p = resultStart + length; p < padEnd; p++) {
-      resultBytes[p] = ' ';
-    }
+    Arrays.fill(resultBytes, resultStart + length, padEnd, (byte) ' ');
     outV.setValPreallocated(i, resultLength);
   }
 
@@ -102,9 +100,7 @@ public class StringExpr {
     final int resultStart = 0;
     System.arraycopy(bytes, start, resultBytes, resultStart, length);
     final int padEnd = resultStart + resultLength;
-    for (int p = resultStart + length; p < padEnd; p++) {
-      resultBytes[p] = ' ';
-    }
+    Arrays.fill(resultBytes, resultStart + length, padEnd, (byte) ' ');
     return resultBytes;
   }
 


### PR DESCRIPTION
### Motivation
- Remove repetitive manual loops used to initialize or clear arrays and replace them with `Arrays.fill` for clarity and consistency.
- Add the required `java.util.Arrays` imports where needed so the new calls are available.

### Description
- Replaced explicit `for` loops that set array elements to constant values (e.g. `null`, `false`, `0`, byte values) with `Arrays.fill(...)` in multiple classes including `CommonJoinOperator`, `DDLPlanUtils`, `MuxOperator`, `KeyValuesInputMerger`, `VectorExpressionDescriptor`, `RCFile`, `HiveBetween`, `HiveFilterJoinRule`, `HiveJoinSwapConstraintsRule`, `BitSetCheckedAuthorizationProvider`, `GenericUDFUtils`, `BytesColumnVector`, and `StringExpr`.
- Added `import java.util.Arrays;` in files that call `Arrays.fill`.
- No functional behavior was changed; this is a refactor to improve readability and ensure consistent array initialization patterns.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eda0585b88328bb0c9cc28f73d1eb)