### PR TITLE
Introduce VECTOR_BATCH_KEY_BYTES constant in ReduceRecordSource

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
@@ -68,6 +68,10 @@ public class ReduceRecordSource implements RecordSource {
 
   public static final Logger l4j = LoggerFactory.getLogger(ReduceRecordSource.class);
 
+  public static final byte[] VECTOR_BATCH_KEY_BYTES = {
+      0x02
+  };
+
   private static final String CLASS_NAME = ReduceRecordSource.class.getName();
 
   private byte tag;


### PR DESCRIPTION
### Motivation
- Introduce a dedicated byte marker to identify vectorized batches in the reduce input stream to enable downstream vectorized processing logic.

### Description
- Add `public static final byte[] VECTOR_BATCH_KEY_BYTES = { 0x02 };` to `ReduceRecordSource` to serve as the canonical key bytes for vector batch records.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d5acc7e148328a82e29135abce793)