### PR TITLE
Implement partition-aware vector shuffle batches

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
@@ -428,6 +428,11 @@ public class TezProcessor extends AbstractLogicalIOProcessor {
       writer.write(key, value);
     }
 
+    public void writeWithPartition(BytesWritable key, BytesWritable value, int partition)
+        throws IOException {
+      writer.writeWithPartition(key, value, partition);
+    }
+
     public void close() {
       writer.closeWriter();
     }
@@ -437,6 +442,12 @@ public class TezProcessor extends AbstractLogicalIOProcessor {
     //   -1: ordered edge
     public int getNumUnorderedPartitions() {
       return writer.getNumUnorderedPartitions();
+    }
+
+    // return value = 0: use key hash to get partition
+    // return value = 1: use value hash to get partition
+    public int getPartitionerType() {
+      return writer.getPartitionerType();
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorShuffleBatchSerializer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorShuffleBatchSerializer.java
@@ -62,6 +62,40 @@ public final class VectorShuffleBatchSerializer {
     output.set(buffer.getData(), 0, buffer.getLength());
   }
 
+  public void serialize(VectorizedRowBatch source, int[] sourceColumnMap, int[] rowIndices,
+      int rowCount, BytesWritable output) throws IOException {
+    serialize(source, sourceColumnMap, rowIndices, 0, rowCount, output);
+  }
+
+  public void serialize(VectorizedRowBatch source, int[] sourceColumnMap, int[] rowIndices,
+      int rowOffset, int rowCount, BytesWritable output) throws IOException {
+    if (source == null || sourceColumnMap == null || rowIndices == null || output == null) {
+      throw new IllegalArgumentException(
+          "Source batch, source column map, row indices, and output are required");
+    }
+    if (rowOffset < 0 || rowCount < 0 || rowOffset > rowIndices.length - rowCount) {
+      throw new IllegalArgumentException(
+          "Invalid row offset " + rowOffset + " and row count " + rowCount
+              + " for " + rowIndices.length + " row indices");
+    }
+    int[] logicalRows = rowIndices;
+    if (rowOffset != 0) {
+      logicalRows = new int[rowCount];
+      System.arraycopy(rowIndices, rowOffset, logicalRows, 0, rowCount);
+    }
+
+    buffer.reset();
+    WritableUtils.writeVInt(buffer, rowCount);
+    WritableUtils.writeVInt(buffer, sourceColumnMap.length);
+    for (int sourceColumn : sourceColumnMap) {
+      if (sourceColumn < 0 || sourceColumn >= source.cols.length || source.cols[sourceColumn] == null) {
+        throw new IllegalArgumentException("Invalid source column " + sourceColumn);
+      }
+      writeColumn(source.cols[sourceColumn], logicalRows, rowCount);
+    }
+    output.set(buffer.getData(), 0, buffer.getLength());
+  }
+
   private void writeColumn(ColumnVector column, int[] indices, int count) throws IOException {
     final boolean repeating = column.isRepeating;
     final int valueCount = repeating ? Math.min(count, 1) : count;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.ql.exec.vector.reducesink;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Properties;
 
@@ -31,6 +32,7 @@ import org.apache.hadoop.hive.ql.exec.TopNHash;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.exec.tez.ReduceRecordSource;
 import org.apache.hadoop.hive.ql.exec.tez.TezProcessor;
+import org.apache.hadoop.hive.ql.exec.vector.VectorExtractRow;
 import org.apache.hadoop.hive.ql.exec.vector.VectorShuffleBatchSerializer;
 import org.apache.hadoop.hive.ql.exec.vector.VectorSerializeRow;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
@@ -52,7 +54,10 @@ import org.apache.hadoop.hive.serde2.ByteStream.Output;
 import org.apache.hadoop.hive.serde2.binarysortable.BinarySortableSerDe;
 import org.apache.hadoop.hive.serde2.binarysortable.fast.BinarySortableSerializeWrite;
 import org.apache.hadoop.hive.serde2.lazybinary.fast.LazyBinarySerializeWrite;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.mapred.OutputCollector;
 import org.slf4j.Logger;
@@ -148,6 +153,12 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
 
   // Scratch hash codes for active rows in the current batch, indexed by physical row.
   protected transient int[] batchKeyHashCodes;
+  protected transient int[] batchValueHashCodes;
+
+  private transient VectorExtractRow valueVectorExtractRow;
+  private transient Object[] valueFieldValues;
+  private transient ObjectInspector[] valueObjectInspectors;
+  private transient ByteBuffer valueHashByteBuffer;
 
   //---------------------------------------------------------------------------
 
@@ -329,6 +340,11 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
 
     batchCounter = 0;
     batchKeyHashCodes = null;
+    batchValueHashCodes = null;
+    valueVectorExtractRow = null;
+    valueFieldValues = null;
+    valueObjectInspectors = null;
+    valueHashByteBuffer = null;
   }
 
   protected int[] ensureBatchKeyHashCodes(VectorizedRowBatch batch) {
@@ -337,6 +353,14 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
       batchKeyHashCodes = new int[minimumLength];
     }
     return batchKeyHashCodes;
+  }
+
+  protected int[] ensureBatchValueHashCodes(VectorizedRowBatch batch) {
+    final int minimumLength = batch.selected.length;
+    if (batchValueHashCodes == null || batchValueHashCodes.length < minimumLength) {
+      batchValueHashCodes = new int[minimumLength];
+    }
+    return batchValueHashCodes;
   }
 
   protected boolean tryCollectVectorShuffleBatch(VectorizedRowBatch batch)
@@ -364,6 +388,58 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
    */
   protected abstract void computeKeyHashCodes(VectorizedRowBatch batch, int[] hashCodes)
       throws HiveException;
+
+  private void initializeValueHashCodeScratch() throws HiveException {
+    if (isEmptyValue || valueVectorExtractRow != null) {
+      return;
+    }
+
+    valueVectorExtractRow = new VectorExtractRow();
+    valueVectorExtractRow.init(reduceSinkValueTypeInfos, reduceSinkValueColumnMap);
+    valueFieldValues = new Object[reduceSinkValueTypeInfos.length];
+    valueObjectInspectors = new ObjectInspector[reduceSinkValueTypeInfos.length];
+    for (int i = 0; i < reduceSinkValueTypeInfos.length; i++) {
+      valueObjectInspectors[i] =
+          TypeInfoUtils.getStandardWritableObjectInspectorFromTypeInfo(reduceSinkValueTypeInfos[i]);
+    }
+    valueHashByteBuffer = ByteBuffer.allocate(8);
+  }
+
+  /**
+   * Computes serialization-free value hash codes for all active rows in the batch.
+   *
+   * This helper intentionally does not serialize values or match any serialized-value hash.
+   * The result is indexed by physical batch row number. When batch.selectedInUse is true,
+   * only entries for batch.selected[0..batch.size) are required to be valid.
+   */
+  protected void computeValueHashCodes(VectorizedRowBatch batch, int[] hashCodes)
+      throws HiveException {
+    final boolean selectedInUse = batch.selectedInUse;
+    final int[] selected = batch.selected;
+    final int size = batch.size;
+
+    if (isEmptyValue) {
+      for (int logical = 0; logical < size; logical++) {
+        final int batchIndex = (selectedInUse ? selected[logical] : logical);
+        hashCodes[batchIndex] = 0;
+      }
+      return;
+    }
+
+    initializeValueHashCodeScratch();
+
+    for (int logical = 0; logical < size; logical++) {
+      final int batchIndex = (selectedInUse ? selected[logical] : logical);
+      valueVectorExtractRow.extractRow(batch, batchIndex, valueFieldValues);
+
+      int hashCode = 0;
+      for (int i = 0; i < valueFieldValues.length; i++) {
+        hashCode = 31 * hashCode + ObjectInspectorUtils.hashCodeMurmur(
+            valueFieldValues[i], valueObjectInspectors[i], valueHashByteBuffer);
+      }
+      hashCodes[batchIndex] = hashCode;
+    }
+  }
 
   protected void initializeEmptyKey(int tag) {
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
@@ -154,6 +154,11 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
   // Scratch hash codes for active rows in the current batch, indexed by physical row.
   protected transient int[] batchKeyHashCodes;
   protected transient int[] batchValueHashCodes;
+  private transient int[] vectorShufflePartitionCounts;
+  private transient int[] vectorShufflePartitionOffsets;
+  private transient int[] vectorShufflePartitionPositions;
+  private transient int[] vectorShuffleRowPartitions;
+  private transient int[] vectorShufflePartitionRowIndices;
 
   private transient VectorExtractRow valueVectorExtractRow;
   private transient Object[] valueFieldValues;
@@ -341,6 +346,11 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
     batchCounter = 0;
     batchKeyHashCodes = null;
     batchValueHashCodes = null;
+    vectorShufflePartitionCounts = null;
+    vectorShufflePartitionOffsets = null;
+    vectorShufflePartitionPositions = null;
+    vectorShuffleRowPartitions = null;
+    vectorShufflePartitionRowIndices = null;
     valueVectorExtractRow = null;
     valueFieldValues = null;
     valueObjectInspectors = null;
@@ -365,8 +375,11 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
 
   protected boolean tryCollectVectorShuffleBatch(VectorizedRowBatch batch)
       throws IOException {
-    if (vectorShuffleBatchSerializer == null || out == null
-        || out.getNumUnorderedPartitions() != 1) {
+    if (vectorShuffleBatchSerializer == null || out == null) {
+      return false;
+    }
+    final int numUnorderedPartitions = out.getNumUnorderedPartitions();
+    if (numUnorderedPartitions < 1) {
       return false;
     }
     // Expressions evaluated by the concrete reduce-sink operator can filter every row after its
@@ -375,9 +388,85 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
     if (batch.size == 0) {
       return true;
     }
-    vectorShuffleBatchSerializer.serialize(batch, vectorShuffleBatchColumnMap, valueBytesWritable);
-    doCollect(vectorShuffleBatchKey, valueBytesWritable);
+    if (numUnorderedPartitions == 1) {
+      vectorShuffleBatchSerializer.serialize(batch, vectorShuffleBatchColumnMap, valueBytesWritable);
+      doCollect(vectorShuffleBatchKey, valueBytesWritable);
+      return true;
+    }
+
+    collectPartitionedVectorShuffleBatch(batch, numUnorderedPartitions);
     return true;
+  }
+
+  private void collectPartitionedVectorShuffleBatch(VectorizedRowBatch batch,
+      int numUnorderedPartitions) throws IOException {
+    ensureVectorShufflePartitionScratch(batch, numUnorderedPartitions);
+
+    final int[] hashCodes;
+    final int partitionerType = out.getPartitionerType();
+    try {
+      if (partitionerType == 0) {
+        hashCodes = ensureBatchKeyHashCodes(batch);
+        computeKeyHashCodes(batch, hashCodes);
+      } else if (partitionerType == 1) {
+        hashCodes = ensureBatchValueHashCodes(batch);
+        computeValueHashCodes(batch, hashCodes);
+      } else {
+        throw new IOException("Unsupported partitioner type " + partitionerType);
+      }
+    } catch (HiveException e) {
+      throw new IOException("Failed to compute vector shuffle batch partition hashes", e);
+    }
+
+    Arrays.fill(vectorShufflePartitionCounts, 0, numUnorderedPartitions, 0);
+    final boolean selectedInUse = batch.selectedInUse;
+    final int[] selected = batch.selected;
+    final int size = batch.size;
+    for (int logical = 0; logical < size; logical++) {
+      final int batchIndex = selectedInUse ? selected[logical] : logical;
+      final int partition = Math.floorMod(hashCodes[batchIndex], numUnorderedPartitions);
+      vectorShuffleRowPartitions[logical] = partition;
+      vectorShufflePartitionCounts[partition]++;
+    }
+
+    vectorShufflePartitionOffsets[0] = 0;
+    for (int partition = 0; partition < numUnorderedPartitions; partition++) {
+      vectorShufflePartitionOffsets[partition + 1] =
+          vectorShufflePartitionOffsets[partition] + vectorShufflePartitionCounts[partition];
+      vectorShufflePartitionPositions[partition] = vectorShufflePartitionOffsets[partition];
+    }
+
+    for (int logical = 0; logical < size; logical++) {
+      final int batchIndex = selectedInUse ? selected[logical] : logical;
+      final int partition = vectorShuffleRowPartitions[logical];
+      vectorShufflePartitionRowIndices[vectorShufflePartitionPositions[partition]++] = batchIndex;
+    }
+
+    for (int partition = 0; partition < numUnorderedPartitions; partition++) {
+      final int rowCount = vectorShufflePartitionCounts[partition];
+      if (rowCount == 0) {
+        continue;
+      }
+      vectorShuffleBatchSerializer.serialize(batch, vectorShuffleBatchColumnMap,
+          vectorShufflePartitionRowIndices, vectorShufflePartitionOffsets[partition], rowCount,
+          valueBytesWritable);
+      doCollectWithPartition(vectorShuffleBatchKey, valueBytesWritable, partition);
+    }
+  }
+
+  private void ensureVectorShufflePartitionScratch(VectorizedRowBatch batch,
+      int numUnorderedPartitions) {
+    if (vectorShufflePartitionCounts == null
+        || vectorShufflePartitionCounts.length < numUnorderedPartitions) {
+      vectorShufflePartitionCounts = new int[numUnorderedPartitions];
+      vectorShufflePartitionOffsets = new int[numUnorderedPartitions + 1];
+      vectorShufflePartitionPositions = new int[numUnorderedPartitions];
+    }
+    final int minimumLength = batch.selected.length;
+    if (vectorShuffleRowPartitions == null || vectorShuffleRowPartitions.length < minimumLength) {
+      vectorShuffleRowPartitions = new int[minimumLength];
+      vectorShufflePartitionRowIndices = new int[minimumLength];
+    }
   }
 
   /**
@@ -486,6 +575,16 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
   }
 
   private void doCollect(HiveKey keyWritable, BytesWritable valueWritable) throws IOException {
+    doCollect(keyWritable, valueWritable, -1);
+  }
+
+  private void doCollectWithPartition(HiveKey keyWritable, BytesWritable valueWritable,
+      int partition) throws IOException {
+    doCollect(keyWritable, valueWritable, partition);
+  }
+
+  private void doCollect(HiveKey keyWritable, BytesWritable valueWritable, int partition)
+      throws IOException {
     // Since this is a terminal operator, update counters explicitly -
     // forward is not called
     if (null != out) {
@@ -505,7 +604,11 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
       //     " valueWritable " + valueBytesWritable.getLength() +
       //     VectorizedBatchUtil.displayBytes(valueBytesWritable.getBytes(), 0, valueBytesWritable.getLength()));
 
-      out.collect(keyWritable, valueWritable);
+      if (partition >= 0) {
+        out.writeWithPartition(keyWritable, valueWritable, partition);
+      } else {
+        out.collect(keyWritable, valueWritable);
+      }
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
@@ -146,6 +146,9 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
   // Debug display.
   protected transient long batchCounter;
 
+  // Scratch hash codes for active rows in the current batch, indexed by physical row.
+  protected transient int[] batchKeyHashCodes;
+
   //---------------------------------------------------------------------------
 
   /** Kryo ctor. */
@@ -325,6 +328,15 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
     }
 
     batchCounter = 0;
+    batchKeyHashCodes = null;
+  }
+
+  protected int[] ensureBatchKeyHashCodes(VectorizedRowBatch batch) {
+    final int minimumLength = batch.selected.length;
+    if (batchKeyHashCodes == null || batchKeyHashCodes.length < minimumLength) {
+      batchKeyHashCodes = new int[minimumLength];
+    }
+    return batchKeyHashCodes;
   }
 
   protected boolean tryCollectVectorShuffleBatch(VectorizedRowBatch batch)
@@ -343,6 +355,15 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
     doCollect(vectorShuffleBatchKey, valueBytesWritable);
     return true;
   }
