### PR TITLE
Add vector shuffle batch serializer/deserializer and unit tests

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorShuffleBatchDeserializer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorShuffleBatchDeserializer.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.exec.vector;
+
+import java.io.IOException;
+
+import org.apache.hadoop.hive.common.type.HiveIntervalDayTime;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.hadoop.io.WritableUtils;
+
+/** Deserializes a compact vector shuffle payload into an already schema-initialized batch. */
+public final class VectorShuffleBatchDeserializer {
+  private static final int IS_REPEATING = 1;
+  private static final int HAS_NULLS = 2;
+
+  private final DataInputBuffer input = new DataInputBuffer();
+
+  public void deserialize(BytesWritable serialized, VectorizedRowBatch destination)
+      throws IOException {
+    if (serialized == null || destination == null) {
+      throw new IllegalArgumentException("Serialized batch and destination are required");
+    }
+
+    input.reset(serialized.getBytes(), serialized.getLength());
+    final int rowCount = WritableUtils.readVInt(input);
+    final int columnCount = WritableUtils.readVInt(input);
+    if (rowCount < 0 || columnCount < 0 || columnCount > destination.cols.length) {
+      throw new IOException("Invalid vector shuffle batch dimensions: " + rowCount + " rows, "
+          + columnCount + " columns");
+    }
+
+    destination.reset();
+    for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+      if (destination.cols[columnIndex] != null) {
+        destination.cols[columnIndex].ensureSize(rowCount, false);
+      }
+    }
+    destination.size = rowCount;
+    destination.selectedInUse = false;
+    destination.projectionSize = columnCount;
+    for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+      destination.projectedColumns[columnIndex] = columnIndex;
+      ColumnVector column = destination.cols[columnIndex];
+      if (column == null) {
+        throw new IOException("Destination column " + columnIndex + " is not initialized");
+      }
+      readColumn(column, rowCount);
+    }
+    if (input.getPosition() != serialized.getLength()) {
+      throw new IOException("Vector shuffle batch has "
+          + (serialized.getLength() - input.getPosition()) + " trailing bytes");
+    }
+  }
+
+  private void readColumn(ColumnVector column, int rowCount) throws IOException {
+    final int flags = input.readUnsignedByte();
+    final boolean repeating = (flags & IS_REPEATING) != 0;
+    final boolean hasNulls = (flags & HAS_NULLS) != 0;
+    final int valueCount = repeating ? Math.min(rowCount, 1) : rowCount;
+    column.ensureSize(valueCount, false);
+
+    byte[] nullBitmap = null;
+    if (hasNulls) {
+      nullBitmap = new byte[(valueCount + 7) / 8];
+      input.readFully(nullBitmap);
+    }
+
+    column.isRepeating = repeating;
+    column.noNulls = !hasNulls;
+    for (int index = 0; index < valueCount; index++) {
+      column.isNull[index] = hasNulls && (nullBitmap[index >>> 3] & (1 << (index & 7))) != 0;
+    }
+    readTypeMetadata(column);
+
+    if (column instanceof StructColumnVector || column instanceof UnionColumnVector) {
+      throw unsupported(column);
+    } else if (column instanceof ListColumnVector) {
+      ListColumnVector list = (ListColumnVector) column;
+      int childCount = readMultiValuedLengths(list, valueCount);
+      list.child.ensureSize(childCount, false);
+      readColumn(list.child, childCount);
+    } else if (column instanceof MapColumnVector) {
+      MapColumnVector map = (MapColumnVector) column;
+      int childCount = readMultiValuedLengths(map, valueCount);
+      map.keys.ensureSize(childCount, false);
+      map.values.ensureSize(childCount, false);
+      readColumn(map.keys, childCount);
+      readColumn(map.values, childCount);
+    } else {
+      ensurePrimitiveSupported(column);
+      for (int index = 0; index < valueCount; index++) {
+        if (!column.isNull[index]) {
+          readValue(column, index);
+        }
+      }
+    }
+  }
+
+  private int readMultiValuedLengths(MultiValuedColumnVector column, int valueCount)
+      throws IOException {
+    int childCount = 0;
+    for (int index = 0; index < valueCount; index++) {
+      column.offsets[index] = childCount;
+      if (!column.isNull[index]) {
+        int length = WritableUtils.readVInt(input);
+        if (length < 0) {
+          throw new IOException("Negative multi-valued vector length " + length);
+        }
+        column.lengths[index] = length;
+        childCount = Math.addExact(childCount, length);
+      } else {
+        column.lengths[index] = 0;
+      }
+    }
+    column.childCount = childCount;
+    return childCount;
+  }
+
+  private void readTypeMetadata(ColumnVector column) throws IOException {
+    if (column instanceof DateColumnVector) {
+      ((DateColumnVector) column).setUsingProlepticCalendar(input.readBoolean());
+    } else if (column instanceof TimestampColumnVector) {
+      TimestampColumnVector timestamp = (TimestampColumnVector) column;
+      timestamp.setIsUTC(input.readBoolean());
+      timestamp.setUsingProlepticCalendar(input.readBoolean());
+    }
+  }
+
+  private void readValue(ColumnVector column, int index) throws IOException {
+    if (column instanceof BytesColumnVector) {
+      int length = WritableUtils.readVInt(input);
+      if (length < 0) {
+        throw new IOException("Negative byte-vector value length " + length);
+      }
+      byte[] bytes = new byte[length];
+      input.readFully(bytes);
+      ((BytesColumnVector) column).setVal(index, bytes);
+    } else if (column instanceof TimestampColumnVector) {
+      TimestampColumnVector timestamp = (TimestampColumnVector) column;
+      timestamp.time[index] = input.readLong();
+      timestamp.nanos[index] = input.readInt();
+    } else if (column instanceof IntervalDayTimeColumnVector) {
+      ((IntervalDayTimeColumnVector) column).set(index,
+          new HiveIntervalDayTime(input.readLong(), input.readInt()));
+    } else if (column instanceof DecimalColumnVector) {
+      ((DecimalColumnVector) column).vector[index].readFields(input);
+    } else if (column instanceof LongColumnVector) {
+      ((LongColumnVector) column).vector[index] = input.readLong();
+    } else if (column instanceof DoubleColumnVector) {
+      ((DoubleColumnVector) column).vector[index] = input.readDouble();
+    } else if (column instanceof VoidColumnVector) {
+      // VOID has no value payload.
+    } else {
+      throw unsupported(column);
+    }
+  }
+
+  private void ensurePrimitiveSupported(ColumnVector column) {
+    if (!(column instanceof BytesColumnVector || column instanceof TimestampColumnVector
+        || column instanceof IntervalDayTimeColumnVector || column instanceof DecimalColumnVector
+        || column instanceof LongColumnVector || column instanceof DoubleColumnVector
+        || column instanceof VoidColumnVector)) {
+      throw unsupported(column);
+    }
+  }
+
+  private IllegalArgumentException unsupported(ColumnVector column) {
+    return new IllegalArgumentException(
+        "Unsupported vector shuffle column type " + column.getClass().getName());
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorShuffleBatchSerializer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorShuffleBatchSerializer.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.exec.vector;
+
+import java.io.IOException;
+
+import org.apache.hadoop.hive.common.type.HiveIntervalDayTime;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.DataOutputBuffer;
+import org.apache.hadoop.io.WritableUtils;
+
+/**
+ * Serializes the active rows of selected columns from a {@link VectorizedRowBatch}.
+ *
+ * <p>The receiver is expected to know the column schema and physical vector layout. Selected rows
+ * are compacted in logical order, inactive rows and unselected columns are omitted, null values are
+ * omitted, and repeating columns are represented by a single value. Primitive, list, and map
+ * vectors are supported; struct and union vectors are rejected until their inactive child slots can
+ * be omitted safely.</p>
+ */
+public final class VectorShuffleBatchSerializer {
+  private static final int IS_REPEATING = 1;
+  private static final int HAS_NULLS = 2;
+
+  private final DataOutputBuffer buffer = new DataOutputBuffer();
+
+  public void serialize(VectorizedRowBatch source, int[] sourceColumnMap, BytesWritable output)
+      throws IOException {
+    if (source == null || sourceColumnMap == null || output == null) {
+      throw new IllegalArgumentException("Source batch, source column map, and output are required");
+    }
+
+    int[] logicalRows = new int[source.size];
+    for (int logical = 0; logical < source.size; logical++) {
+      logicalRows[logical] = source.selectedInUse ? source.selected[logical] : logical;
+    }
+
+    buffer.reset();
+    WritableUtils.writeVInt(buffer, source.size);
+    WritableUtils.writeVInt(buffer, sourceColumnMap.length);
+    for (int sourceColumn : sourceColumnMap) {
+      if (sourceColumn < 0 || sourceColumn >= source.cols.length || source.cols[sourceColumn] == null) {
+        throw new IllegalArgumentException("Invalid source column " + sourceColumn);
+      }
+      writeColumn(source.cols[sourceColumn], logicalRows, source.size);
+    }
+    output.set(buffer.getData(), 0, buffer.getLength());
+  }
+
+  private void writeColumn(ColumnVector column, int[] indices, int count) throws IOException {
+    final boolean repeating = column.isRepeating;
+    final int valueCount = repeating ? Math.min(count, 1) : count;
+    final boolean hasNulls = hasNulls(column, indices, valueCount, repeating);
+    buffer.writeByte((repeating ? IS_REPEATING : 0) | (hasNulls ? HAS_NULLS : 0));
+
+    byte[] nullBitmap = null;
+    if (hasNulls) {
+      nullBitmap = new byte[(valueCount + 7) / 8];
+      for (int logical = 0; logical < valueCount; logical++) {
+        if (isNull(column, indices, logical, repeating)) {
+          nullBitmap[logical >>> 3] |= 1 << (logical & 7);
+        }
+      }
+      buffer.write(nullBitmap);
+    }
+
+    writeTypeMetadata(column);
+    if (column instanceof StructColumnVector || column instanceof UnionColumnVector) {
+      throw unsupported(column);
+    } else if (column instanceof ListColumnVector) {
+      ListColumnVector list = (ListColumnVector) column;
+      writeMultiValuedChildren(list, list.child, null, indices, valueCount, repeating, nullBitmap);
+    } else if (column instanceof MapColumnVector) {
+      MapColumnVector map = (MapColumnVector) column;
+      writeMultiValuedChildren(map, map.keys, map.values, indices, valueCount, repeating, nullBitmap);
+    } else {
+      ensurePrimitiveSupported(column);
+      for (int logical = 0; logical < valueCount; logical++) {
+        if (!hasNulls || (nullBitmap[logical >>> 3] & (1 << (logical & 7))) == 0) {
+          writeValue(column, physicalIndex(indices, logical, repeating));
+        }
+      }
+    }
+  }
+
+  private void writeMultiValuedChildren(MultiValuedColumnVector parent, ColumnVector firstChild,
+      ColumnVector secondChild, int[] indices, int valueCount, boolean repeating, byte[] nullBitmap)
+      throws IOException {
+    int childCount = 0;
+    for (int logical = 0; logical < valueCount; logical++) {
+      if (nullBitmap == null || (nullBitmap[logical >>> 3] & (1 << (logical & 7))) == 0) {
+        int index = physicalIndex(indices, logical, repeating);
+        int length = Math.toIntExact(parent.lengths[index]);
+        WritableUtils.writeVInt(buffer, length);
+        childCount = Math.addExact(childCount, length);
+      }
+    }
+
+    int[] childIndices = new int[childCount];
+    int childPosition = 0;
+    for (int logical = 0; logical < valueCount; logical++) {
+      if (nullBitmap == null || (nullBitmap[logical >>> 3] & (1 << (logical & 7))) == 0) {
+        int index = physicalIndex(indices, logical, repeating);
+        int offset = Math.toIntExact(parent.offsets[index]);
+        int length = Math.toIntExact(parent.lengths[index]);
+        for (int child = 0; child < length; child++) {
+          childIndices[childPosition++] = offset + child;
+        }
+      }
+    }
+    writeColumn(firstChild, childIndices, childCount);
+    if (secondChild != null) {
+      writeColumn(secondChild, childIndices, childCount);
+    }
+  }
+
+  private boolean hasNulls(ColumnVector column, int[] indices, int valueCount,
+      boolean repeating) {
+    if (column.noNulls) {
+      return false;
+    }
+    for (int logical = 0; logical < valueCount; logical++) {
+      if (isNull(column, indices, logical, repeating)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isNull(ColumnVector column, int[] indices, int logical, boolean repeating) {
+    return column.isNull[physicalIndex(indices, logical, repeating)];
+  }
+
+  private int physicalIndex(int[] indices, int logical, boolean repeating) {
+    return repeating ? 0 : indices[logical];
+  }
+
+  private void writeTypeMetadata(ColumnVector column) throws IOException {
+    if (column instanceof DateColumnVector) {
+      buffer.writeBoolean(((DateColumnVector) column).isUsingProlepticCalendar());
+    } else if (column instanceof TimestampColumnVector) {
+      TimestampColumnVector timestamp = (TimestampColumnVector) column;
+      buffer.writeBoolean(timestamp.isUTC());
+      buffer.writeBoolean(timestamp.usingProlepticCalendar());
+    }
+  }
+
+  private void writeValue(ColumnVector column, int index) throws IOException {
+    if (column instanceof BytesColumnVector) {
+      BytesColumnVector bytes = (BytesColumnVector) column;
+      WritableUtils.writeVInt(buffer, bytes.length[index]);
+      buffer.write(bytes.vector[index], bytes.start[index], bytes.length[index]);
+    } else if (column instanceof TimestampColumnVector) {
+      TimestampColumnVector timestamp = (TimestampColumnVector) column;
+      buffer.writeLong(timestamp.time[index]);
+      buffer.writeInt(timestamp.nanos[index]);
+    } else if (column instanceof IntervalDayTimeColumnVector) {
+      HiveIntervalDayTime interval =
+          ((IntervalDayTimeColumnVector) column).asScratchIntervalDayTime(index);
+      buffer.writeLong(interval.getTotalSeconds());
+      buffer.writeInt(interval.getNanos());
+    } else if (column instanceof DecimalColumnVector) {
+      ((DecimalColumnVector) column).vector[index].write(buffer);
+    } else if (column instanceof LongColumnVector) {
+      buffer.writeLong(((LongColumnVector) column).vector[index]);
+    } else if (column instanceof DoubleColumnVector) {
+      buffer.writeDouble(((DoubleColumnVector) column).vector[index]);
+    } else if (column instanceof VoidColumnVector) {
+      // VOID has no value payload.
+    } else {
+      throw unsupported(column);
+    }
+  }
+
+  private void ensurePrimitiveSupported(ColumnVector column) {
+    if (!(column instanceof BytesColumnVector || column instanceof TimestampColumnVector
+        || column instanceof IntervalDayTimeColumnVector || column instanceof DecimalColumnVector
+        || column instanceof LongColumnVector || column instanceof DoubleColumnVector
+        || column instanceof VoidColumnVector)) {
+      throw unsupported(column);
+    }
+  }
+
+  private IllegalArgumentException unsupported(ColumnVector column) {
+    return new IllegalArgumentException(
+        "Unsupported vector shuffle column type " + column.getClass().getName());
+  }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorShuffleBatchSerde.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorShuffleBatchSerde.java
@@ -35,6 +35,202 @@ public class TestVectorShuffleBatchSerde {
   private final VectorShuffleBatchDeserializer deserializer = new VectorShuffleBatchDeserializer();
 
   @Test
+  public void testBigIntColumnSchema() throws Exception {
+    VectorizedRowBatch source = new VectorizedRowBatch(1);
+    LongColumnVector sourceLongs = new LongColumnVector();
+    source.cols[0] = sourceLongs;
+    source.size = 3;
+    sourceLongs.vector[0] = Long.MIN_VALUE;
+    sourceLongs.vector[1] = 0;
+    sourceLongs.vector[2] = Long.MAX_VALUE;
+
+    VectorizedRowBatch result = new VectorizedRowBatch(1);
+    result.cols[0] = new LongColumnVector();
+    roundTrip(source, new int[] {0}, result);
+
+    LongColumnVector resultLongs = (LongColumnVector) result.cols[0];
+    assertEquals(Long.MIN_VALUE, resultLongs.vector[0]);
+    assertEquals(0, resultLongs.vector[1]);
+    assertEquals(Long.MAX_VALUE, resultLongs.vector[2]);
+  }
+
+  @Test
+  public void testStringColumnSchema() throws Exception {
+    VectorizedRowBatch source = new VectorizedRowBatch(1);
+    BytesColumnVector sourceStrings = new BytesColumnVector();
+    sourceStrings.initBuffer();
+    source.cols[0] = sourceStrings;
+    source.size = 3;
+    sourceStrings.setVal(0, bytes("alpha"));
+    sourceStrings.setVal(1, bytes(""));
+    sourceStrings.setVal(2, bytes("omega"));
+
+    VectorizedRowBatch result = new VectorizedRowBatch(1);
+    result.cols[0] = new BytesColumnVector();
+    roundTrip(source, new int[] {0}, result);
+
+    BytesColumnVector resultStrings = (BytesColumnVector) result.cols[0];
+    assertBytes("alpha", resultStrings, 0);
+    assertBytes("", resultStrings, 1);
+    assertBytes("omega", resultStrings, 2);
+  }
+
+  @Test
+  public void testDecimalColumnSchema() throws Exception {
+    VectorizedRowBatch source = new VectorizedRowBatch(1);
+    DecimalColumnVector sourceDecimals = new DecimalColumnVector(20, 4);
+    source.cols[0] = sourceDecimals;
+    source.size = 3;
+    sourceDecimals.set(0, HiveDecimal.create("-12345.6789"));
+    sourceDecimals.set(1, HiveDecimal.ZERO);
+    sourceDecimals.set(2, HiveDecimal.create("98765.4321"));
+
+    VectorizedRowBatch result = new VectorizedRowBatch(1);
+    result.cols[0] = new DecimalColumnVector(20, 4);
+    roundTrip(source, new int[] {0}, result);
+
+    DecimalColumnVector resultDecimals = (DecimalColumnVector) result.cols[0];
+    assertEquals(HiveDecimal.create("-12345.6789"), resultDecimals.vector[0].getHiveDecimal());
+    assertEquals(HiveDecimal.ZERO, resultDecimals.vector[1].getHiveDecimal());
+    assertEquals(HiveDecimal.create("98765.4321"), resultDecimals.vector[2].getHiveDecimal());
+  }
+
+  @Test
+  public void testArrayOfBigIntColumnSchema() throws Exception {
+    LongColumnVector sourceElements = new LongColumnVector();
+    ListColumnVector sourceLists =
+        new ListColumnVector(VectorizedRowBatch.DEFAULT_SIZE, sourceElements);
+    VectorizedRowBatch source = new VectorizedRowBatch(1);
+    source.cols[0] = sourceLists;
+    source.size = 2;
+    sourceLists.offsets[0] = 2;
+    sourceLists.lengths[0] = 2;
+    sourceLists.offsets[1] = 7;
+    sourceLists.lengths[1] = 1;
+    sourceLists.childCount = 8;
+    sourceElements.vector[2] = 20;
+    sourceElements.vector[3] = 30;
+    sourceElements.vector[7] = 70;
+
+    ListColumnVector resultLists =
+        new ListColumnVector(VectorizedRowBatch.DEFAULT_SIZE, new LongColumnVector());
+    VectorizedRowBatch result = new VectorizedRowBatch(1);
+    result.cols[0] = resultLists;
+    roundTrip(source, new int[] {0}, result);
+
+    LongColumnVector resultElements = (LongColumnVector) resultLists.child;
+    assertEquals(3, resultLists.childCount);
+    assertEquals(0, resultLists.offsets[0]);
+    assertEquals(2, resultLists.lengths[0]);
+    assertEquals(2, resultLists.offsets[1]);
+    assertEquals(1, resultLists.lengths[1]);
+    assertEquals(20, resultElements.vector[0]);
+    assertEquals(30, resultElements.vector[1]);
+    assertEquals(70, resultElements.vector[2]);
+  }
+
+  @Test
+  public void testMapOfStringToBigIntColumnSchema() throws Exception {
+    BytesColumnVector sourceKeys = new BytesColumnVector();
+    sourceKeys.initBuffer();
+    LongColumnVector sourceValues = new LongColumnVector();
+    MapColumnVector sourceMaps =
+        new MapColumnVector(VectorizedRowBatch.DEFAULT_SIZE, sourceKeys, sourceValues);
+    VectorizedRowBatch source = new VectorizedRowBatch(1);
+    source.cols[0] = sourceMaps;
+    source.size = 2;
+    sourceMaps.offsets[0] = 1;
+    sourceMaps.lengths[0] = 2;
+    sourceMaps.offsets[1] = 5;
+    sourceMaps.lengths[1] = 1;
+    sourceMaps.childCount = 6;
+    sourceKeys.setVal(1, bytes("one"));
+    sourceKeys.setVal(2, bytes("two"));
+    sourceKeys.setVal(5, bytes("five"));
+    sourceValues.vector[1] = 1;
+    sourceValues.vector[2] = 2;
+    sourceValues.vector[5] = 5;
+
+    BytesColumnVector resultKeys = new BytesColumnVector();
+    LongColumnVector resultValues = new LongColumnVector();
+    MapColumnVector resultMaps =
+        new MapColumnVector(VectorizedRowBatch.DEFAULT_SIZE, resultKeys, resultValues);
+    VectorizedRowBatch result = new VectorizedRowBatch(1);
+    result.cols[0] = resultMaps;
+    roundTrip(source, new int[] {0}, result);
+
+    assertEquals(3, resultMaps.childCount);
+    assertEquals(0, resultMaps.offsets[0]);
+    assertEquals(2, resultMaps.lengths[0]);
+    assertEquals(2, resultMaps.offsets[1]);
+    assertEquals(1, resultMaps.lengths[1]);
+    assertBytes("one", resultKeys, 0);
+    assertBytes("two", resultKeys, 1);
+    assertBytes("five", resultKeys, 2);
+    assertEquals(1, resultValues.vector[0]);
+    assertEquals(2, resultValues.vector[1]);
+    assertEquals(5, resultValues.vector[2]);
+  }
+
+  @Test
+  public void testArrayOfMapOfStringToBigIntColumnSchema() throws Exception {
+    BytesColumnVector sourceKeys = new BytesColumnVector();
+    sourceKeys.initBuffer();
+    LongColumnVector sourceValues = new LongColumnVector();
+    MapColumnVector sourceMaps =
+        new MapColumnVector(VectorizedRowBatch.DEFAULT_SIZE, sourceKeys, sourceValues);
+    ListColumnVector sourceLists =
+        new ListColumnVector(VectorizedRowBatch.DEFAULT_SIZE, sourceMaps);
+    VectorizedRowBatch source = new VectorizedRowBatch(1);
+    source.cols[0] = sourceLists;
+    source.size = 2;
+
+    sourceLists.offsets[0] = 1;
+    sourceLists.lengths[0] = 1;
+    sourceLists.offsets[1] = 3;
+    sourceLists.lengths[1] = 1;
+    sourceLists.childCount = 4;
+    sourceMaps.offsets[1] = 2;
+    sourceMaps.lengths[1] = 2;
+    sourceMaps.offsets[3] = 6;
+    sourceMaps.lengths[3] = 1;
+    sourceMaps.childCount = 7;
+    sourceKeys.setVal(2, bytes("a"));
+    sourceKeys.setVal(3, bytes("b"));
+    sourceKeys.setVal(6, bytes("c"));
+    sourceValues.vector[2] = 10;
+    sourceValues.vector[3] = 20;
+    sourceValues.vector[6] = 30;
+
+    BytesColumnVector resultKeys = new BytesColumnVector();
+    LongColumnVector resultValues = new LongColumnVector();
+    MapColumnVector resultMaps =
+        new MapColumnVector(VectorizedRowBatch.DEFAULT_SIZE, resultKeys, resultValues);
+    ListColumnVector resultLists =
+        new ListColumnVector(VectorizedRowBatch.DEFAULT_SIZE, resultMaps);
+    VectorizedRowBatch result = new VectorizedRowBatch(1);
+    result.cols[0] = resultLists;
+    roundTrip(source, new int[] {0}, result);
+
+    assertEquals(2, resultLists.childCount);
+    assertEquals(0, resultLists.offsets[0]);
+    assertEquals(1, resultLists.lengths[0]);
+    assertEquals(1, resultLists.offsets[1]);
+    assertEquals(1, resultLists.lengths[1]);
+    assertEquals(3, resultMaps.childCount);
+    assertEquals(0, resultMaps.offsets[0]);
+    assertEquals(2, resultMaps.lengths[0]);
+    assertEquals(2, resultMaps.offsets[1]);
+    assertEquals(1, resultMaps.lengths[1]);
+    assertBytes("a", resultKeys, 0);
+    assertBytes("b", resultKeys, 1);
+    assertBytes("c", resultKeys, 2);
+    assertEquals(10, resultValues.vector[0]);
+    assertEquals(20, resultValues.vector[1]);
+    assertEquals(30, resultValues.vector[2]);
+  }
+
+  @Test
   public void testSelectedRowsAndColumnMapAreCompacted() throws Exception {
     VectorizedRowBatch source = new VectorizedRowBatch(3);
     LongColumnVector ignored = new LongColumnVector();

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorShuffleBatchSerde.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorShuffleBatchSerde.java
@@ -44,6 +44,7 @@ public class TestVectorShuffleBatchSerde {
     source.cols[1] = strings;
     source.cols[2] = longs;
 
+    strings.initBuffer();
     strings.setVal(2, bytes("two"));
     strings.setVal(5, bytes("five"));
     strings.setVal(9, bytes("nine"));

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorShuffleBatchSerde.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorShuffleBatchSerde.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.exec.vector;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.common.type.HiveIntervalDayTime;
+import org.apache.hadoop.io.BytesWritable;
+import org.junit.Test;
+
+public class TestVectorShuffleBatchSerde {
+  private final VectorShuffleBatchSerializer serializer = new VectorShuffleBatchSerializer();
+  private final VectorShuffleBatchDeserializer deserializer = new VectorShuffleBatchDeserializer();
+
+  @Test
+  public void testSelectedRowsAndColumnMapAreCompacted() throws Exception {
+    VectorizedRowBatch source = new VectorizedRowBatch(3);
+    LongColumnVector ignored = new LongColumnVector();
+    BytesColumnVector strings = new BytesColumnVector();
+    LongColumnVector longs = new LongColumnVector();
+    source.cols[0] = ignored;
+    source.cols[1] = strings;
+    source.cols[2] = longs;
+
+    strings.setVal(2, bytes("two"));
+    strings.setVal(5, bytes("five"));
+    strings.setVal(9, bytes("nine"));
+    longs.vector[2] = 20;
+    longs.vector[5] = 50;
+    longs.vector[9] = 90;
+    source.selectedInUse = true;
+    source.selected[0] = 2;
+    source.selected[1] = 5;
+    source.selected[2] = 9;
+    source.size = 3;
+
+    VectorizedRowBatch result = new VectorizedRowBatch(2);
+    result.cols[0] = new LongColumnVector();
+    result.cols[1] = new BytesColumnVector();
+    roundTrip(source, new int[] {2, 1}, result);
+
+    assertEquals(3, result.size);
+    assertFalse(result.selectedInUse);
+    assertEquals(20, ((LongColumnVector) result.cols[0]).vector[0]);
+    assertEquals(50, ((LongColumnVector) result.cols[0]).vector[1]);
+    assertEquals(90, ((LongColumnVector) result.cols[0]).vector[2]);
+    assertBytes("two", (BytesColumnVector) result.cols[1], 0);
+    assertBytes("five", (BytesColumnVector) result.cols[1], 1);
+    assertBytes("nine", (BytesColumnVector) result.cols[1], 2);
+  }
+
+  @Test
+  public void testNullAndRepeatingColumnsUseLogicalRepresentation() throws Exception {
+    VectorizedRowBatch source = new VectorizedRowBatch(3);
+    LongColumnVector repeating = new LongColumnVector();
+    DoubleColumnVector nullable = new DoubleColumnVector();
+    BytesColumnVector repeatingNull = new BytesColumnVector();
+    source.cols[0] = repeating;
+    source.cols[1] = nullable;
+    source.cols[2] = repeatingNull;
+    source.size = 4;
+
+    repeating.isRepeating = true;
+    repeating.vector[0] = 73;
+    nullable.noNulls = false;
+    nullable.vector[0] = 1.25;
+    nullable.isNull[1] = true;
+    nullable.vector[2] = 2.5;
+    nullable.vector[3] = 5.0;
+    repeatingNull.isRepeating = true;
+    repeatingNull.noNulls = false;
+    repeatingNull.isNull[0] = true;
+
+    VectorizedRowBatch result = new VectorizedRowBatch(3);
+    result.cols[0] = new LongColumnVector();
+    result.cols[1] = new DoubleColumnVector();
+    result.cols[2] = new BytesColumnVector();
+    roundTrip(source, new int[] {0, 1, 2}, result);
+
+    LongColumnVector resultRepeating = (LongColumnVector) result.cols[0];
+    assertTrue(resultRepeating.isRepeating);
+    assertEquals(73, resultRepeating.vector[0]);
+    DoubleColumnVector resultNullable = (DoubleColumnVector) result.cols[1];
+    assertFalse(resultNullable.noNulls);
+    assertTrue(resultNullable.isNull[1]);
+    assertEquals(2.5, resultNullable.vector[2], 0);
+    assertTrue(result.cols[2].isRepeating);
+    assertFalse(result.cols[2].noNulls);
+    assertTrue(result.cols[2].isNull[0]);
+  }
+
+  @Test
+  public void testAdditionalPrimitivePhysicalVectors() throws Exception {
+    VectorizedRowBatch source = new VectorizedRowBatch(5);
+    DateColumnVector date = new DateColumnVector().setUsingProlepticCalendar(true);
+    TimestampColumnVector timestamp = new TimestampColumnVector().setUsingProlepticCalendar(true);
+    IntervalDayTimeColumnVector interval = new IntervalDayTimeColumnVector();
+    DecimalColumnVector decimal = new DecimalColumnVector(12, 3);
+    Decimal64ColumnVector decimal64 = new Decimal64ColumnVector(12, 3);
+    source.cols[0] = date;
+    source.cols[1] = timestamp;
+    source.cols[2] = interval;
+    source.cols[3] = decimal;
+    source.cols[4] = decimal64;
+    source.size = 1;
+
+    date.vector[0] = -100000;
+    timestamp.setIsUTC(true);
+    timestamp.time[0] = 123456789L;
+    timestamp.nanos[0] = 987654321;
+    interval.set(0, new HiveIntervalDayTime(123, 456));
+    decimal.set(0, HiveDecimal.create("123.456"));
+    decimal64.set(0, HiveDecimal.create("789.012"));
+
+    VectorizedRowBatch result = new VectorizedRowBatch(5);
+    result.cols[0] = new DateColumnVector();
+    result.cols[1] = new TimestampColumnVector();
+    result.cols[2] = new IntervalDayTimeColumnVector();
+    result.cols[3] = new DecimalColumnVector(12, 3);
+    result.cols[4] = new Decimal64ColumnVector(12, 3);
+    roundTrip(source, new int[] {0, 1, 2, 3, 4}, result);
+
+    assertTrue(((DateColumnVector) result.cols[0]).isUsingProlepticCalendar());
+    assertEquals(-100000, ((DateColumnVector) result.cols[0]).vector[0]);
+    TimestampColumnVector resultTimestamp = (TimestampColumnVector) result.cols[1];
+    assertTrue(resultTimestamp.isUTC());
+    assertTrue(resultTimestamp.usingProlepticCalendar());
+    assertEquals(123456789L, resultTimestamp.time[0]);
+    assertEquals(987654321, resultTimestamp.nanos[0]);
+    HiveIntervalDayTime resultInterval =
+        ((IntervalDayTimeColumnVector) result.cols[2]).asScratchIntervalDayTime(0);
+    assertEquals(123, resultInterval.getTotalSeconds());
+    assertEquals(456, resultInterval.getNanos());
+    assertEquals(HiveDecimal.create("123.456"),
+        ((DecimalColumnVector) result.cols[3]).vector[0].getHiveDecimal());
+    assertEquals(((Decimal64ColumnVector) source.cols[4]).vector[0],
+        ((Decimal64ColumnVector) result.cols[4]).vector[0]);
+  }
+
+  @Test
+  public void testListColumnIsCompacted() throws Exception {
+    LongColumnVector sourceChild = new LongColumnVector();
+    ListColumnVector sourceList = new ListColumnVector(VectorizedRowBatch.DEFAULT_SIZE, sourceChild);
+    VectorizedRowBatch source = new VectorizedRowBatch(1);
+    source.cols[0] = sourceList;
+    source.size = 2;
+    source.selectedInUse = true;
+    source.selected[0] = 2;
+    source.selected[1] = 5;
+    sourceList.offsets[2] = 3;
+    sourceList.lengths[2] = 2;
+    sourceChild.vector[3] = 30;
+    sourceChild.vector[4] = 40;
+    sourceList.offsets[5] = 8;
+    sourceList.lengths[5] = 1;
+    sourceChild.vector[8] = 80;
+
+    ListColumnVector resultList =
+        new ListColumnVector(VectorizedRowBatch.DEFAULT_SIZE, new LongColumnVector());
+    VectorizedRowBatch result = new VectorizedRowBatch(1);
+    result.cols[0] = resultList;
+    roundTrip(source, new int[] {0}, result);
+
+    assertEquals(3, resultList.childCount);
+    assertEquals(0, resultList.offsets[0]);
+    assertEquals(2, resultList.lengths[0]);
+    assertEquals(2, resultList.offsets[1]);
+    assertEquals(1, resultList.lengths[1]);
+    assertEquals(30, ((LongColumnVector) resultList.child).vector[0]);
+    assertEquals(40, ((LongColumnVector) resultList.child).vector[1]);
+    assertEquals(80, ((LongColumnVector) resultList.child).vector[2]);
+  }
+
+  @Test
+  public void testStructColumnIsRejectedUntilInactiveChildrenCanBeOmitted() {
+    VectorizedRowBatch source = new VectorizedRowBatch(1);
+    source.cols[0] = new StructColumnVector(VectorizedRowBatch.DEFAULT_SIZE, new BytesColumnVector());
+    source.size = 1;
+
+    assertThrows(IllegalArgumentException.class,
+        () -> serializer.serialize(source, new int[] {0}, new BytesWritable()));
+  }
+
+  private void roundTrip(VectorizedRowBatch source, int[] sourceColumnMap,
+      VectorizedRowBatch destination) throws Exception {
+    BytesWritable serialized = new BytesWritable();
+    serializer.serialize(source, sourceColumnMap, serialized);
+    deserializer.deserialize(serialized, destination);
+  }
+
+  private static byte[] bytes(String value) {
+    return value.getBytes(StandardCharsets.UTF_8);
+  }
+
+  private static void assertBytes(String expected, BytesColumnVector vector, int index) {
+    assertArrayEquals(bytes(expected),
+        java.util.Arrays.copyOfRange(vector.vector[index], vector.start[index],
+            vector.start[index] + vector.length[index]));
+  }
+}


### PR DESCRIPTION
### Motivation
- Introduce a compact on-wire representation for selected columns/rows of a `VectorizedRowBatch` so batches can be shuffled efficiently between components while omitting inactive rows and unselected columns.
- Support logical representation of repeating and nullable vectors and preserve necessary type metadata for date/timestamp vectors.

### Description
- Add `VectorShuffleBatchSerializer` which writes a compact payload including row/column counts, per-column flags (repeating/nulls), null bitmaps, type metadata, multi-valued lengths for lists/maps, and primitive value payloads for supported types.
- Add `VectorShuffleBatchDeserializer` which restores data into an already schema-initialized `VectorizedRowBatch` and reconstructs child vectors for lists and maps; both classes reject `StructColumnVector` and `UnionColumnVector` as unsupported.
- Implement support for primitive vectors (`Bytes`, `Timestamp`, `IntervalDayTime`, `Decimal`, `Long`, `Double`, `Void`) and for `ListColumnVector` and `MapColumnVector` with flattened child compaction.
- Add `TestVectorShuffleBatchSerde` unit tests that exercise selected row compaction, repeating/null semantics, additional primitive types and metadata, list compaction, and rejection of struct columns.

### Testing
- Added and ran the unit test class `TestVectorShuffleBatchSerde` which contains `testSelectedRowsAndColumnMapAreCompacted`, `testNullAndRepeatingColumnsUseLogicalRepresentation`, `testAdditionalPrimitivePhysicalVectors`, `testListColumnIsCompacted`, and `testStructColumnIsRejectedUntilInactiveChildrenCanBeOmitted`.
- Executed the test class with `mvn -Dtest=TestVectorShuffleBatchSerde test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a246b7d3ff8832889ec30ac3e609251)