### PR TITLE
Set configured output buffer size for MR3 broadcast edges

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/DAGUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/DAGUtils.java
@@ -921,11 +921,15 @@ public class DAGUtils {
     EdgeType edgeType = edgeProp.getEdgeType();
     switch (edgeType) {
     case BROADCAST_EDGE:
-      UnorderedKVEdgeConfig et1Conf = UnorderedKVEdgeConfig
+      UnorderedKVEdgeConfig.Builder et1Conf = UnorderedKVEdgeConfig
           .newBuilder(keyClass, valClass)
-          .setFromConfiguration(conf)
-          .build();
-      return et1Conf.createDefaultBroadcastEdgeProperty();
+          .setFromConfiguration(conf);
+      if (edgeProp.getBufferSize() != null) {
+        et1Conf.setAdditionalConfiguration(
+            TezRuntimeConfiguration.TEZ_RUNTIME_UNORDERED_OUTPUT_BUFFER_SIZE_MB,
+            edgeProp.getBufferSize().toString());
+      }
+      return et1Conf.build().createDefaultBroadcastEdgeProperty();
     case CUSTOM_EDGE:
       UnorderedPartitionedKVEdgeConfig et2Conf = UnorderedPartitionedKVEdgeConfig
           .newBuilder(keyClass, valClass, HashPartitioner.class.getName())


### PR DESCRIPTION
### Motivation
- Ensure a `TezEdgeProperty` buffer size set via `TezEdgeProperty.setBufferSize()` is honored for MR3 `BROADCAST_EDGE` the same way it is for `CUSTOM_SIMPLE_EDGE` so edge-specific output-buffer overrides are respected.

### Description
- In `ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/DAGUtils.java` update `createTezEdgeProperty` so the `BROADCAST_EDGE` branch uses `UnorderedKVEdgeConfig.Builder` and, when `edgeProp.getBufferSize()` is non-null, calls `setAdditionalConfiguration(TezRuntimeConfiguration.TEZ_RUNTIME_UNORDERED_OUTPUT_BUFFER_SIZE_MB, edgeProp.getBufferSize().toString())` before building the edge property.

### Testing
- Ran `git diff --check` which produced no issues and the patch was applied cleanly. 
- Attempted `mvn -pl ql -am -DskipTests -Dcheckstyle.skip -Drat.skip package` but the build could not complete due to an external Maven parent POM resolution error (HTTP 403) while fetching `org.apache:apache:pom:23`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fd54a17c08328b10bc90e92de0a22)