+
+  /**
+   * Computes reducer-routing hash codes for all active rows in the batch.
+   *
+   * The result is indexed by physical batch row number. When batch.selectedInUse is true,
+   * only entries for batch.selected[0..batch.size) are required to be valid.
+   */
+  protected abstract void computeKeyHashCodes(VectorizedRowBatch batch, int[] hashCodes)
+      throws HiveException;
 
   protected void initializeEmptyKey(int tag) {
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkEmptyKeyOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkEmptyKeyOperator.java
@@ -74,6 +74,21 @@ public class VectorReduceSinkEmptyKeyOperator extends VectorReduceSinkCommonOper
   }
 
   @Override
+  protected void computeKeyHashCodes(VectorizedRowBatch batch, int[] hashCodes) throws HiveException {
+    final int size = batch.size;
+    if (batch.selectedInUse) {
+      final int[] selected = batch.selected;
+      for (int logical = 0; logical < size; logical++) {
+        hashCodes[selected[logical]] = 0;
+      }
+    } else {
+      for (int batchIndex = 0; batchIndex < size; batchIndex++) {
+        hashCodes[batchIndex] = 0;
+      }
+    }
+  }
+
+  @Override
   public void process(Object row, int tag) throws HiveException {
 
     try {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkObjectHashOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkObjectHashOperator.java
@@ -234,22 +234,29 @@ public class VectorReduceSinkObjectHashOperator extends VectorReduceSinkCommonOp
         }
       }
 
