### PR TITLE
Add serialization-free value hash computation for vectorized ReduceSink

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.ql.exec.vector.reducesink;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Properties;
 
@@ -31,6 +32,7 @@ import org.apache.hadoop.hive.ql.exec.TopNHash;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.exec.tez.ReduceRecordSource;
 import org.apache.hadoop.hive.ql.exec.tez.TezProcessor;
+import org.apache.hadoop.hive.ql.exec.vector.VectorExtractRow;
 import org.apache.hadoop.hive.ql.exec.vector.VectorShuffleBatchSerializer;
 import org.apache.hadoop.hive.ql.exec.vector.VectorSerializeRow;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
@@ -52,7 +54,10 @@ import org.apache.hadoop.hive.serde2.ByteStream.Output;
 import org.apache.hadoop.hive.serde2.binarysortable.BinarySortableSerDe;
 import org.apache.hadoop.hive.serde2.binarysortable.fast.BinarySortableSerializeWrite;
 import org.apache.hadoop.hive.serde2.lazybinary.fast.LazyBinarySerializeWrite;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.mapred.OutputCollector;
 import org.slf4j.Logger;
@@ -148,6 +153,12 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
 
   // Scratch hash codes for active rows in the current batch, indexed by physical row.
   protected transient int[] batchKeyHashCodes;
+  protected transient int[] batchValueHashCodes;
+
+  private transient VectorExtractRow valueVectorExtractRow;
+  private transient Object[] valueFieldValues;
+  private transient ObjectInspector[] valueObjectInspectors;
+  private transient ByteBuffer valueHashByteBuffer;
 
   //---------------------------------------------------------------------------
 
@@ -329,6 +340,11 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
 
     batchCounter = 0;
     batchKeyHashCodes = null;
+    batchValueHashCodes = null;
+    valueVectorExtractRow = null;
+    valueFieldValues = null;
+    valueObjectInspectors = null;
+    valueHashByteBuffer = null;
   }
 
   protected int[] ensureBatchKeyHashCodes(VectorizedRowBatch batch) {
@@ -337,6 +353,14 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
       batchKeyHashCodes = new int[minimumLength];
     }
     return batchKeyHashCodes;
+  }
+
+  protected int[] ensureBatchValueHashCodes(VectorizedRowBatch batch) {
+    final int minimumLength = batch.selected.length;
+    if (batchValueHashCodes == null || batchValueHashCodes.length < minimumLength) {
+      batchValueHashCodes = new int[minimumLength];
+    }
+    return batchValueHashCodes;
   }
 
   protected boolean tryCollectVectorShuffleBatch(VectorizedRowBatch batch)
@@ -364,6 +388,58 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
    */
   protected abstract void computeKeyHashCodes(VectorizedRowBatch batch, int[] hashCodes)
       throws HiveException;
+
+  private void initializeValueHashCodeScratch() throws HiveException {
+    if (isEmptyValue || valueVectorExtractRow != null) {
+      return;
+    }
+
+    valueVectorExtractRow = new VectorExtractRow();
+    valueVectorExtractRow.init(reduceSinkValueTypeInfos, reduceSinkValueColumnMap);
+    valueFieldValues = new Object[reduceSinkValueTypeInfos.length];
+    valueObjectInspectors = new ObjectInspector[reduceSinkValueTypeInfos.length];
+    for (int i = 0; i < reduceSinkValueTypeInfos.length; i++) {
+      valueObjectInspectors[i] =
+          TypeInfoUtils.getStandardWritableObjectInspectorFromTypeInfo(reduceSinkValueTypeInfos[i]);
+    }
+    valueHashByteBuffer = ByteBuffer.allocate(8);
+  }
+
+  /**
+   * Computes serialization-free value hash codes for all active rows in the batch.
+   *
+   * This helper intentionally does not serialize values or match any serialized-value hash.
+   * The result is indexed by physical batch row number. When batch.selectedInUse is true,
+   * only entries for batch.selected[0..batch.size) are required to be valid.
+   */
+  protected void computeValueHashCodes(VectorizedRowBatch batch, int[] hashCodes)
+      throws HiveException {
+    final boolean selectedInUse = batch.selectedInUse;
+    final int[] selected = batch.selected;
+    final int size = batch.size;
+
+    if (isEmptyValue) {
+      for (int logical = 0; logical < size; logical++) {
+        final int batchIndex = (selectedInUse ? selected[logical] : logical);
+        hashCodes[batchIndex] = 0;
+      }
+      return;
+    }
+
+    initializeValueHashCodeScratch();
+
+    for (int logical = 0; logical < size; logical++) {
+      final int batchIndex = (selectedInUse ? selected[logical] : logical);
+      valueVectorExtractRow.extractRow(batch, batchIndex, valueFieldValues);
+
+      int hashCode = 0;
+      for (int i = 0; i < valueFieldValues.length; i++) {
+        hashCode = 31 * hashCode + ObjectInspectorUtils.hashCodeMurmur(
+            valueFieldValues[i], valueObjectInspectors[i], valueHashByteBuffer);
+      }
+      hashCodes[batchIndex] = hashCode;
+    }
+  }
 
   protected void initializeEmptyKey(int tag) {
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
@@ -146,6 +146,9 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
   // Debug display.
   protected transient long batchCounter;
 
+  // Scratch hash codes for active rows in the current batch, indexed by physical row.
+  protected transient int[] batchKeyHashCodes;
+
   //---------------------------------------------------------------------------
 
   /** Kryo ctor. */
@@ -325,6 +328,15 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
     }
 
     batchCounter = 0;
