### PR TITLE
Cache serialized uniform-hash vector shuffle keys

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
@@ -384,6 +384,8 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
       int numUnorderedPartitions, int tag) throws IOException {
     ensureVectorShufflePartitionBatchScratch(batch);
 
+    clearVectorShuffleRowKeyBatchCache();
+
     final int[] hashCodes;
     final int partitionerType = vectorShufflePartitionerType;
     try {
@@ -512,20 +514,13 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
     try {
       if (isEmptyKey) {
         initializeEmptyKey(tag);
-      } else {
+      } else if (!serializeVectorShuffleRowKeyFromBatchCache(batchIndex, tag)) {
         vectorShuffleRowKeySerializeWrite.reset();
         vectorShuffleRowKeySerializeRow.serializeWrite(batch, batchIndex);
 
         final int keyLength = vectorShuffleRowKeyOutput.getLength();
-        if (tag == -1 || reduceSkipTag) {
-          keyWritable.set(vectorShuffleRowKeyOutput.getData(), 0, keyLength);
-        } else {
-          keyWritable.setSize(keyLength + 1);
-          System.arraycopy(vectorShuffleRowKeyOutput.getData(), 0, keyWritable.get(), 0, keyLength);
-          keyWritable.get()[keyLength] = reduceTagByte;
-        }
-        keyWritable.setDistKeyLength(keyLength);
-        keyWritable.setHashCode(Murmur3.hash32(vectorShuffleRowKeyOutput.getData(), 0, keyLength, 0));
+        setVectorShuffleRowKey(vectorShuffleRowKeyOutput.getData(), 0, keyLength,
+            Murmur3.hash32(vectorShuffleRowKeyOutput.getData(), 0, keyLength, 0), tag);
       }
 
       if (isEmptyValue) {
@@ -538,6 +533,27 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
     } catch (Exception e) {
       throw new IOException("Failed to serialize vector shuffle row", e);
     }
+  }
+
+  protected void clearVectorShuffleRowKeyBatchCache() {
+  }
+
+  protected boolean serializeVectorShuffleRowKeyFromBatchCache(int batchIndex, int tag)
+      throws IOException {
+    return false;
+  }
+
+  protected void setVectorShuffleRowKey(byte[] keyBytes, int keyStart, int keyLength,
+      int keyHashCode, int tag) {
+    if (tag == -1 || reduceSkipTag) {
+      keyWritable.set(keyBytes, keyStart, keyLength);
+    } else {
+      keyWritable.setSize(keyLength + 1);
+      System.arraycopy(keyBytes, keyStart, keyWritable.get(), 0, keyLength);
+      keyWritable.get()[keyLength] = reduceTagByte;
+    }
+    keyWritable.setDistKeyLength(keyLength);
+    keyWritable.setHashCode(keyHashCode);
   }
 
   private void doCollectRowWithPartition(HiveKey keyWritable, BytesWritable valueWritable, int partition)

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
@@ -514,7 +514,9 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
     try {
       if (isEmptyKey) {
         initializeEmptyKey(tag);
-      } else if (!serializeVectorShuffleRowKeyFromBatchCache(batchIndex, tag)) {
+      } else if (hasVectorShuffleRowKeyBatchCache()) {
+        serializeVectorShuffleRowKeyFromBatchCache(batchIndex, tag);
+      } else {
         vectorShuffleRowKeySerializeWrite.reset();
         vectorShuffleRowKeySerializeRow.serializeWrite(batch, batchIndex);
 
@@ -538,9 +540,12 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
   protected void clearVectorShuffleRowKeyBatchCache() {
   }
 
-  protected boolean serializeVectorShuffleRowKeyFromBatchCache(int batchIndex, int tag)
-      throws IOException {
+  protected boolean hasVectorShuffleRowKeyBatchCache() {
     return false;
+  }
+
+  protected void serializeVectorShuffleRowKeyFromBatchCache(int batchIndex, int tag)
+      throws IOException {
   }
 
   protected void setVectorShuffleRowKey(byte[] keyBytes, int keyStart, int keyLength,

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkUniformHashOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkUniformHashOperator.java
@@ -58,6 +58,13 @@ public abstract class VectorReduceSinkUniformHashOperator extends VectorReduceSi
   // The object that determines equal key series.
   protected transient VectorKeySeriesSerialized serializedKeySeries;
 
+  // Cached serialized keys from the most recent computeKeyHashCodes call, indexed by physical row.
+  private transient byte[][] serializedKeyBytesByRow;
+  private transient int[] serializedKeyStartsByRow;
+  private transient int[] serializedKeyLengthsByRow;
+  private transient int[] serializedKeyHashCodesByRow;
+  private transient boolean serializedKeyCacheValid;
+
 
   /** Kryo ctor. */
   protected VectorReduceSinkUniformHashOperator() {
@@ -100,22 +107,59 @@ public abstract class VectorReduceSinkUniformHashOperator extends VectorReduceSi
     try {
       serializedKeySeries.processBatch(batch);
     } catch (IOException e) {
+      serializedKeyCacheValid = false;
       throw new HiveException(e);
     }
+
+    ensureSerializedKeyCache(batch.selected.length);
+    serializedKeyCacheValid = true;
 
     final boolean selectedInUse = batch.selectedInUse;
     final int[] selected = batch.selected;
 
     do {
-      final int hashCode = serializedKeySeries.getCurrentIsAllNull()
-          ? nullKeyHashCode : serializedKeySeries.getCurrentHashCode();
+      final boolean isAllNull = serializedKeySeries.getCurrentIsAllNull();
+      final byte[] keyBytes = isAllNull ? nullBytes : serializedKeySeries.getSerializedBytes();
+      final int keyStart = isAllNull ? 0 : serializedKeySeries.getSerializedStart();
+      final int keyLength = isAllNull ? nullBytes.length : serializedKeySeries.getSerializedLength();
+      final int hashCode = isAllNull ? nullKeyHashCode : serializedKeySeries.getCurrentHashCode();
       final int end = serializedKeySeries.getCurrentLogical()
           + serializedKeySeries.getCurrentDuplicateCount();
       for (int logical = serializedKeySeries.getCurrentLogical(); logical < end; logical++) {
         final int batchIndex = selectedInUse ? selected[logical] : logical;
         hashCodes[batchIndex] = hashCode;
+        serializedKeyBytesByRow[batchIndex] = keyBytes;
+        serializedKeyStartsByRow[batchIndex] = keyStart;
+        serializedKeyLengthsByRow[batchIndex] = keyLength;
+        serializedKeyHashCodesByRow[batchIndex] = hashCode;
       }
     } while (serializedKeySeries.next());
+  }
+
+  private void ensureSerializedKeyCache(int minimumLength) {
+    if (serializedKeyBytesByRow == null || serializedKeyBytesByRow.length < minimumLength) {
+      serializedKeyBytesByRow = new byte[minimumLength][];
+      serializedKeyStartsByRow = new int[minimumLength];
+      serializedKeyLengthsByRow = new int[minimumLength];
+      serializedKeyHashCodesByRow = new int[minimumLength];
+    }
+  }
+
+  @Override
+  protected void clearVectorShuffleRowKeyBatchCache() {
+    serializedKeyCacheValid = false;
+  }
+
+  @Override
+  protected boolean serializeVectorShuffleRowKeyFromBatchCache(int batchIndex, int tag)
+      throws IOException {
+    if (!serializedKeyCacheValid || serializedKeyBytesByRow == null
+        || batchIndex >= serializedKeyBytesByRow.length || serializedKeyBytesByRow[batchIndex] == null) {
+      return false;
+    }
+    setVectorShuffleRowKey(serializedKeyBytesByRow[batchIndex], serializedKeyStartsByRow[batchIndex],
+        serializedKeyLengthsByRow[batchIndex], serializedKeyHashCodesByRow[batchIndex], tag);
+    return true;
   }
 
   @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkUniformHashOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkUniformHashOperator.java
@@ -151,15 +151,15 @@ public abstract class VectorReduceSinkUniformHashOperator extends VectorReduceSi
   }
 
   @Override
-  protected boolean serializeVectorShuffleRowKeyFromBatchCache(int batchIndex, int tag)
+  protected boolean hasVectorShuffleRowKeyBatchCache() {
+    return serializedKeyCacheValid;
+  }
+
+  @Override
+  protected void serializeVectorShuffleRowKeyFromBatchCache(int batchIndex, int tag)
       throws IOException {
-    if (!serializedKeyCacheValid || serializedKeyBytesByRow == null
-        || batchIndex >= serializedKeyBytesByRow.length || serializedKeyBytesByRow[batchIndex] == null) {
-      return false;
-    }
     setVectorShuffleRowKey(serializedKeyBytesByRow[batchIndex], serializedKeyStartsByRow[batchIndex],
         serializedKeyLengthsByRow[batchIndex], serializedKeyHashCodesByRow[batchIndex], tag);
-    return true;
   }
 
   @Override


### PR DESCRIPTION
### Motivation
- Computing serialized keys in `VectorReduceSinkUniformHashOperator.computeKeyHashCodes()` can cause keys to be serialized twice when a partition contains a single record, leading to wasted CPU and allocations. 
- Cache the serialized key bytes and metadata produced during hash-code computation so subsequent row-wise vector shuffle serialization can reuse the result and avoid reserializing the same key.

### Description
- Add transient per-physical-row caches (`serializedKeyBytesByRow`, `serializedKeyStartsByRow`, `serializedKeyLengthsByRow`, `serializedKeyHashCodesByRow`) and a `serializedKeyCacheValid` flag to `VectorReduceSinkUniformHashOperator` and populate them from `computeKeyHashCodes()` as keys are scanned. 
- Introduce `ensureSerializedKeyCache()` and set `serializedKeyCacheValid` appropriately; mark cache invalid on errors. 
- Add common hooks in `VectorReduceSinkCommonOperator`: `clearVectorShuffleRowKeyBatchCache()`, `serializeVectorShuffleRowKeyFromBatchCache(int batchIndex, int tag)`, and centralized `setVectorShuffleRowKey(...)` to allow reuse of cached bytes before falling back to per-row serialization. 
- Change `serializeVectorShuffleRow()` to attempt cache reuse via `serializeVectorShuffleRowKeyFromBatchCache()` before performing row-wise serialization, and call `clearVectorShuffleRowKeyBatchCache()` before computing partition hashes so the cache only applies to the current batch. 

### Testing
- Ran `git diff --check` which produced no whitespace/patch issues. 
- Attempted `mvn -pl ql -DskipTests compile -q` to compile the module, but the build was blocked by an external dependency resolution error fetching parent POM `org.apache:apache:pom:23` from Maven Central (HTTP 403), so a full compile could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34a2e318048328977dbc0a209dd569)