-      if (tryCollectVectorShuffleBatch(batch)) {
-        return;
-      }
-
       // Perform any bucket expressions.  Results will go into scratch columns.
+      // The vector shuffle batch path needs these before computing partition hash codes.
+      // Keep _bucket_number evaluation row-local because it depends on the computed bucket id.
       if (reduceSinkBucketExpressions != null) {
         for (VectorExpression ve : reduceSinkBucketExpressions) {
+          if (ve instanceof BucketNumExpression) {
+            continue;
+          }
           ve.evaluate(batch);
         }
       }
 
       // Perform any partition expressions.  Results will go into scratch columns.
+      // This must happen before tryCollectVectorShuffleBatch(), otherwise the partition-aware
+      // batch path hashes stale scratch-column values and can route rows to the wrong partition.
       if (reduceSinkPartitionExpressions != null) {
         for (VectorExpression ve : reduceSinkPartitionExpressions) {
           ve.evaluate(batch);
         }
+      }
+
+      if (tryCollectVectorShuffleBatch(batch)) {
+        return;
       }
 
       final boolean selectedInUse = batch.selectedInUse;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkObjectHashOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkObjectHashOperator.java
@@ -292,6 +292,44 @@ public class VectorReduceSinkObjectHashOperator extends VectorReduceSinkCommonOp
     }
   }
 
