### PR TITLE
Add vector-shuffle batch serialization/deserialization between VectorReduceSink and ReduceRecordSource

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordProcessor.java
@@ -191,7 +191,7 @@ public class ReduceRecordProcessor extends RecordProcessor {
         // Check immediately after reducer is assigned, in cae the abort came in during
         checkAbortCondition();
         initializeSourceForTag(redWork, i, mainWorkOIs, sources, redWork.getTagToValueDesc().get(0),
-            redWork.getTagToInput().get(0), redWork.getTagToVectorizedRowBatchCtx().get(0));
+            redWork.getTagToInput().get(0), 0);
         reducer.initializeLocalWork(jconf);
       }
       reducer = reduceWork.getReducer();
@@ -263,12 +263,12 @@ public class ReduceRecordProcessor extends RecordProcessor {
       }
       checkAbortCondition();
       initializeSourceForTag(redWork, tag, ois, sources, redWork.getTagToValueDesc().get(tag),
-          redWork.getTagToInput().get(tag), redWork.getTagToVectorizedRowBatchCtx().get(tag));
+          redWork.getTagToInput().get(tag), tag);
     }
   }
 
   private void initializeSourceForTag(ReduceWork redWork, int tag, ObjectInspector[] ois, ReduceRecordSource[] sources,
-      TableDesc valueTableDesc, String inputName, VectorizedRowBatchCtx inputBatchContext) throws Exception {
+      TableDesc valueTableDesc, String inputName, int inputDescTag) throws Exception {
     reducer = redWork.getReducer();
     reducer.getParentOperators().clear();
     reducer.setParentOperators(null); // clear out any parents as reducer is the root
@@ -281,8 +281,11 @@ public class ReduceRecordProcessor extends RecordProcessor {
     // Only the big table input source should be vectorized (if applicable)
     // Note this behavior may have to change if we ever implement a vectorized merge join
     boolean vectorizedRecordSource = (tag == bigTablePosition) && redWork.getVectorMode();
+    // MergeJoinWork stores each input in a separate ReduceWork at descriptor index 0, while a
+    // multi-tag ReduceWork uses the input tag as its descriptor index.
     VectorizedRowBatchCtx batchContext =
-        vectorizedRecordSource ? redWork.getVectorizedRowBatchCtx() : inputBatchContext;
+        vectorizedRecordSource ? redWork.getVectorizedRowBatchCtx()
+            : redWork.getTagToVectorizedRowBatchCtx().get(inputDescTag);
     sources[tag].init(jconf, redWork.getReducer(), vectorizedRecordSource, keyTableDesc, valueTableDesc, reader,
         tag == bigTablePosition, (byte) tag, batchContext, redWork.getVectorizedVertexNum(),
         redWork.getVectorizedTestingReducerBatchSize());

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
@@ -135,6 +135,8 @@ public class ReduceRecordSource implements RecordSource {
   private final PerfLogger perfLogger = SessionState.getPerfLogger();
 
   private Iterable<? extends BytesWritable> valueWritables;
+  private Iterator<? extends BytesWritable> vectorBatchValueWritables;
+  private int vectorBatchLogicalRow;
 
   private final GroupIterator groupIterator = new GroupIterator();
 
@@ -331,6 +333,10 @@ public class ReduceRecordSource implements RecordSource {
     }
 
     try {
+      if (processNextVectorBatchRow()) {
+        return true;
+      }
+
       if (!reader.next()) {
         if (flushLastRecord) {
           reducer.flushRecursive();
@@ -345,7 +351,8 @@ public class ReduceRecordSource implements RecordSource {
       // an empty key followed by a reduce tag). Only interpret the marker for inputs that received
       // a vector batch context and initialized the vector shuffle reader.
       if (vectorShuffleBatchDeserializer != null && isVectorBatchKey(keyWritable)) {
-        processVectorBatchAsRows(valueWritables);
+        vectorBatchValueWritables = valueWritables.iterator();
+        processNextVectorBatchRow();
         return true;
       }
 
@@ -391,31 +398,39 @@ public class ReduceRecordSource implements RecordSource {
     }
   }
 
-  private void processVectorBatchAsRows(Iterable<? extends BytesWritable> values)
-      throws Exception {
+  private boolean processNextVectorBatchRow() throws Exception {
+    while (vectorBatchValueWritables != null && vectorBatchLogicalRow >= batch.size) {
+      batch.reset();
+      if (!vectorBatchValueWritables.hasNext()) {
+        vectorBatchValueWritables = null;
+        return false;
+      }
+      vectorShuffleBatchDeserializer.deserialize(vectorBatchValueWritables.next(), batch);
+      vectorBatchLogicalRow = 0;
+    }
+    if (vectorBatchValueWritables == null) {
+      return false;
+    }
+
     List<Object> row = new ArrayList<>(Utilities.reduceFieldNameList.size());
     BytesWritable keyWritable = new BytesWritable();
     BytesWritable valueWritable = new BytesWritable();
-    for (BytesWritable value : values) {
-      vectorShuffleBatchDeserializer.deserialize(value, batch);
-      for (int logical = 0; logical < batch.size; logical++) {
-        int batchIndex = batch.selectedInUse ? batch.selected[logical] : logical;
+    int batchIndex = batch.selectedInUse
+        ? batch.selected[vectorBatchLogicalRow] : vectorBatchLogicalRow;
+    vectorBatchLogicalRow++;
 
-        rowModeKeySerializeWrite.reset();
-        rowModeKeySerializeRow.serializeWrite(batch, batchIndex);
-        keyWritable.set(rowModeKeyOutput.getData(), 0, rowModeKeyOutput.getLength());
+    rowModeKeySerializeWrite.reset();
+    rowModeKeySerializeRow.serializeWrite(batch, batchIndex);
+    keyWritable.set(rowModeKeyOutput.getData(), 0, rowModeKeyOutput.getLength());
 
-        rowModeValueSerializeWrite.reset();
-        rowModeValueSerializeRow.serializeWrite(batch, batchIndex);
-        valueWritable.set(rowModeValueOutput.getData(), 0, rowModeValueOutput.getLength());
+    rowModeValueSerializeWrite.reset();
+    rowModeValueSerializeRow.serializeWrite(batch, batchIndex);
+    valueWritable.set(rowModeValueOutput.getData(), 0, rowModeValueOutput.getLength());
 
-        row.clear();
-        row.add(inputKeySerDe.deserializeBytesWritable(keyWritable));
-        row.add(inputValueSerDe.deserializeBytesWritable(valueWritable));
-        reducer.process(row, tag);
-      }
-      batch.reset();
-    }
+    row.add(inputKeySerDe.deserializeBytesWritable(keyWritable));
+    row.add(inputValueSerDe.deserializeBytesWritable(valueWritable));
+    reducer.process(row, tag);
+    return true;
   }
 
   private Object deserializeValue(BytesWritable valueWritable, byte tag)

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
@@ -164,6 +164,7 @@ public class ReduceRecordSource implements RecordSource {
 
     this.reducer = reducer;
     this.vectorized = vectorized;
+    this.batchContext = batchContext;
     this.keyTableDesc = keyTableDesc;
     if (reader instanceof KeyValueReaderEdge) {
       // for unordered key/value records
@@ -211,7 +212,6 @@ public class ReduceRecordSource implements RecordSource {
 
         rowObjectInspector = Utilities.constructVectorizedReduceRowOI(keyStructInspector,
             valueStructInspectors);
-        this.batchContext = batchContext;
         batch = batchContext.createVectorizedRowBatch();
         vectorShuffleBatchDeserializer = new VectorShuffleBatchDeserializer();
 
@@ -262,9 +262,6 @@ public class ReduceRecordSource implements RecordSource {
         rowObjectInspector =
             ObjectInspectorFactory.getStandardStructObjectInspector(Utilities.reduceFieldNameList,
                 ois);
-        if (batchContext != null) {
-          initializeRowModeVectorShuffle(batchContext, keyObjectInspector, valueObjectInspector);
-        }
       }
     } catch (Throwable e) {
       abort = true;
@@ -284,7 +281,6 @@ public class ReduceRecordSource implements RecordSource {
 
   private void initializeRowModeVectorShuffle(VectorizedRowBatchCtx batchContext,
       ObjectInspector keyObjectInspector, ObjectInspector valueObjectInspector) throws HiveException {
-    this.batchContext = batchContext;
     batch = batchContext.createVectorizedRowBatch();
     vectorShuffleBatchDeserializer = new VectorShuffleBatchDeserializer();
 
@@ -347,12 +343,15 @@ public class ReduceRecordSource implements RecordSource {
       BytesWritable keyWritable = reader.getCurrentKey();
       valueWritables = reader.getCurrentValues();
 
-      // A regular row-mode input can have the same bytes as the vector-batch marker (for example,
-      // an empty key followed by a reduce tag). Only interpret the marker for inputs that received
-      // a vector batch context and initialized the vector shuffle reader.
-      if (vectorShuffleBatchDeserializer != null && isVectorBatchKey(keyWritable)) {
+      if (batchContext != null && isVectorBatchKey(keyWritable)) {
+        if (vectorShuffleBatchDeserializer == null) {
+          initializeRowModeVectorShuffle(batchContext, inputKeySerDe.getObjectInspector(),
+              valueObjectInspector);
+        }
         vectorBatchValueWritables = valueWritables.iterator();
-        processNextVectorBatchRow();
+        if (!processNextVectorBatchRow()) {
+          throw new HiveException("Vector shuffle batch marker has no rows");
+        }
         return true;
       }
 
@@ -427,6 +426,8 @@ public class ReduceRecordSource implements RecordSource {
     rowModeValueSerializeRow.serializeWrite(batch, batchIndex);
     valueWritable.set(rowModeValueOutput.getData(), 0, rowModeValueOutput.getLength());
 
+    // Preserve the row-mode reducer ObjectInspector contract. In particular, the value object must
+    // be the LazyBinaryStruct produced by inputValueSerDe rather than an extracted standard object.
     row.add(inputKeySerDe.deserializeBytesWritable(keyWritable));
     row.add(inputValueSerDe.deserializeBytesWritable(valueWritable));
     reducer.process(row, tag);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
@@ -33,6 +33,8 @@ import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorDeserializeRow;
+import org.apache.hadoop.hive.ql.exec.vector.VectorShuffleBatchDeserializer;
+import org.apache.hadoop.hive.ql.exec.vector.VectorSerializeRow;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedBatchUtil;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatchCtx;
@@ -41,16 +43,20 @@ import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.serde2.AbstractSerDe;
+import org.apache.hadoop.hive.serde2.ByteStream.Output;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.SerDeUtils;
 import org.apache.hadoop.hive.serde2.binarysortable.BinarySortableSerDe;
 import org.apache.hadoop.hive.serde2.binarysortable.fast.BinarySortableDeserializeRead;
+import org.apache.hadoop.hive.serde2.binarysortable.fast.BinarySortableSerializeWrite;
 import org.apache.hadoop.hive.serde2.lazybinary.fast.LazyBinaryDeserializeRead;
+import org.apache.hadoop.hive.serde2.lazybinary.fast.LazyBinarySerializeWrite;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils.ObjectInspectorCopyOption;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.util.ReflectionUtils;
@@ -101,6 +107,13 @@ public class ReduceRecordSource implements RecordSource {
 
   private VectorizedRowBatchCtx batchContext;
   private VectorizedRowBatch batch;
+  private VectorShuffleBatchDeserializer vectorShuffleBatchDeserializer;
+  private VectorSerializeRow<BinarySortableSerializeWrite> rowModeKeySerializeRow;
+  private VectorSerializeRow<LazyBinarySerializeWrite> rowModeValueSerializeRow;
+  private BinarySortableSerializeWrite rowModeKeySerializeWrite;
+  private LazyBinarySerializeWrite rowModeValueSerializeWrite;
+  private Output rowModeKeyOutput;
+  private Output rowModeValueOutput;
 
   // number of columns pertaining to keys in a vectorized row batch
   private int firstValueColumnOffset;
@@ -198,6 +211,7 @@ public class ReduceRecordSource implements RecordSource {
             valueStructInspectors);
         this.batchContext = batchContext;
         batch = batchContext.createVectorizedRowBatch();
+        vectorShuffleBatchDeserializer = new VectorShuffleBatchDeserializer();
 
         // Setup vectorized deserialization for the key and value.
         BinarySortableSerDe binarySortableSerDe = (BinarySortableSerDe) inputKeySerDe;
@@ -246,6 +260,9 @@ public class ReduceRecordSource implements RecordSource {
         rowObjectInspector =
             ObjectInspectorFactory.getStandardStructObjectInspector(Utilities.reduceFieldNameList,
                 ois);
+        if (batchContext != null) {
+          initializeRowModeVectorShuffle(batchContext, keyObjectInspector, valueObjectInspector);
+        }
       }
     } catch (Throwable e) {
       abort = true;
@@ -261,6 +278,39 @@ public class ReduceRecordSource implements RecordSource {
 
   public TableDesc getKeyTableDesc() {
     return keyTableDesc;
+  }
+
+  private void initializeRowModeVectorShuffle(VectorizedRowBatchCtx batchContext,
+      ObjectInspector keyObjectInspector, ObjectInspector valueObjectInspector) throws HiveException {
+    this.batchContext = batchContext;
+    batch = batchContext.createVectorizedRowBatch();
+    vectorShuffleBatchDeserializer = new VectorShuffleBatchDeserializer();
+
+    TypeInfo[] keyTypeInfos = VectorizedBatchUtil.typeInfosFromStructObjectInspector(
+        (StructObjectInspector) keyObjectInspector);
+    TypeInfo[] valueTypeInfos = VectorizedBatchUtil.typeInfosFromStructObjectInspector(
+        (StructObjectInspector) valueObjectInspector);
+    int[] keyColumnMap = new int[keyTypeInfos.length];
+    int[] valueColumnMap = new int[valueTypeInfos.length];
+    for (int i = 0; i < keyColumnMap.length; i++) {
+      keyColumnMap[i] = i;
+    }
+    for (int i = 0; i < valueColumnMap.length; i++) {
+      valueColumnMap[i] = keyColumnMap.length + i;
+    }
+
+    rowModeKeySerializeWrite =
+        BinarySortableSerializeWrite.with(keyTableDesc.getProperties(), keyColumnMap.length);
+    rowModeKeySerializeRow = new VectorSerializeRow<>(rowModeKeySerializeWrite);
+    rowModeKeySerializeRow.init(keyTypeInfos, keyColumnMap);
+    rowModeKeyOutput = new Output();
+    rowModeKeySerializeWrite.set(rowModeKeyOutput);
+
+    rowModeValueSerializeWrite = new LazyBinarySerializeWrite(valueColumnMap.length);
+    rowModeValueSerializeRow = new VectorSerializeRow<>(rowModeValueSerializeWrite);
+    rowModeValueSerializeRow.init(valueTypeInfos, valueColumnMap);
+    rowModeValueOutput = new Output();
+    rowModeValueSerializeRow.setOutput(rowModeValueOutput);
   }
 
   @Override
@@ -290,6 +340,11 @@ public class ReduceRecordSource implements RecordSource {
 
       BytesWritable keyWritable = reader.getCurrentKey();
       valueWritables = reader.getCurrentValues();
+
+      if (isVectorBatchKey(keyWritable)) {
+        processVectorBatchAsRows(valueWritables);
+        return true;
+      }
 
       //Set the key, check if this is a new group or same group
       try {
@@ -330,6 +385,33 @@ public class ReduceRecordSource implements RecordSource {
         l4j.error(StringUtils.stringifyException(e));
         throw new RuntimeException(e);
       }
+    }
+  }
+
+  private void processVectorBatchAsRows(Iterable<? extends BytesWritable> values)
+      throws Exception {
+    List<Object> row = new ArrayList<>(Utilities.reduceFieldNameList.size());
+    BytesWritable keyWritable = new BytesWritable();
+    BytesWritable valueWritable = new BytesWritable();
+    for (BytesWritable value : values) {
+      vectorShuffleBatchDeserializer.deserialize(value, batch);
+      for (int logical = 0; logical < batch.size; logical++) {
+        int batchIndex = batch.selectedInUse ? batch.selected[logical] : logical;
+
+        rowModeKeySerializeWrite.reset();
+        rowModeKeySerializeRow.serializeWrite(batch, batchIndex);
+        keyWritable.set(rowModeKeyOutput.getData(), 0, rowModeKeyOutput.getLength());
+
+        rowModeValueSerializeWrite.reset();
+        rowModeValueSerializeRow.serializeWrite(batch, batchIndex);
+        valueWritable.set(rowModeValueOutput.getData(), 0, rowModeValueOutput.getLength());
+
+        row.clear();
+        row.add(inputKeySerDe.deserializeBytesWritable(keyWritable));
+        row.add(inputValueSerDe.deserializeBytesWritable(valueWritable));
+        reducer.process(row, tag);
+      }
+      batch.reset();
     }
   }
 
@@ -500,6 +582,19 @@ public class ReduceRecordSource implements RecordSource {
     }
     Preconditions.checkState(batch.size == 0);
 
+    if (isVectorBatchKey(keyWritable)) {
+      try {
+        vectorShuffleBatchDeserializer.deserialize(valueWritable, batch);
+        reducer.process(batch, tag);
+        if (!reducer.batchNeedsClone()) {
+          batch.reset();
+        }
+        return;
+      } catch (Exception e) {
+        throw new HiveException("Unable to deserialize vector shuffle batch", e);
+      }
+    }
+
     // Deserialize key into vector row columns.
     byte[] keyBytes = keyWritable.getBytesRaw();
     int keyOffset = keyWritable.getOffset();
@@ -544,6 +639,11 @@ public class ReduceRecordSource implements RecordSource {
       throw new HiveException("Hive Runtime Error while processing vector batch (tag="
           + tag + ") (vectorizedVertexNum " + vectorizedVertexNum + ")", e);
     }
+  }
+
+  private boolean isVectorBatchKey(BytesWritable keyWritable) {
+    return keyWritable.getLength() == VECTOR_BATCH_KEY_BYTES.length
+        && keyWritable.getBytesRaw()[keyWritable.getOffset()] == VECTOR_BATCH_KEY_BYTES[0];
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
@@ -341,7 +341,10 @@ public class ReduceRecordSource implements RecordSource {
       BytesWritable keyWritable = reader.getCurrentKey();
       valueWritables = reader.getCurrentValues();
 
-      if (isVectorBatchKey(keyWritable)) {
+      // A regular row-mode input can have the same bytes as the vector-batch marker (for example,
+      // an empty key followed by a reduce tag). Only interpret the marker for inputs that received
+      // a vector batch context and initialized the vector shuffle reader.
+      if (vectorShuffleBatchDeserializer != null && isVectorBatchKey(keyWritable)) {
         processVectorBatchAsRows(valueWritables);
         return true;
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
@@ -349,9 +349,7 @@ public class ReduceRecordSource implements RecordSource {
               valueObjectInspector);
         }
         vectorBatchValueWritables = valueWritables.iterator();
-        if (!processNextVectorBatchRow()) {
-          throw new HiveException("Vector shuffle batch marker has no rows");
-        }
+        processNextVectorBatchRow();
         return true;
       }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
@@ -29,8 +29,11 @@ import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.exec.TerminalOperator;
 import org.apache.hadoop.hive.ql.exec.TopNHash;
 import org.apache.hadoop.hive.ql.exec.Utilities;
+import org.apache.hadoop.hive.ql.exec.tez.ReduceRecordSource;
 import org.apache.hadoop.hive.ql.exec.tez.TezProcessor;
+import org.apache.hadoop.hive.ql.exec.vector.VectorShuffleBatchSerializer;
 import org.apache.hadoop.hive.ql.exec.vector.VectorSerializeRow;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizationContext;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizationContextRegion;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizationOperator;
@@ -123,6 +126,10 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
   // The hive key and bytes writable value needed to pass the key and value to the collector.
   protected transient HiveKey keyWritable;
   protected transient BytesWritable valueBytesWritable;
+
+  private transient VectorShuffleBatchSerializer vectorShuffleBatchSerializer;
+  private transient int[] vectorShuffleBatchColumnMap;
+  private transient HiveKey vectorShuffleBatchKey;
 
   // Picks topN K:V pairs from input.
   protected transient TopNHash reducerHash;
@@ -301,7 +308,34 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
       reducerHash.initialize(limit, memUsage, conf.isMapGroupBy(), this, conf, hconf);
     }
 
+    if (conf.isVectorShuffleBatchEnabled() && reducerHash == null) {
+      vectorShuffleBatchSerializer = new VectorShuffleBatchSerializer();
+      final int keyColumnCount = isEmptyKey ? 0 : reduceSinkKeyColumnMap.length;
+      final int valueColumnCount = isEmptyValue ? 0 : reduceSinkValueColumnMap.length;
+      vectorShuffleBatchColumnMap = new int[keyColumnCount + valueColumnCount];
+      if (keyColumnCount > 0) {
+        System.arraycopy(reduceSinkKeyColumnMap, 0, vectorShuffleBatchColumnMap, 0, keyColumnCount);
+      }
+      if (valueColumnCount > 0) {
+        System.arraycopy(reduceSinkValueColumnMap, 0, vectorShuffleBatchColumnMap, keyColumnCount,
+            valueColumnCount);
+      }
+      vectorShuffleBatchKey = new HiveKey(ReduceRecordSource.VECTOR_BATCH_KEY_BYTES, 0);
+      vectorShuffleBatchKey.setDistKeyLength(ReduceRecordSource.VECTOR_BATCH_KEY_BYTES.length);
+    }
+
     batchCounter = 0;
+  }
+
+  protected boolean tryCollectVectorShuffleBatch(VectorizedRowBatch batch)
+      throws IOException {
+    if (vectorShuffleBatchSerializer == null || out == null
+        || out.getNumUnorderedPartitions() != 1) {
+      return false;
+    }
+    vectorShuffleBatchSerializer.serialize(batch, vectorShuffleBatchColumnMap, valueBytesWritable);
+    doCollect(vectorShuffleBatchKey, valueBytesWritable);
+    return true;
   }
 
   protected void initializeEmptyKey(int tag) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
@@ -333,6 +333,12 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
         || out.getNumUnorderedPartitions() != 1) {
       return false;
     }
+    // Expressions evaluated by the concrete reduce-sink operator can filter every row after its
+    // initial empty-batch check. Treat that batch as handled without emitting an empty shuffle
+    // record, matching the per-row serialization path.
+    if (batch.size == 0) {
+      return true;
+    }
     vectorShuffleBatchSerializer.serialize(batch, vectorShuffleBatchColumnMap, valueBytesWritable);
     doCollect(vectorShuffleBatchKey, valueBytesWritable);
     return true;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkEmptyKeyOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkEmptyKeyOperator.java
@@ -102,6 +102,10 @@ public class VectorReduceSinkEmptyKeyOperator extends VectorReduceSinkCommonOper
         }
       }
 
+      if (tryCollectVectorShuffleBatch(batch)) {
+        return;
+      }
+
       final int size = batch.size;
       if (!isEmptyValue) {
         if (batch.selectedInUse) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkObjectHashOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkObjectHashOperator.java
@@ -234,6 +234,10 @@ public class VectorReduceSinkObjectHashOperator extends VectorReduceSinkCommonOp
         }
       }
 
+      if (tryCollectVectorShuffleBatch(batch)) {
+        return;
+      }
+
       // Perform any bucket expressions.  Results will go into scratch columns.
       if (reduceSinkBucketExpressions != null) {
         for (VectorExpression ve : reduceSinkBucketExpressions) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkUniformHashOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkUniformHashOperator.java
@@ -121,6 +121,10 @@ public abstract class VectorReduceSinkUniformHashOperator extends VectorReduceSi
         }
       }
 
+      if (tryCollectVectorShuffleBatch(batch)) {
+        return;
+      }
+
       serializedKeySeries.processBatch(batch);
 
       boolean selectedInUse = batch.selectedInUse;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
@@ -1067,6 +1067,7 @@ public class Vectorizer implements PhysicalPlanResolver {
 
             // Always set the EXPLAIN conditions.
             setMergeJoinWorkExplainConditions(mergeJoinWork);
+            setMergeJoinWorkInputVectorizedRowBatchCtxs(mergeJoinWork);
 
             logMergeJoinWorkExplainVectorization(mergeJoinWork);
           }
@@ -1113,6 +1114,19 @@ public class Vectorizer implements PhysicalPlanResolver {
         if (valueTableDesc != null) {
           tagToBatchCtx.put(tag, createReduceInputVectorizedRowBatchCtx(reduceWork.getKeyDesc(),
               valueTableDesc));
+        }
+      }
+    }
+
+    private void setMergeJoinWorkInputVectorizedRowBatchCtxs(MergeJoinWork mergeJoinWork)
+        throws SemanticException {
+      BaseWork mainWork = mergeJoinWork.getMainWork();
+      if (mainWork instanceof ReduceWork) {
+        setReduceWorkInputVectorizedRowBatchCtxs((ReduceWork) mainWork);
+      }
+      for (BaseWork mergeWork : mergeJoinWork.getBaseWorkList()) {
+        if (mergeWork instanceof ReduceWork) {
+          setReduceWorkInputVectorizedRowBatchCtxs((ReduceWork) mergeWork);
         }
       }
     }


### PR DESCRIPTION
### Motivation

- Enable an optimized path to shuffle entire `VectorizedRowBatch` objects through the shuffle boundary instead of per-row serialization for vectorized execution.

### Description

- Introduce a vector-batch marker `VECTOR_BATCH_KEY_BYTES` and detection via `isVectorBatchKey` to identify vectorized shuffle records in `ReduceRecordSource`. 
- Add a `VectorShuffleBatchDeserializer` and logic in `ReduceRecordSource` to directly deserialize a shuffled vector batch and pass it to vectorized reducers, including a fallback that converts vector batches to row-mode key/value pairs via `initializeRowModeVectorShuffle` and `processVectorBatchAsRows` for non-vector reducers. 
- Add row-mode serializers `VectorSerializeRow` / `BinarySortableSerializeWrite` / `LazyBinarySerializeWrite` and buffers to support converting deserialized vector batches into row-mode key/value `BytesWritable` when needed. 
- Add `VectorShuffleBatchSerializer` support to `VectorReduceSinkCommonOperator` and create a `tryCollectVectorShuffleBatch` helper to emit a single shuffled vector batch record (with a special `HiveKey`) when the configuration enables vector shuffle and conditions allow; assemble a column map and key for the serializer. 
- Wire `tryCollectVectorShuffleBatch` into the vector reduce-sink operator implementations (`VectorReduceSinkEmptyKeyOperator`, `VectorReduceSinkObjectHashOperator`, `VectorReduceSinkUniformHashOperator`) so they short-circuit per-row collection when a vector shuffle batch is emitted. 
- Add required imports and class members to store serializer/deserializer instances and outputs; initialize them during operator setup.

### Testing

- Project was compiled to ensure the changes build (`mvn -DskipTests package` succeeded). 
- No automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d641aa1a483289244c32f9f23f0dc)