### PR TITLE
Serialize small vector shuffle batches row-by-row and remove ShuffleInputFormat tracking

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
@@ -108,7 +108,6 @@ public class ReduceRecordSource implements RecordSource {
   private VectorizedRowBatchCtx batchContext;
   private VectorizedRowBatch batch;
   private VectorShuffleBatchDeserializer vectorShuffleBatchDeserializer;
-  private ShuffleInputFormat shuffleInputFormat = ShuffleInputFormat.UNKNOWN;
   private VectorSerializeRow<BinarySortableSerializeWrite> rowModeKeySerializeRow;
   private VectorSerializeRow<LazyBinarySerializeWrite> rowModeValueSerializeRow;
   private BinarySortableSerializeWrite rowModeKeySerializeWrite;
@@ -146,12 +145,6 @@ public class ReduceRecordSource implements RecordSource {
 
   // Flush the last record when reader is out of records
   private boolean flushLastRecord = false;
-
-  private enum ShuffleInputFormat {
-    UNKNOWN,
-    ROW,
-    VECTOR_BATCH
-  }
 
   void init(JobConf jconf, Operator<?> reducer, boolean vectorized, TableDesc keyTableDesc,
       TableDesc valueTableDesc, ReaderEdge reader, boolean handleGroupKey, byte tag,
@@ -537,8 +530,6 @@ public class ReduceRecordSource implements RecordSource {
       BytesWritable keyWritable = keyValueReader.getCurrentKey();
       BytesWritable valueWritable = keyValueReader.getCurrentValue();
 
-      // This fallback path does not expose the boundary between underlying readers.
-      shuffleInputFormat = ShuffleInputFormat.UNKNOWN;
       processVectorRecordUnordered(keyWritable, valueWritable, tag);
       return true;
     } catch (Throwable e) {
@@ -588,8 +579,7 @@ public class ReduceRecordSource implements RecordSource {
   void consumeAllUnordered(RecordProgress progress) throws HiveException, InterruptedException {
     // called when canConsumeAllUnordered() == true
     try {
-      keyValueReader.consumeAll(() -> shuffleInputFormat = ShuffleInputFormat.UNKNOWN,
-          (keyWritable, valueWritable) -> {
+      keyValueReader.consumeAll((keyWritable, valueWritable) -> {
         // KeyValueReaderEdge provides unordered key/value records. The same logical key can
         // appear again later, so every record must be treated as an independent final batch.
         processVectorRecordUnordered(keyWritable, valueWritable, tag);
@@ -613,11 +603,7 @@ public class ReduceRecordSource implements RecordSource {
     }
     Preconditions.checkState(batch.size == 0);
 
-    if (shuffleInputFormat == ShuffleInputFormat.UNKNOWN) {
-      shuffleInputFormat = isVectorBatchKey(keyWritable) ?
-          ShuffleInputFormat.VECTOR_BATCH : ShuffleInputFormat.ROW;
-    }
-    if (shuffleInputFormat == ShuffleInputFormat.VECTOR_BATCH) {
+    if (isVectorBatchKey(keyWritable)) {
       try {
         vectorShuffleBatchDeserializer.deserialize(valueWritable, batch);
         reducer.process(batch, tag);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
@@ -428,6 +428,11 @@ public class TezProcessor extends AbstractLogicalIOProcessor {
       writer.write(key, value);
     }
 
+    public void writeWithPartition(BytesWritable key, BytesWritable value, int partition)
+        throws IOException {
+      writer.writeWithPartition(key, value, partition);
+    }
+
     public void close() {
       writer.closeWriter();
     }
@@ -437,6 +442,12 @@ public class TezProcessor extends AbstractLogicalIOProcessor {
     //   -1: ordered edge
     public int getNumUnorderedPartitions() {
       return writer.getNumUnorderedPartitions();
+    }
+
+    // return value = 0: use key hash to get partition
+    // return value = 1: use value hash to get partition
+    public int getPartitionerType() {
+      return writer.getPartitionerType();
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorShuffleBatchSerializer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorShuffleBatchSerializer.java
@@ -62,6 +62,35 @@ public final class VectorShuffleBatchSerializer {
     output.set(buffer.getData(), 0, buffer.getLength());
   }
 
+  public void serialize(VectorizedRowBatch source, int[] sourceColumnMap, int[] rowIndices,
+      int rowOffset, int rowCount, BytesWritable output) throws IOException {
+    if (source == null || sourceColumnMap == null || rowIndices == null || output == null) {
+      throw new IllegalArgumentException(
+          "Source batch, source column map, row indices, and output are required");
+    }
+    if (rowOffset < 0 || rowCount < 0 || rowOffset > rowIndices.length - rowCount) {
+      throw new IllegalArgumentException(
+          "Invalid row offset " + rowOffset + " and row count " + rowCount
+              + " for " + rowIndices.length + " row indices");
+    }
+    int[] logicalRows = rowIndices;
+    if (rowOffset != 0) {
+      logicalRows = new int[rowCount];
+      System.arraycopy(rowIndices, rowOffset, logicalRows, 0, rowCount);
+    }
+
+    buffer.reset();
+    WritableUtils.writeVInt(buffer, rowCount);
+    WritableUtils.writeVInt(buffer, sourceColumnMap.length);
+    for (int sourceColumn : sourceColumnMap) {
+      if (sourceColumn < 0 || sourceColumn >= source.cols.length || source.cols[sourceColumn] == null) {
+        throw new IllegalArgumentException("Invalid source column " + sourceColumn);
+      }
+      writeColumn(source.cols[sourceColumn], logicalRows, rowCount);
+    }
+    output.set(buffer.getData(), 0, buffer.getLength());
+  }
+
   private void writeColumn(ColumnVector column, int[] indices, int count) throws IOException {
     final boolean repeating = column.isRepeating;
     final int valueCount = repeating ? Math.min(count, 1) : count;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
@@ -54,6 +54,7 @@ import org.apache.hadoop.hive.serde2.binarysortable.fast.BinarySortableSerialize
 import org.apache.hadoop.hive.serde2.lazybinary.fast.LazyBinarySerializeWrite;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.io.BytesWritable;
+import org.apache.hive.common.util.Murmur3;
 import org.apache.hadoop.mapred.OutputCollector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,6 +71,8 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
   private static final long serialVersionUID = 1L;
   private static final String CLASS_NAME = VectorReduceSinkCommonOperator.class.getName();
   private static final Logger LOG = LoggerFactory.getLogger(CLASS_NAME);
+
+  private static final int NUM_ROWS_THRESHOLD_FOR_BATCH = 1;
 
   /**
    * Information about our native vectorized reduce sink created by the Vectorizer class during
@@ -130,6 +133,9 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
   private transient VectorShuffleBatchSerializer vectorShuffleBatchSerializer;
   private transient int[] vectorShuffleBatchColumnMap;
   private transient HiveKey vectorShuffleBatchKey;
+  private transient BinarySortableSerializeWrite vectorShuffleRowKeySerializeWrite;
+  private transient Output vectorShuffleRowKeyOutput;
+  private transient VectorSerializeRow<BinarySortableSerializeWrite> vectorShuffleRowKeySerializeRow;
 
   // Picks topN K:V pairs from input.
   protected transient TopNHash reducerHash;
@@ -330,6 +336,14 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
       }
       vectorShuffleBatchKey = new HiveKey(ReduceRecordSource.VECTOR_BATCH_KEY_BYTES, 0);
       vectorShuffleBatchKey.setDistKeyLength(ReduceRecordSource.VECTOR_BATCH_KEY_BYTES.length);
+      if (!isEmptyKey) {
+        vectorShuffleRowKeySerializeWrite = BinarySortableSerializeWrite.with(
+            conf.getKeySerializeInfo().getProperties(), reduceSinkKeyColumnMap.length);
+        vectorShuffleRowKeyOutput = new Output();
+        vectorShuffleRowKeySerializeWrite.set(vectorShuffleRowKeyOutput);
+        vectorShuffleRowKeySerializeRow = new VectorSerializeRow<>(vectorShuffleRowKeySerializeWrite);
+        vectorShuffleRowKeySerializeRow.init(reduceSinkKeyTypeInfos, reduceSinkKeyColumnMap);
+      }
     }
 
     batchCounter = 0;
@@ -358,7 +372,7 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
     return batchValueHashCodes;
   }
 
-  protected boolean tryCollectVectorShuffleBatch(VectorizedRowBatch batch)
+  protected boolean tryCollectVectorShuffleBatch(VectorizedRowBatch batch, int tag)
       throws IOException {
     if (vectorShuffleBatchSerializer == null || out == null) {
       return false;
@@ -377,17 +391,21 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
       // VectorizedRowBatch.size is the number of active logical rows. When
       // selectedInUse is true, selected[0..size) contains their physical indices.
       final int logicalRecordCount = batch.size;
-      vectorShuffleBatchSerializer.serialize(batch, vectorShuffleBatchColumnMap, valueBytesWritable);
-      doCollectBatch(vectorShuffleBatchKey, valueBytesWritable, 0, logicalRecordCount);
+      if (logicalRecordCount <= NUM_ROWS_THRESHOLD_FOR_BATCH) {
+        collectVectorShuffleRows(batch, null, 0, logicalRecordCount, 0, tag);
+      } else {
+        vectorShuffleBatchSerializer.serialize(batch, vectorShuffleBatchColumnMap, valueBytesWritable);
+        doCollectBatch(vectorShuffleBatchKey, valueBytesWritable, 0, logicalRecordCount);
+      }
       return true;
     }
 
-    collectPartitionedVectorShuffleBatch(batch, numUnorderedPartitions);
+    collectPartitionedVectorShuffleBatch(batch, numUnorderedPartitions, tag);
     return true;
   }
 
   private void collectPartitionedVectorShuffleBatch(VectorizedRowBatch batch,
-      int numUnorderedPartitions) throws IOException {
+      int numUnorderedPartitions, int tag) throws IOException {
     ensureVectorShufflePartitionScratch(batch, numUnorderedPartitions);
 
     final int[] hashCodes;
@@ -435,10 +453,15 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
       if (rowCount == 0) {
         continue;
       }
-      vectorShuffleBatchSerializer.serialize(batch, vectorShuffleBatchColumnMap,
-          vectorShufflePartitionRowIndices, vectorShufflePartitionOffsets[partition], rowCount,
-          valueBytesWritable);
-      doCollectBatch(vectorShuffleBatchKey, valueBytesWritable, partition, rowCount);
+      if (rowCount <= NUM_ROWS_THRESHOLD_FOR_BATCH) {
+        collectVectorShuffleRows(batch, vectorShufflePartitionRowIndices,
+            vectorShufflePartitionOffsets[partition], rowCount, partition, tag);
+      } else {
+        vectorShuffleBatchSerializer.serialize(batch, vectorShuffleBatchColumnMap,
+            vectorShufflePartitionRowIndices, vectorShufflePartitionOffsets[partition], rowCount,
+            valueBytesWritable);
+        doCollectBatch(vectorShuffleBatchKey, valueBytesWritable, partition, rowCount);
+      }
     }
   }
 
@@ -454,6 +477,66 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
     if (vectorShuffleRowPartitions == null || vectorShuffleRowPartitions.length < minimumLength) {
       vectorShuffleRowPartitions = new int[minimumLength];
       vectorShufflePartitionRowIndices = new int[minimumLength];
+    }
+  }
+
+
+  private void collectVectorShuffleRows(VectorizedRowBatch batch, int[] rowIndices, int rowOffset,
+      int rowCount, int partition, int tag) throws IOException {
+    for (int logical = 0; logical < rowCount; logical++) {
+      final int batchIndex = rowIndices == null
+          ? (batch.selectedInUse ? batch.selected[logical] : logical)
+          : rowIndices[rowOffset + logical];
+      serializeVectorShuffleRow(batch, batchIndex, tag);
+      doCollectRowWithPartition(keyWritable, valueBytesWritable, partition);
+    }
+  }
+
+  private void serializeVectorShuffleRow(VectorizedRowBatch batch, int batchIndex, int tag) throws IOException {
+    try {
+      if (isEmptyKey) {
+        initializeEmptyKey(tag);
+      } else {
+        vectorShuffleRowKeySerializeWrite.reset();
+        vectorShuffleRowKeySerializeRow.serializeWrite(batch, batchIndex);
+
+        final int keyLength = vectorShuffleRowKeyOutput.getLength();
+        if (tag == -1 || reduceSkipTag) {
+          keyWritable.set(vectorShuffleRowKeyOutput.getData(), 0, keyLength);
+        } else {
+          keyWritable.setSize(keyLength + 1);
+          System.arraycopy(vectorShuffleRowKeyOutput.getData(), 0, keyWritable.get(), 0, keyLength);
+          keyWritable.get()[keyLength] = reduceTagByte;
+        }
+        keyWritable.setDistKeyLength(keyLength);
+        keyWritable.setHashCode(Murmur3.hash32(vectorShuffleRowKeyOutput.getData(), 0, keyLength, 0));
+      }
+
+      if (isEmptyValue) {
+        valueBytesWritable.setSize(0);
+      } else {
+        valueLazyBinarySerializeWrite.reset();
+        valueVectorSerializeRow.serializeWrite(batch, batchIndex);
+        valueBytesWritable.set(valueOutput.getData(), 0, valueOutput.getLength());
+      }
+    } catch (Exception e) {
+      throw new IOException("Failed to serialize vector shuffle row", e);
+    }
+  }
+
+  private void doCollectRowWithPartition(HiveKey keyWritable, BytesWritable valueWritable, int partition)
+      throws IOException {
+    if (null != out) {
+      numRows++;
+      if (numRows == cntr) {
+        cntr = cntr * 10;
+        if (cntr < 0 || numRows < 0) {
+          cntr = 0;
+          numRows = 1;
+        }
+        LOG.info("{}: records written - {}", this, numRows);
+      }
+      out.writeWithPartition(keyWritable, valueWritable, partition);
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
@@ -138,13 +138,21 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
   private transient TezProcessor.TezKVOutputCollector out;
 
   private transient long cntr = 1;
-  private transient long logEveryNRows = 0;
 
   // For debug tracing: the name of the map or reduce task.
   protected transient String taskName;
 
   // Debug display.
   protected transient long batchCounter;
+
+  // Scratch hash codes for active rows in the current batch, indexed by physical row.
+  protected transient int[] batchKeyHashCodes;
+  protected transient int[] batchValueHashCodes;
+  private transient int[] vectorShufflePartitionCounts;
+  private transient int[] vectorShufflePartitionOffsets;
+  private transient int[] vectorShufflePartitionPositions;
+  private transient int[] vectorShuffleRowPartitions;
+  private transient int[] vectorShufflePartitionRowIndices;
 
   //---------------------------------------------------------------------------
 
@@ -325,12 +333,38 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
     }
 
     batchCounter = 0;
+    batchKeyHashCodes = null;
+    batchValueHashCodes = null;
+    vectorShufflePartitionCounts = null;
+    vectorShufflePartitionOffsets = null;
+    vectorShufflePartitionPositions = null;
+    vectorShuffleRowPartitions = null;
+    vectorShufflePartitionRowIndices = null;
+  }
+
+  protected int[] ensureBatchKeyHashCodes(VectorizedRowBatch batch) {
+    final int minimumLength = batch.selected.length;
+    if (batchKeyHashCodes == null || batchKeyHashCodes.length < minimumLength) {
+      batchKeyHashCodes = new int[minimumLength];
+    }
+    return batchKeyHashCodes;
+  }
+
+  protected int[] ensureBatchValueHashCodes(VectorizedRowBatch batch) {
+    final int minimumLength = batch.selected.length;
+    if (batchValueHashCodes == null || batchValueHashCodes.length < minimumLength) {
+      batchValueHashCodes = new int[minimumLength];
+    }
+    return batchValueHashCodes;
   }
 
   protected boolean tryCollectVectorShuffleBatch(VectorizedRowBatch batch)
       throws IOException {
-    if (vectorShuffleBatchSerializer == null || out == null
-        || out.getNumUnorderedPartitions() != 1) {
+    if (vectorShuffleBatchSerializer == null || out == null) {
+      return false;
+    }
+    final int numUnorderedPartitions = out.getNumUnorderedPartitions();
+    if (numUnorderedPartitions < 1) {
       return false;
     }
     // Expressions evaluated by the concrete reduce-sink operator can filter every row after its
@@ -339,15 +373,136 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
     if (batch.size == 0) {
       return true;
     }
-    vectorShuffleBatchSerializer.serialize(batch, vectorShuffleBatchColumnMap, valueBytesWritable);
-    doCollect(vectorShuffleBatchKey, valueBytesWritable);
+    if (numUnorderedPartitions == 1) {
+      // VectorizedRowBatch.size is the number of active logical rows. When
+      // selectedInUse is true, selected[0..size) contains their physical indices.
+      final int logicalRecordCount = batch.size;
+      vectorShuffleBatchSerializer.serialize(batch, vectorShuffleBatchColumnMap, valueBytesWritable);
+      doCollectBatch(vectorShuffleBatchKey, valueBytesWritable, 0, logicalRecordCount);
+      return true;
+    }
+
+    collectPartitionedVectorShuffleBatch(batch, numUnorderedPartitions);
     return true;
   }
 
-  protected void initializeEmptyKey(int tag) {
+  private void collectPartitionedVectorShuffleBatch(VectorizedRowBatch batch,
+      int numUnorderedPartitions) throws IOException {
+    ensureVectorShufflePartitionScratch(batch, numUnorderedPartitions);
 
+    final int[] hashCodes;
+    final int partitionerType = out.getPartitionerType();
+    try {
+      if (partitionerType == 0) {
+        hashCodes = ensureBatchKeyHashCodes(batch);
+        computeKeyHashCodes(batch, hashCodes);
+      } else if (partitionerType == 1) {
+        hashCodes = ensureBatchValueHashCodes(batch);
+        computeValueHashCodes(batch, hashCodes);
+      } else {
+        throw new IOException("Unsupported partitioner type " + partitionerType);
+      }
+    } catch (HiveException e) {
+      throw new IOException("Failed to compute vector shuffle batch partition hashes", e);
+    }
+
+    Arrays.fill(vectorShufflePartitionCounts, 0, numUnorderedPartitions, 0);
+    final boolean selectedInUse = batch.selectedInUse;
+    final int[] selected = batch.selected;
+    final int size = batch.size;
+    for (int logical = 0; logical < size; logical++) {
+      final int batchIndex = selectedInUse ? selected[logical] : logical;
+      final int partition = (hashCodes[batchIndex] & Integer.MAX_VALUE) % numUnorderedPartitions;
+      vectorShuffleRowPartitions[logical] = partition;
+      vectorShufflePartitionCounts[partition]++;
+    }
+
+    vectorShufflePartitionOffsets[0] = 0;
+    for (int partition = 0; partition < numUnorderedPartitions; partition++) {
+      vectorShufflePartitionOffsets[partition + 1] =
+          vectorShufflePartitionOffsets[partition] + vectorShufflePartitionCounts[partition];
+      vectorShufflePartitionPositions[partition] = vectorShufflePartitionOffsets[partition];
+    }
+
+    for (int logical = 0; logical < size; logical++) {
+      final int batchIndex = selectedInUse ? selected[logical] : logical;
+      final int partition = vectorShuffleRowPartitions[logical];
+      vectorShufflePartitionRowIndices[vectorShufflePartitionPositions[partition]++] = batchIndex;
+    }
+
+    for (int partition = 0; partition < numUnorderedPartitions; partition++) {
+      final int rowCount = vectorShufflePartitionCounts[partition];
+      if (rowCount == 0) {
+        continue;
+      }
+      vectorShuffleBatchSerializer.serialize(batch, vectorShuffleBatchColumnMap,
+          vectorShufflePartitionRowIndices, vectorShufflePartitionOffsets[partition], rowCount,
+          valueBytesWritable);
+      doCollectBatch(vectorShuffleBatchKey, valueBytesWritable, partition, rowCount);
+    }
+  }
+
+  private void ensureVectorShufflePartitionScratch(VectorizedRowBatch batch,
+      int numUnorderedPartitions) {
+    if (vectorShufflePartitionCounts == null
+        || vectorShufflePartitionCounts.length < numUnorderedPartitions) {
+      vectorShufflePartitionCounts = new int[numUnorderedPartitions];
+      vectorShufflePartitionOffsets = new int[numUnorderedPartitions + 1];
+      vectorShufflePartitionPositions = new int[numUnorderedPartitions];
+    }
+    final int minimumLength = batch.selected.length;
+    if (vectorShuffleRowPartitions == null || vectorShuffleRowPartitions.length < minimumLength) {
+      vectorShuffleRowPartitions = new int[minimumLength];
+      vectorShufflePartitionRowIndices = new int[minimumLength];
+    }
+  }
+
+  /**
+   * Computes reducer-routing hash codes for all active rows in the batch.
+   *
+   * The result is indexed by physical batch row number. When batch.selectedInUse is true,
+   * only entries for batch.selected[0..batch.size) are required to be valid.
+   */
+  protected abstract void computeKeyHashCodes(VectorizedRowBatch batch, int[] hashCodes)
+      throws HiveException;
+
+  /**
+   * Computes reducer-routing value hash codes for all active rows in the batch.
+   *
+   * The hash is computed from the same serialized LazyBinary value representation that the
+   * row-wise reduce-sink path writes to the edge. The result is indexed by physical batch row
+   * number. When batch.selectedInUse is true, only entries for batch.selected[0..batch.size)
+   * are required to be valid.
+   */
+  protected void computeValueHashCodes(VectorizedRowBatch batch, int[] hashCodes)
+      throws HiveException {
+    final boolean selectedInUse = batch.selectedInUse;
+    final int[] selected = batch.selected;
+    final int size = batch.size;
+
+    if (isEmptyValue) {
+      for (int logical = 0; logical < size; logical++) {
+        final int batchIndex = selectedInUse ? selected[logical] : logical;
+        hashCodes[batchIndex] = 0;
+      }
+      return;
+    }
+
+    try {
+      for (int logical = 0; logical < size; logical++) {
+        final int batchIndex = selectedInUse ? selected[logical] : logical;
+        valueLazyBinarySerializeWrite.reset();
+        valueVectorSerializeRow.serializeWrite(batch, batchIndex);
+        valueBytesWritable.set(valueOutput.getData(), 0, valueOutput.getLength());
+        hashCodes[batchIndex] = valueBytesWritable.hashCode();
+      }
+    } catch (Exception e) {
+      throw new HiveException(e);
+    }
+  }
+
+  protected void initializeEmptyKey(int tag) {
     // Use the same logic as ReduceSinkOperator.toHiveKey.
-    //
     if (tag == -1 || reduceSkipTag) {
       keyWritable.setSize(0);
     } else {
@@ -394,7 +549,7 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
     if (null != out) {
       numRows++;
       if (numRows == cntr) {
-        cntr = logEveryNRows == 0 ? cntr * 10 : numRows + logEveryNRows;
+        cntr = cntr * 10;
         if (cntr < 0 || numRows < 0) {
           cntr = 0;
           numRows = 1;
@@ -412,16 +567,27 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
     }
   }
 
+  private void doCollectBatch(HiveKey keyWritable, BytesWritable valueWritable, int partition,
+                              long logicalRecordCount) throws IOException {
+    if (null != out) {
+      numRows += logicalRecordCount;
+      if (numRows >= cntr) {
+        cntr = cntr * 10;
+        LOG.info("{}:: records written - {}", this, numRows);
+      }
+      out.writeWithPartition(keyWritable, valueWritable, partition);
+    }
+  }
+
   @Override
   protected void closeOp(boolean abort) throws HiveException {
     if (!abort && reducerHash != null) {
       reducerHash.flush();
     }
-    runTimeNumRows = numRows;
     super.closeOp(abort);
     out = null;
     reducerHash = null;
-    LOG.info("{}:: records written - {}", this, numRows);
+    LOG.info("{}::: records written - {}", this, numRows);
     this.runTimeNumRows = numRows;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkEmptyKeyOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkEmptyKeyOperator.java
@@ -74,6 +74,21 @@ public class VectorReduceSinkEmptyKeyOperator extends VectorReduceSinkCommonOper
   }
 
   @Override
+  protected void computeKeyHashCodes(VectorizedRowBatch batch, int[] hashCodes) throws HiveException {
+    final int size = batch.size;
+    if (batch.selectedInUse) {
+      final int[] selected = batch.selected;
+      for (int logical = 0; logical < size; logical++) {
+        hashCodes[selected[logical]] = 0;
+      }
+    } else {
+      for (int batchIndex = 0; batchIndex < size; batchIndex++) {
+        hashCodes[batchIndex] = 0;
+      }
+    }
+  }
+
+  @Override
   public void process(Object row, int tag) throws HiveException {
 
     try {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkEmptyKeyOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkEmptyKeyOperator.java
@@ -117,7 +117,7 @@ public class VectorReduceSinkEmptyKeyOperator extends VectorReduceSinkCommonOper
         }
       }
 
-      if (tryCollectVectorShuffleBatch(batch)) {
+      if (tryCollectVectorShuffleBatch(batch, tag)) {
         return;
       }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkObjectHashOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkObjectHashOperator.java
@@ -292,6 +292,44 @@ public class VectorReduceSinkObjectHashOperator extends VectorReduceSinkCommonOp
     }
   }
 
+
+  @Override
+  protected void computeKeyHashCodes(VectorizedRowBatch batch, int[] hashCodes) throws HiveException {
+    final boolean selectedInUse = batch.selectedInUse;
+    final int[] selected = batch.selected;
+    final int size = batch.size;
+
+    for (int logical = 0; logical < size; logical++) {
+      final int batchIndex = (selectedInUse ? selected[logical] : logical);
+      int hashCode;
+      if (isEmptyPartitions) {
+        if (isSingleReducer) {
+          // Empty partition, single reducer -> constant hashCode
+          hashCode = 0;
+        } else {
+          // Empty partition, multiple reducers -> random hashCode
+          hashCode = nonPartitionRandom.nextInt();
+        }
+      } else {
+        // Compute hashCode from partitions
+        partitionVectorExtractRow.extractRow(batch, batchIndex, partitionFieldValues);
+        hashCode = partitionHashFunc.applyAsInt(partitionFieldValues);
+      }
+
+      // Compute hashCode from buckets
+      if (!isEmptyBuckets) {
+        bucketVectorExtractRow.extractRow(batch, batchIndex, bucketFieldValues);
+        final int bucketNum = ObjectInspectorUtils.getBucketNumber(
+            bucketHashFunc.applyAsInt(bucketFieldValues), numBuckets);
+        if (bucketExpr != null) {
+          evaluateBucketExpr(batch, batchIndex, bucketNum);
+        }
+        hashCode = hashCode * 31 + bucketNum;
+      }
+      hashCodes[batchIndex] = hashCode;
+    }
+  }
+
   private void processKey(VectorizedRowBatch batch, int batchIndex, int tag)
   throws HiveException{
     if (isEmptyKey) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkObjectHashOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkObjectHashOperator.java
@@ -234,7 +234,7 @@ public class VectorReduceSinkObjectHashOperator extends VectorReduceSinkCommonOp
         }
       }
 
-      if (tryCollectVectorShuffleBatch(batch)) {
+      if (tryCollectVectorShuffleBatch(batch, tag)) {
         return;
       }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkUniformHashOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkUniformHashOperator.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.hive.ql.exec.vector.reducesink;
 
+import java.io.IOException;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.CompilationOpContext;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizationContext;
@@ -87,9 +89,33 @@ public abstract class VectorReduceSinkUniformHashOperator extends VectorReduceSi
       nullBytes = new byte[nullBytesLength];
       System.arraycopy(nullKeyOutput.getData(), 0, nullBytes, 0, nullBytesLength);
       nullKeyHashCode = Murmur3.hash32(nullBytes, 0, nullBytesLength, 0);
+
     } catch (Exception e) {
       throw new HiveException(e);
     }
+  }
+
+  @Override
+  protected void computeKeyHashCodes(VectorizedRowBatch batch, int[] hashCodes) throws HiveException {
+    try {
+      serializedKeySeries.processBatch(batch);
+    } catch (IOException e) {
+      throw new HiveException(e);
+    }
+
+    final boolean selectedInUse = batch.selectedInUse;
+    final int[] selected = batch.selected;
+
+    do {
+      final int hashCode = serializedKeySeries.getCurrentIsAllNull()
+          ? nullKeyHashCode : serializedKeySeries.getCurrentHashCode();
+      final int end = serializedKeySeries.getCurrentLogical()
+          + serializedKeySeries.getCurrentDuplicateCount();
+      for (int logical = serializedKeySeries.getCurrentLogical(); logical < end; logical++) {
+        final int batchIndex = selectedInUse ? selected[logical] : logical;
+        hashCodes[batchIndex] = hashCode;
+      }
+    } while (serializedKeySeries.next());
   }
 
   @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkUniformHashOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkUniformHashOperator.java
@@ -147,7 +147,7 @@ public abstract class VectorReduceSinkUniformHashOperator extends VectorReduceSi
         }
       }
 
-      if (tryCollectVectorShuffleBatch(batch)) {
+      if (tryCollectVectorShuffleBatch(batch, tag)) {
         return;
       }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorShuffleBatchSerde.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorShuffleBatchSerde.java
@@ -369,6 +369,26 @@ public class TestVectorShuffleBatchSerde {
   }
 
   @Test
+  public void testExplicitRowIndicesSubset() throws Exception {
+    LongColumnVector source = new LongColumnVector();
+    for (int row = 0; row < 8; row++) {
+      source.vector[row] = row * 10L;
+    }
+    VectorizedRowBatch destination = batchWithColumn(new LongColumnVector(), 0);
+    BytesWritable serialized = new BytesWritable();
+
+    serializer.serialize(batchWithColumn(source, 8), new int[] {0}, new int[] {5, 1, 7}, 0, 3,
+        serialized);
+    deserializer.deserialize(serialized, destination);
+
+    assertEquals(3, destination.size);
+    LongColumnVector actual = (LongColumnVector) destination.cols[0];
+    assertEquals(50L, actual.vector[0]);
+    assertEquals(10L, actual.vector[1]);
+    assertEquals(70L, actual.vector[2]);
+  }
+
+  @Test
   public void testNullBitmapBoundaries() throws Exception {
     LongColumnVector source = new LongColumnVector();
     source.noNulls = false;


### PR DESCRIPTION
### Motivation
- Avoid unnecessary vector-batch serialization overhead for very small batches or partitions by emitting per-row serialized records instead of always producing a vector batch blob.
- Simplify shuffle handling by removing the `ShuffleInputFormat` fallback tracking in the unordered key/value vectorized path.
- Ensure the reduce-sink tag is propagated into vectorized shuffle collection so per-row keys include the tag and correct hash.

### Description
- Removed the `ShuffleInputFormat` enum usage and related fallback tracking from `ReduceRecordSource`, and always detect vector-batch keys dynamically when processing unordered vector records.
- Extended `VectorReduceSinkCommonOperator` to support emitting small vector shuffle partitions row-by-row by adding `NUM_ROWS_THRESHOLD_FOR_BATCH`, `collectVectorShuffleRows`, `serializeVectorShuffleRow`, and `doCollectRowWithPartition` helper methods.
- Added per-row key serialization fields (`vectorShuffleRowKeySerializeWrite`, `vectorShuffleRowKeyOutput`, `vectorShuffleRowKeySerializeRow`) and initialization when `vectorShuffleBatchSerializer` is enabled and the key is not empty.
- When serializing per-row keys, compute the key hash with `Murmur3.hash32` and include `reduceTagByte` when appropriate; value serialization reuses existing `valueVectorSerializeRow` and `valueLazyBinarySerializeWrite` logic.
- Updated `tryCollectVectorShuffleBatch` signature to accept `tag` and branched logic to choose per-row emission when the logical record count for a (sub-)partition is <= `NUM_ROWS_THRESHOLD_FOR_BATCH`; updated callers in `VectorReduceSinkEmptyKeyOperator`, `VectorReduceSinkObjectHashOperator`, and `VectorReduceSinkUniformHashOperator` accordingly.
- Added simple counters/logging (`numRows`, `cntr`) and used `out.writeWithPartition` for partitioned per-row emission.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33f30f2718832883e8411c09cb8d9f)