+
+  @Override
+  protected void computeKeyHashCodes(VectorizedRowBatch batch, int[] hashCodes) throws HiveException {
+    final boolean selectedInUse = batch.selectedInUse;
+    final int[] selected = batch.selected;
+    final int size = batch.size;
+
+    for (int logical = 0; logical < size; logical++) {
+      final int batchIndex = (selectedInUse ? selected[logical] : logical);
+      int hashCode;
+      if (isEmptyPartitions) {
+        if (isSingleReducer) {
+          // Empty partition, single reducer -> constant hashCode
+          hashCode = 0;
+        } else {
+          // Empty partition, multiple reducers -> random hashCode
+          hashCode = nonPartitionRandom.nextInt();
+        }
+      } else {
+        // Compute hashCode from partitions
+        partitionVectorExtractRow.extractRow(batch, batchIndex, partitionFieldValues);
+        hashCode = partitionHashFunc.applyAsInt(partitionFieldValues);
+      }
+
+      // Compute hashCode from buckets
+      if (!isEmptyBuckets) {
+        bucketVectorExtractRow.extractRow(batch, batchIndex, bucketFieldValues);
+        final int bucketNum = ObjectInspectorUtils.getBucketNumber(
+            bucketHashFunc.applyAsInt(bucketFieldValues), numBuckets);
+        if (bucketExpr != null) {
+          evaluateBucketExpr(batch, batchIndex, bucketNum);
+        }
+        hashCode = hashCode * 31 + bucketNum;
+      }
+      hashCodes[batchIndex] = hashCode;
+    }
+  }
+
   private void processKey(VectorizedRowBatch batch, int batchIndex, int tag)
   throws HiveException{
     if (isEmptyKey) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkUniformHashOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkUniformHashOperator.java
@@ -18,8 +18,11 @@
 
 package org.apache.hadoop.hive.ql.exec.vector.reducesink;
 
+import java.nio.ByteBuffer;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.CompilationOpContext;
+import org.apache.hadoop.hive.ql.exec.vector.VectorExtractRow;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizationContext;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.ql.exec.vector.expressions.VectorExpression;
@@ -28,6 +31,9 @@ import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.VectorDesc;
 import org.apache.hadoop.hive.serde2.ByteStream.Output;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.hive.common.util.Murmur3;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,6 +61,12 @@ public abstract class VectorReduceSinkUniformHashOperator extends VectorReduceSi
 
   // The object that determines equal key series.
   protected transient VectorKeySeriesSerialized serializedKeySeries;
+
+  // Serialization-free key hash support.
+  private transient VectorExtractRow keyVectorExtractRow;
+  private transient Object[] keyFieldValues;
+  private transient ObjectInspector[] keyObjectInspectors;
+  private transient ByteBuffer keyHashByteBuffer;
 
 
   /** Kryo ctor. */
@@ -87,8 +99,50 @@ public abstract class VectorReduceSinkUniformHashOperator extends VectorReduceSi
       nullBytes = new byte[nullBytesLength];
       System.arraycopy(nullKeyOutput.getData(), 0, nullBytes, 0, nullBytesLength);
       nullKeyHashCode = Murmur3.hash32(nullBytes, 0, nullBytesLength, 0);
+
+      keyVectorExtractRow = null;
+      keyFieldValues = null;
+      keyObjectInspectors = null;
+      keyHashByteBuffer = null;
     } catch (Exception e) {
       throw new HiveException(e);
+    }
+  }
+
+  private void initializeKeyHashCodeScratch() throws HiveException {
+    if (keyVectorExtractRow != null) {
+      return;
+    }
+
+    keyVectorExtractRow = new VectorExtractRow();
+    keyVectorExtractRow.init(reduceSinkKeyTypeInfos, reduceSinkKeyColumnMap);
+    keyFieldValues = new Object[reduceSinkKeyTypeInfos.length];
+    keyObjectInspectors = new ObjectInspector[reduceSinkKeyTypeInfos.length];
+    for (int i = 0; i < reduceSinkKeyTypeInfos.length; i++) {
+      keyObjectInspectors[i] =
+          TypeInfoUtils.getStandardWritableObjectInspectorFromTypeInfo(reduceSinkKeyTypeInfos[i]);
+    }
+    keyHashByteBuffer = ByteBuffer.allocate(8);
+  }
+
+  @Override
+  protected void computeKeyHashCodes(VectorizedRowBatch batch, int[] hashCodes) throws HiveException {
+    initializeKeyHashCodeScratch();
+
+    final boolean selectedInUse = batch.selectedInUse;
+    final int[] selected = batch.selected;
+    final int size = batch.size;
+
+    for (int logical = 0; logical < size; logical++) {
+      final int batchIndex = (selectedInUse ? selected[logical] : logical);
+      keyVectorExtractRow.extractRow(batch, batchIndex, keyFieldValues);
+
+      int hashCode = 0;
+      for (int i = 0; i < keyFieldValues.length; i++) {
+        hashCode = 31 * hashCode + ObjectInspectorUtils.hashCodeMurmur(
+            keyFieldValues[i], keyObjectInspectors[i], keyHashByteBuffer);
+      }
+      hashCodes[batchIndex] = hashCode;
     }
   }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorShuffleBatchSerde.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorShuffleBatchSerde.java
