### PR TITLE
Avoid serializing vector map join keys

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastHashTableContainerBase.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastHashTableContainerBase.java
@@ -35,6 +35,15 @@ public abstract class VectorMapJoinFastHashTableContainerBase implements VectorM
 
   public abstract long getHashCode(BytesWritable currentKey) throws HiveException, IOException;
 
+  public void putLongRow(long hashCode, long key, BytesWritable currentValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  public void putBytesRow(long hashCode, byte[] keyBytes, int keyOffset, int keyLength,
+      BytesWritable currentValue) {
+    throw new UnsupportedOperationException();
+  }
+
   public abstract long getEstimatedMemorySize();
 
   public abstract int size();

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastHashTableLoader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastHashTableLoader.java
@@ -53,12 +53,18 @@ import org.apache.hadoop.hive.ql.exec.mr.ExecMapperContext;
 import org.apache.hadoop.hive.ql.exec.persistence.MapJoinTableContainer;
 import org.apache.hadoop.hive.ql.exec.persistence.MapJoinTableContainerSerDe;
 import org.apache.hadoop.hive.ql.exec.tez.TezContext;
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorSerializeRow;
 import org.apache.hadoop.hive.ql.exec.vector.VectorShuffleBatchDeserializer;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedBatchUtil;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.plan.MapJoinDesc;
+import org.apache.hadoop.hive.ql.plan.VectorMapJoinDesc;
+import org.apache.hadoop.hive.ql.plan.VectorMapJoinDesc.HashTableKeyType;
+import org.apache.hadoop.hive.ql.plan.VectorMapJoinDesc.HashTableKind;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.ByteStream.Output;
 import org.apache.hadoop.hive.serde2.binarysortable.fast.BinarySortableSerializeWrite;
@@ -67,6 +73,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.io.BytesWritable;
+import org.apache.hive.common.util.HashCodeUtil;
 import org.apache.tez.runtime.api.Input;
 import org.apache.tez.runtime.api.LogicalInput;
 import org.apache.tez.runtime.library.api.KeyValueReader;
@@ -196,7 +203,14 @@ public class VectorMapJoinFastHashTableLoader implements org.apache.hadoop.hive.
       for (int i = 0; i < batch.getSize(); i++) {
         try {
           HashTableElement h = batch.getBatch(i);
-          tableContainer.putRow(h.getHashCode(), h.getKey(), h.getValue());
+          if (h.isDirectLongKey()) {
+            tableContainer.putLongRow(h.getHashCode(), h.getLongKey(), h.getValue());
+          } else if (h.isDirectBytesKey()) {
+            tableContainer.putBytesRow(h.getHashCode(), h.getKeyBytes(), h.getKeyOffset(),
+                h.getKeyLength(), h.getValue());
+          } else {
+            tableContainer.putRow(h.getHashCode(), h.getKey(), h.getValue());
+          }
         }
         catch (Exception e) {
           throw new HiveException("Exception in draining thread put row", e);
@@ -304,8 +318,10 @@ public class VectorMapJoinFastHashTableLoader implements org.apache.hadoop.hive.
             for (int logicalIndex = 0; logicalIndex < vectorSerde.getBatch().size; logicalIndex++) {
               int batchIndex = vectorSerde.getBatch().selectedInUse
                   ? vectorSerde.getBatch().selected[logicalIndex] : logicalIndex;
-              addHashTableEntry(tableContainer, vectorSerde.serializeKey(batchIndex),
-                  vectorSerde.serializeValue(batchIndex), true);
+              if (!vectorSerde.addDirectHashTableEntry(this, batchIndex)) {
+                addHashTableEntry(tableContainer, vectorSerde.serializeKey(batchIndex),
+                    vectorSerde.serializeValue(batchIndex), true);
+              }
               receivedEntries++;
               checkLoadProgress(tableContainer, inputName, receivedEntries, interruptCheckInterval,
                   doMemCheck, memoryMonitorInfo, effectiveThreshold);
@@ -383,6 +399,31 @@ public class VectorMapJoinFastHashTableLoader implements org.apache.hadoop.hive.
     HashTableElement element = new HashTableElement(hashCode, keyBytes,
         copyBytes ? 0 : currentKey.getOffset(), currentKey.getLength(), valueBytes,
         copyBytes ? 0 : currentValue.getOffset(), currentValue.getLength());
+    addHashTableElement(partitionId, element);
+  }
+
+  private void addLongHashTableEntry(long key, BytesWritable currentValue)
+      throws InterruptedException {
+    long hashCode = HashCodeUtil.calculateLongHashCode(key);
+    addHashTableElement((int) ((numLoadThreads - 1) & hashCode),
+        HashTableElement.forLongKey(hashCode, key, copyBytes(currentValue)));
+  }
+
+  private void addBytesHashTableEntry(byte[] keyBytes, int keyOffset, int keyLength,
+      BytesWritable currentValue) throws InterruptedException {
+    byte[] keyCopy = Arrays.copyOfRange(keyBytes, keyOffset, keyOffset + keyLength);
+    long hashCode = HashCodeUtil.murmurHash(keyCopy, 0, keyCopy.length);
+    addHashTableElement((int) ((numLoadThreads - 1) & hashCode),
+        HashTableElement.forBytesKey(hashCode, keyCopy, copyBytes(currentValue)));
+  }
+
+  private static byte[] copyBytes(BytesWritable writable) {
+    return Arrays.copyOfRange(writable.getBytesRaw(), writable.getOffset(),
+        writable.getOffset() + writable.getLength());
+  }
+
+  private void addHashTableElement(int partitionId, HashTableElement element)
+      throws InterruptedException {
     if (elementBatches[partitionId].addElement(element)) {
       loadBatchQueues[partitionId].add(elementBatches[partitionId]);
       elementBatches[partitionId] = batchPool.take();
@@ -423,8 +464,14 @@ public class VectorMapJoinFastHashTableLoader implements org.apache.hadoop.hive.
     private final Output valueOutput = new Output();
     private final BytesWritable key = new BytesWritable();
     private final BytesWritable value = new BytesWritable();
+    private final BytesWritable emptyValue = new BytesWritable();
+    private final HashTableKeyType hashTableKeyType;
+    private final HashTableKind hashTableKind;
 
     VectorBatchReaderSerde(MapJoinDesc desc, int smallTablePosition) throws HiveException {
+      VectorMapJoinDesc vectorDesc = (VectorMapJoinDesc) desc.getVectorDesc();
+      hashTableKeyType = vectorDesc.getHashTableKeyType();
+      hashTableKind = vectorDesc.getHashTableKind();
       TypeInfo[] keyTypes = getTypeInfos(desc.getKeyTblDesc().getProperties()
           .getProperty(serdeConstants.LIST_COLUMN_TYPES));
       TypeInfo[] valueTypes = getTypeInfos((desc.getNoOuterJoin() ? desc.getValueTblDescs()
@@ -473,6 +520,39 @@ public class VectorMapJoinFastHashTableLoader implements org.apache.hadoop.hive.
       return batch;
     }
 
+    boolean addDirectHashTableEntry(VectorMapJoinFastHashTableLoader loader, int batchIndex)
+        throws IOException, InterruptedException {
+      if (batch.cols.length == 0) {
+        return false;
+      }
+      ColumnVector keyColumn = batch.cols[0];
+      int keyIndex = keyColumn.isRepeating ? 0 : batchIndex;
+      if (!keyColumn.noNulls && keyColumn.isNull[keyIndex]) {
+        return false;
+      }
+      // Maps retain serialized values in their value store. Sets and multisets only need the
+      // direct key, so skip value serialization for them as well.
+      BytesWritable serializedValue = hashTableKind == HashTableKind.HASH_MAP
+          ? serializeValue(batchIndex) : emptyValue;
+      switch (hashTableKeyType) {
+      case BOOLEAN:
+      case BYTE:
+      case SHORT:
+      case INT:
+      case DATE:
+      case LONG:
+        loader.addLongHashTableEntry(((LongColumnVector) keyColumn).vector[keyIndex], serializedValue);
+        return true;
+      case STRING:
+        BytesColumnVector bytesColumn = (BytesColumnVector) keyColumn;
+        loader.addBytesHashTableEntry(bytesColumn.vector[keyIndex], bytesColumn.start[keyIndex],
+            bytesColumn.length[keyIndex], serializedValue);
+        return true;
+      default:
+        return false;
+      }
+    }
+
     BytesWritable serializeKey(int batchIndex) throws IOException {
       keySerializeWrite.reset();
       keySerializer.serializeWrite(batch, batchIndex);
@@ -490,23 +570,44 @@ public class VectorMapJoinFastHashTableLoader implements org.apache.hadoop.hive.
 
   private static class HashTableElement {
     private final long hashCode;
+    private final long longKey;
+    private final boolean directLongKey;
+    private final boolean directBytesKey;
     private final byte[] keyBytes;
     private final int keyOffset, keyLength;
     private final byte[] valueBytes;
     private final int valueOffset, valueLength;
 
     public HashTableElement(long hashCode,
-                            byte[] keyBytes, int keyOffset, int keyLength,
-                            byte[] valueBytes, int valueOffset, int valueLength) {
-      this.hashCode = hashCode;
+        byte[] keyBytes, int keyOffset, int keyLength,
+        byte[] valueBytes, int valueOffset, int valueLength) {
+      this(hashCode, 0, false, false, keyBytes, keyOffset, keyLength,
+          valueBytes, valueOffset, valueLength);
+    }
 
+    private HashTableElement(long hashCode, long longKey, boolean directLongKey,
+        boolean directBytesKey, byte[] keyBytes, int keyOffset, int keyLength,
+        byte[] valueBytes, int valueOffset, int valueLength) {
+      this.hashCode = hashCode;
+      this.longKey = longKey;
+      this.directLongKey = directLongKey;
+      this.directBytesKey = directBytesKey;
       this.keyBytes = keyBytes;
       this.keyOffset = keyOffset;
       this.keyLength = keyLength;
-
       this.valueBytes = valueBytes;
       this.valueOffset = valueOffset;
       this.valueLength = valueLength;
+    }
+
+    static HashTableElement forLongKey(long hashCode, long key, byte[] valueBytes) {
+      return new HashTableElement(hashCode, key, true, false, null, 0, 0,
+          valueBytes, 0, valueBytes.length);
+    }
+
+    static HashTableElement forBytesKey(long hashCode, byte[] keyBytes, byte[] valueBytes) {
+      return new HashTableElement(hashCode, 0, false, true, keyBytes, 0, keyBytes.length,
+          valueBytes, 0, valueBytes.length);
     }
 
     public BytesWritable getKey() {
@@ -518,7 +619,31 @@ public class VectorMapJoinFastHashTableLoader implements org.apache.hadoop.hive.
     }
 
     public long getHashCode() {
-      return this.hashCode;
+      return hashCode;
+    }
+
+    public long getLongKey() {
+      return longKey;
+    }
+
+    public boolean isDirectLongKey() {
+      return directLongKey;
+    }
+
+    public boolean isDirectBytesKey() {
+      return directBytesKey;
+    }
+
+    public byte[] getKeyBytes() {
+      return keyBytes;
+    }
+
+    public int getKeyOffset() {
+      return keyOffset;
+    }
+
+    public int getKeyLength() {
+      return keyLength;
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastLongHashMap.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastLongHashMap.java
@@ -152,6 +152,10 @@ public class VectorMapJoinFastLongHashMap
     }
   }
 
+  public void putLongRow(long hashCode, long key, BytesWritable currentValue) {
+    add(hashCode, key, currentValue);
+  }
+
   @Override
   public boolean containsLongKey(long currentKey) {
     return containsKey(currentKey);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastLongHashMapContainer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastLongHashMapContainer.java
@@ -175,6 +175,12 @@ public class VectorMapJoinFastLongHashMapContainer extends VectorMapJoinFastHash
   }
 
   @Override
+  public void putLongRow(long hashCode, long key, BytesWritable currentValue) {
+    vectorMapJoinFastLongHashMaps[(int) ((numThreads - 1) & hashCode)]
+        .putLongRow(hashCode, key, currentValue);
+  }
+
+  @Override
   public void putRow(long hashCode, BytesWritable currentKey, BytesWritable currentValue)
       throws HiveException, IOException {
     // glad

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastLongHashMultiSet.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastLongHashMultiSet.java
@@ -63,6 +63,10 @@ public class VectorMapJoinFastLongHashMultiSet
     }
   }
 
+  public void putLongRow(long hashCode, long key, BytesWritable currentValue) {
+    add(hashCode, key, currentValue);
+  }
+
   @Override
   public boolean containsLongKey(long currentKey) {
     return containsKey(currentKey);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastLongHashMultiSetContainer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastLongHashMultiSetContainer.java
@@ -93,6 +93,12 @@ public class VectorMapJoinFastLongHashMultiSetContainer extends VectorMapJoinFas
   }
 
   @Override
+  public void putLongRow(long hashCode, long key, BytesWritable currentValue) {
+    vectorMapJoinFastLongHashMultiSets[(int) ((numThreads - 1) & hashCode)]
+        .putLongRow(hashCode, key, currentValue);
+  }
+
+  @Override
   public void putRow(long hashCode, BytesWritable currentKey, BytesWritable currentValue)
       throws HiveException, IOException {
     vectorMapJoinFastLongHashMultiSets[(int) ((numThreads - 1) & hashCode)].putRow(hashCode, currentKey, currentValue);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastLongHashSet.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastLongHashSet.java
@@ -56,6 +56,10 @@ public class VectorMapJoinFastLongHashSet
     adaptPutRow(hashCode, currentKey, currentValue);  // glad
   }
 
+  public void putLongRow(long hashCode, long key, BytesWritable currentValue) {
+    add(hashCode, key, currentValue);
+  }
+
   @Override
   public boolean containsLongKey(long currentKey) {
     return containsKey(currentKey);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastLongHashSetContainer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastLongHashSetContainer.java
@@ -92,6 +92,12 @@ public class VectorMapJoinFastLongHashSetContainer extends VectorMapJoinFastHash
   }
 
   @Override
+  public void putLongRow(long hashCode, long key, BytesWritable currentValue) {
+    vectorMapJoinFastLongHashSets[(int) ((numThreads - 1) & hashCode)]
+        .putLongRow(hashCode, key, currentValue);
+  }
+
+  @Override
   public void putRow(long hashCode, BytesWritable currentKey, BytesWritable currentValue)
       throws HiveException, IOException {
     vectorMapJoinFastLongHashSets[(int) ((numThreads - 1) & hashCode)].putRow(hashCode, currentKey, currentValue);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastStringHashMap.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastStringHashMap.java
@@ -45,6 +45,11 @@ public class VectorMapJoinFastStringHashMap extends VectorMapJoinFastBytesHashMa
     }
   }
 
+  public void putBytesRow(long hashCode, byte[] keyBytes, int keyOffset, int keyLength,
+      BytesWritable currentValue) {
+    add(keyBytes, keyOffset, keyLength, currentValue, hashCode);
+  }
+
   public VectorMapJoinFastStringHashMap(
           boolean isFullOuter,
           int initialCapacity, float loadFactor, int writeBuffersSize, long estimatedKeyCount, TableDesc tableDesc) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastStringHashMapContainer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastStringHashMapContainer.java
@@ -129,6 +129,13 @@ public class VectorMapJoinFastStringHashMapContainer extends VectorMapJoinFastHa
   }
 
   @Override
+  public void putBytesRow(long hashCode, byte[] keyBytes, int keyOffset, int keyLength,
+      BytesWritable currentValue) {
+    vectorMapJoinFastStringHashMaps[(int) ((numThreads - 1) & hashCode)].putBytesRow(
+        hashCode, keyBytes, keyOffset, keyLength, currentValue);
+  }
+
+  @Override
   public void putRow(long hashCode, BytesWritable currentKey, BytesWritable currentValue)
       throws HiveException, IOException {
     // glad

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastStringHashMultiSet.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastStringHashMultiSet.java
@@ -47,6 +47,11 @@ public class VectorMapJoinFastStringHashMultiSet extends VectorMapJoinFastBytesH
     }
   }
 
+  public void putBytesRow(long hashCode, byte[] keyBytes, int keyOffset, int keyLength,
+      BytesWritable currentValue) {
+    add(keyBytes, keyOffset, keyLength, currentValue, hashCode);
+  }
+
   public VectorMapJoinFastStringHashMultiSet(
       boolean isFullOuter,
       int initialCapacity, float loadFactor, int writeBuffersSize, long estimatedKeyCount, TableDesc tableDesc) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastStringHashMultiSetContainer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastStringHashMultiSetContainer.java
@@ -67,6 +67,13 @@ public class VectorMapJoinFastStringHashMultiSetContainer extends VectorMapJoinF
   }
 
   @Override
+  public void putBytesRow(long hashCode, byte[] keyBytes, int keyOffset, int keyLength,
+      BytesWritable currentValue) {
+    vectorMapJoinFastStringHashMultiSets[(int) ((numThreads - 1) & hashCode)].putBytesRow(
+        hashCode, keyBytes, keyOffset, keyLength, currentValue);
+  }
+
+  @Override
   public void putRow(long hashCode, BytesWritable currentKey, BytesWritable currentValue)
       throws HiveException, IOException {
     vectorMapJoinFastStringHashMultiSets[(int) ((numThreads - 1) & hashCode)].putRow(hashCode, currentKey, currentValue);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastStringHashSet.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastStringHashSet.java
@@ -41,6 +41,11 @@ public class VectorMapJoinFastStringHashSet extends VectorMapJoinFastBytesHashSe
     stringCommon.adaptPutRow(this, currentKey, currentValue, hashCode);   // glad
   }
 
+  public void putBytesRow(long hashCode, byte[] keyBytes, int keyOffset, int keyLength,
+      BytesWritable currentValue) {
+    add(keyBytes, keyOffset, keyLength, currentValue, hashCode);
+  }
+
   public VectorMapJoinFastStringHashSet(
       boolean isFullOuter,
       int initialCapacity, float loadFactor, int writeBuffersSize, long estimatedKeyCount, TableDesc tableDesc) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastStringHashSetContainer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastStringHashSetContainer.java
@@ -67,6 +67,13 @@ public class VectorMapJoinFastStringHashSetContainer extends VectorMapJoinFastHa
   }
 
   @Override
+  public void putBytesRow(long hashCode, byte[] keyBytes, int keyOffset, int keyLength,
+      BytesWritable currentValue) {
+    vectorMapJoinFastStringHashSets[(int) ((numThreads - 1) & hashCode)].putBytesRow(
+        hashCode, keyBytes, keyOffset, keyLength, currentValue);
+  }
+
+  @Override
   public void putRow(long hashCode, BytesWritable currentKey, BytesWritable currentValue)
       throws HiveException, IOException {
     vectorMapJoinFastStringHashSets[(int) ((numThreads - 1) & hashCode)].putRow(hashCode, currentKey, currentValue);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastTableContainer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastTableContainer.java
@@ -165,6 +165,15 @@ public class VectorMapJoinFastTableContainer implements VectorMapJoinTableContai
     return INSTANCE.getHashCode(currentKey);
   }
 
+  public void putLongRow(long hashCode, long key, BytesWritable currentValue) {
+    INSTANCE.putLongRow(hashCode, key, currentValue);
+  }
+
+  public void putBytesRow(long hashCode, byte[] keyBytes, int keyOffset, int keyLength,
+      BytesWritable currentValue) {
+    INSTANCE.putBytesRow(hashCode, keyBytes, keyOffset, keyLength, currentValue);
+  }
+
   @Override
   public MapJoinKey putRow(Writable currentKey, Writable currentValue)
       throws SerDeException, HiveException, IOException {

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/TestVectorMapJoinFastHashTableLoader.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/TestVectorMapJoinFastHashTableLoader.java
@@ -24,6 +24,9 @@ import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.ql.plan.MapJoinDesc;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
+import org.apache.hadoop.hive.ql.plan.VectorMapJoinDesc;
+import org.apache.hadoop.hive.ql.plan.VectorMapJoinDesc.HashTableKeyType;
+import org.apache.hadoop.hive.ql.plan.VectorMapJoinDesc.HashTableKind;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.io.BytesWritable;
 import org.junit.Assert;
@@ -37,6 +40,10 @@ public class TestVectorMapJoinFastHashTableLoader {
     desc.setNoOuterJoin(true);
     desc.setKeyTblDesc(tableDesc("bigint"));
     desc.setValueTblDescs(Arrays.asList(null, tableDesc("bigint")));
+    VectorMapJoinDesc vectorDesc = new VectorMapJoinDesc();
+    vectorDesc.setHashTableKeyType(HashTableKeyType.LONG);
+    vectorDesc.setHashTableKind(HashTableKind.HASH_MAP);
+    desc.setVectorDesc(vectorDesc);
 
     VectorMapJoinFastHashTableLoader.VectorBatchReaderSerde serde =
         new VectorMapJoinFastHashTableLoader.VectorBatchReaderSerde(desc, 1);

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/TestVectorMapJoinFastLongHashSet.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/TestVectorMapJoinFastLongHashSet.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hive.ql.exec.vector.mapjoin.fast.VectorMapJoinFastLongH
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
 import org.apache.hadoop.hive.ql.plan.VectorMapJoinDesc.HashTableKeyType;
+import org.apache.hive.common.util.HashCodeUtil;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -69,6 +70,17 @@ public class TestVectorMapJoinFastLongHashSet extends CommonFastHashTable {
      map.testPutRow(key);
     verifyTable.add(key);
     verifyTable.verify(map);
+  }
+
+  @Test
+  public void testPutLongRow() throws Exception {
+    VectorMapJoinFastLongHashSet map = new VectorMapJoinFastLongHashSet(
+        false, false, HashTableKeyType.LONG, CAPACITY, LOAD_FACTOR, WB_SIZE, -1, keyTableDesc);
+    long key = 42;
+
+    map.putLongRow(HashCodeUtil.calculateLongHashCode(key), key, null);
+
+    assertTrue(map.containsLongKey(key));
   }
 
   @Test


### PR DESCRIPTION
### Motivation

- Vector-batch reads currently serialize each key (and often values) then immediately deserialize them for hashtable insertion, which is wasteful for primitive and simple byte/string keys.
- The goal is to load supported vector-batch keys directly into fast hash tables to reduce CPU and GC overhead during hashtable construction.

### Description

- Added direct-key insertion APIs `putLongRow` and `putBytesRow` to `VectorMapJoinFastHashTableContainerBase` and implemented delegating/leaf methods for long-family and string/binary-family fast hash tables.
- Extended `VectorMapJoinFastHashTableLoader` to let `VectorBatchReaderSerde` probe vector batches and, when possible, enqueue `HashTableElement` objects that carry direct long or byte keys instead of serialized `BytesWritable` blobs for later parallel insertion.
- Implemented `HashTableElement` variants and helpers (`addLongHashTableEntry`, `addBytesHashTableEntry`, `addHashTableElement`) and modified the loader drain threads to dispatch direct-key calls (`putLongRow` / `putBytesRow`) into the per-partition table containers while preserving the serialized fallback for null/multi-key rows.
- Updated `VectorBatchReaderSerde` to consult `VectorMapJoinDesc` (key type and hash kind), extract primitive long keys from `LongColumnVector` or raw bytes from `BytesColumnVector`, and avoid value serialization for `HASH_SET`/`HASH_MULTISET` paths while retaining it for `HASH_MAP`.

### Testing

- Ran `git diff --check` and static diffs locally with no reported check errors.
- Attempted a Maven QL module package (`mvn -pl ql -am -DskipTests ...`) but the build was blocked when Maven could not resolve the parent POM `org.apache:apache:pom:23` from Central (HTTP 403), so a full build and unit test run did not execute.
- Added and updated unit tests to cover the new direct-path (a `testPutLongRow` test and vector-serde setup changes), but these tests were not executed due to the external Maven resolution failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ac48f0a4c8328828ef703edf0f483)