+    batchKeyHashCodes = null;
+  }
+
+  protected int[] ensureBatchKeyHashCodes(VectorizedRowBatch batch) {
+    final int minimumLength = batch.selected.length;
+    if (batchKeyHashCodes == null || batchKeyHashCodes.length < minimumLength) {
+      batchKeyHashCodes = new int[minimumLength];
+    }
+    return batchKeyHashCodes;
   }
 
   protected boolean tryCollectVectorShuffleBatch(VectorizedRowBatch batch)
@@ -343,6 +355,15 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
     doCollect(vectorShuffleBatchKey, valueBytesWritable);
     return true;
   }
+
+  /**
+   * Computes reducer-routing hash codes for all active rows in the batch.
+   *
+   * The result is indexed by physical batch row number. When batch.selectedInUse is true,
+   * only entries for batch.selected[0..batch.size) are required to be valid.
+   */
+  protected abstract void computeKeyHashCodes(VectorizedRowBatch batch, int[] hashCodes)
+      throws HiveException;
 
   protected void initializeEmptyKey(int tag) {
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkEmptyKeyOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkEmptyKeyOperator.java
@@ -74,6 +74,21 @@ public class VectorReduceSinkEmptyKeyOperator extends VectorReduceSinkCommonOper
   }
 
   @Override
+  protected void computeKeyHashCodes(VectorizedRowBatch batch, int[] hashCodes) throws HiveException {
+    final int size = batch.size;
+    if (batch.selectedInUse) {
+      final int[] selected = batch.selected;
+      for (int logical = 0; logical < size; logical++) {
+        hashCodes[selected[logical]] = 0;
+      }
+    } else {
+      for (int batchIndex = 0; batchIndex < size; batchIndex++) {
+        hashCodes[batchIndex] = 0;
+      }
+    }
+  }
+
+  @Override
   public void process(Object row, int tag) throws HiveException {
 
     try {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkObjectHashOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkObjectHashOperator.java
@@ -292,6 +292,44 @@ public class VectorReduceSinkObjectHashOperator extends VectorReduceSinkCommonOp
     }
   }
 