@@ -369,6 +369,26 @@ public class TestVectorShuffleBatchSerde {
   }
 
   @Test
+  public void testExplicitRowIndicesSubset() throws Exception {
+    LongColumnVector source = new LongColumnVector();
+    for (int row = 0; row < 8; row++) {
+      source.vector[row] = row * 10L;
+    }
+    VectorizedRowBatch destination = batchWithColumn(new LongColumnVector(), 0);
+    BytesWritable serialized = new BytesWritable();
+
+    serializer.serialize(batchWithColumn(source, 8), new int[] {0}, new int[] {5, 1, 7}, 3,
+        serialized);
+    deserializer.deserialize(serialized, destination);
+
+    assertEquals(3, destination.size);
+    LongColumnVector actual = (LongColumnVector) destination.cols[0];
+    assertEquals(50L, actual.vector[0]);
+    assertEquals(10L, actual.vector[1]);
+    assertEquals(70L, actual.vector[2]);
+  }
+
+  @Test
   public void testNullBitmapBoundaries() throws Exception {
     LongColumnVector source = new LongColumnVector();
     source.noNulls = false;


### PR DESCRIPTION
### Motivation
- Support adaptive, partition-aware vector shuffle batching so a single `VectorizedRowBatch` can be split by destination partition and each partition group serialized as one `BytesWritable` using the existing vector-batch serde.
- Extend the existing single-unordered-partition fast path to work with `KeyValuesWriterEdge` that exposes multi-partition unordered edges and a partitioner type (key vs value hashing).

### Description
- Add row-index based serialization APIs to `VectorShuffleBatchSerializer` with `serialize(..., int[] rowIndices, int rowCount)` and an offset-aware overload so a contiguous subset of physical row indices can be serialized directly from the source batch.
- Expose `writeWithPartition(BytesWritable, BytesWritable, int)` and `getPartitionerType()` on `TezProcessor.TezKVOutputCollector`, delegating to the underlying `KeyValuesWriterEdge` to enable partition-aware writes and selection of key/value hashing.
- Extend `VectorReduceSinkCommonOperator` with transient scratch arrays for partition counts, offsets, positions, per-row partition assignments, and grouped physical row indices, and add `ensureVectorShufflePartitionScratch(...)` to manage them.
- Update `tryCollectVectorShuffleBatch(...)` to: check `out.getNumUnorderedPartitions()`, preserve the existing single-partition fast path, or route to a new `collectPartitionedVectorShuffleBatch(...)` which:
  - calls `out.getPartitionerType()` to choose `computeKeyHashCodes()` or `computeValueHashCodes()` once for all active rows,
  - computes per-row partitions using `Math.floorMod(hash, numUnorderedPartitions)`, builds `partitionCounts[]`, computes prefix-sum offsets, fills a compact `partitionRowIndices[]` array, and
  - serializes each non-empty partition slice via the new serializer overload and emits it with the partition-aware `writeWithPartition` path.
- Add `doCollect` overloads to route partitioned writes through `writeWithPartition` while keeping the original `collect` semantics for non-partitioned writes.
- Add a unit test `testExplicitRowIndicesSubset` in `TestVectorShuffleBatchSerde` to validate the serializer subset/offset API.

### Testing
- Ran `git diff --check` with no issues found.
- Attempted `mvn -pl ql -Dtest=TestVectorShuffleBatchSerde -DskipSparkTests -DskipIcebergTests test`, but the build/test run was blocked by environment repository access errors (Maven failed to resolve `org.apache:apache:pom:23` with HTTP 403), so the test suite could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32b4c349f0832883d12a64655420f6)