+
+  @Override
+  protected void computeKeyHashCodes(VectorizedRowBatch batch, int[] hashCodes) throws HiveException {
+    final boolean selectedInUse = batch.selectedInUse;
+    final int[] selected = batch.selected;
+    final int size = batch.size;
+
+    for (int logical = 0; logical < size; logical++) {
+      final int batchIndex = (selectedInUse ? selected[logical] : logical);
+      int hashCode;
+      if (isEmptyPartitions) {
+        if (isSingleReducer) {
+          // Empty partition, single reducer -> constant hashCode
+          hashCode = 0;
+        } else {
+          // Empty partition, multiple reducers -> random hashCode
+          hashCode = nonPartitionRandom.nextInt();
+        }
+      } else {
+        // Compute hashCode from partitions
+        partitionVectorExtractRow.extractRow(batch, batchIndex, partitionFieldValues);
+        hashCode = partitionHashFunc.applyAsInt(partitionFieldValues);
+      }
+
+      // Compute hashCode from buckets
+      if (!isEmptyBuckets) {
+        bucketVectorExtractRow.extractRow(batch, batchIndex, bucketFieldValues);
+        final int bucketNum = ObjectInspectorUtils.getBucketNumber(
+            bucketHashFunc.applyAsInt(bucketFieldValues), numBuckets);
+        if (bucketExpr != null) {
+          evaluateBucketExpr(batch, batchIndex, bucketNum);
+        }
+        hashCode = hashCode * 31 + bucketNum;
+      }
+      hashCodes[batchIndex] = hashCode;
+    }
+  }
+
   private void processKey(VectorizedRowBatch batch, int batchIndex, int tag)
   throws HiveException{
     if (isEmptyKey) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkUniformHashOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkUniformHashOperator.java
@@ -18,8 +18,11 @@
 
 package org.apache.hadoop.hive.ql.exec.vector.reducesink;
 
+import java.nio.ByteBuffer;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.CompilationOpContext;
+import org.apache.hadoop.hive.ql.exec.vector.VectorExtractRow;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizationContext;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.ql.exec.vector.expressions.VectorExpression;
@@ -28,6 +31,9 @@ import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.VectorDesc;
 import org.apache.hadoop.hive.serde2.ByteStream.Output;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.hive.common.util.Murmur3;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,6 +61,12 @@ public abstract class VectorReduceSinkUniformHashOperator extends VectorReduceSi
 
   // The object that determines equal key series.
   protected transient VectorKeySeriesSerialized serializedKeySeries;
+
+  // Serialization-free key hash support.
+  private transient VectorExtractRow keyVectorExtractRow;
+  private transient Object[] keyFieldValues;
+  private transient ObjectInspector[] keyObjectInspectors;
+  private transient ByteBuffer keyHashByteBuffer;
 
 
   /** Kryo ctor. */
@@ -87,8 +99,50 @@ public abstract class VectorReduceSinkUniformHashOperator extends VectorReduceSi
       nullBytes = new byte[nullBytesLength];
       System.arraycopy(nullKeyOutput.getData(), 0, nullBytes, 0, nullBytesLength);
       nullKeyHashCode = Murmur3.hash32(nullBytes, 0, nullBytesLength, 0);
+
+      keyVectorExtractRow = null;
+      keyFieldValues = null;
+      keyObjectInspectors = null;
+      keyHashByteBuffer = null;
     } catch (Exception e) {
       throw new HiveException(e);
+    }
+  }
+
+  private void initializeKeyHashCodeScratch() throws HiveException {
+    if (keyVectorExtractRow != null) {
+      return;
+    }
+
+    keyVectorExtractRow = new VectorExtractRow();
+    keyVectorExtractRow.init(reduceSinkKeyTypeInfos, reduceSinkKeyColumnMap);
+    keyFieldValues = new Object[reduceSinkKeyTypeInfos.length];
+    keyObjectInspectors = new ObjectInspector[reduceSinkKeyTypeInfos.length];
+    for (int i = 0; i < reduceSinkKeyTypeInfos.length; i++) {
+      keyObjectInspectors[i] =
+          TypeInfoUtils.getStandardWritableObjectInspectorFromTypeInfo(reduceSinkKeyTypeInfos[i]);
+    }
+    keyHashByteBuffer = ByteBuffer.allocate(8);
+  }
+
+  @Override
+  protected void computeKeyHashCodes(VectorizedRowBatch batch, int[] hashCodes) throws HiveException {
+    initializeKeyHashCodeScratch();
+
+    final boolean selectedInUse = batch.selectedInUse;
+    final int[] selected = batch.selected;
+    final int size = batch.size;
+
+    for (int logical = 0; logical < size; logical++) {
+      final int batchIndex = (selectedInUse ? selected[logical] : logical);
+      keyVectorExtractRow.extractRow(batch, batchIndex, keyFieldValues);
+
+      int hashCode = 0;
+      for (int i = 0; i < keyFieldValues.length; i++) {
+        hashCode = 31 * hashCode + ObjectInspectorUtils.hashCodeMurmur(
+            keyFieldValues[i], keyObjectInspectors[i], keyHashByteBuffer);
+      }
+      hashCodes[batchIndex] = hashCode;
     }
   }
 


### PR DESCRIPTION
### Motivation
- Provide a fast, serialization-free way to compute hash codes for reduce-sink values in the vectorized path to support routing and TopN logic.
- Prepare internal scratch structures to avoid serializing values when only a hash is required for reducer routing.
- Preserve behavior for empty values while enabling efficient per-batch value hashing for active rows.

### Description
- Added new fields to `VectorReduceSinkCommonOperator` to hold value hash scratch state: `batchValueHashCodes`, `valueVectorExtractRow`, `valueFieldValues`, `valueObjectInspectors`, and `valueHashByteBuffer` and corresponding imports for `VectorExtractRow`, `ObjectInspector`, `ObjectInspectorUtils`, and `TypeInfoUtils`.
- Initialized these scratch fields to `null` in `initializeOp` and added `ensureBatchValueHashCodes` to lazily size the `batchValueHashCodes` array.
- Implemented `initializeValueHashCodeScratch` to set up `VectorExtractRow`, field value arrays, object inspectors and a `ByteBuffer` for hashing based on `reduceSinkValueTypeInfos` and `reduceSinkValueColumnMap`.
- Implemented `computeValueHashCodes(VectorizedRowBatch, int[])` to fill per-physical-row value hash codes without serializing values, using `VectorExtractRow.extractRow` and `ObjectInspectorUtils.hashCodeMurmur` and to handle `isEmptyValue` efficiently.

### Testing
- No automated tests were added or modified for this change.
- No automated test runs were performed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a329b59f8288328a4c6606f9f37a70b)