### PR TITLE
Use fixed-width byte-buffer serde for vector shuffle and add direct decimal read/write

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorShuffleBatchDeserializer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorShuffleBatchDeserializer.java
@@ -22,8 +22,6 @@ import java.io.IOException;
 import org.apache.hadoop.hive.common.type.HiveIntervalDayTime;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.io.BytesWritable;
-import org.apache.hadoop.io.DataInputBuffer;
-import org.apache.hadoop.io.WritableUtils;
 
 /** Deserializes a compact vector shuffle payload into an already schema-initialized batch. */
 public final class VectorShuffleBatchDeserializer {
@@ -31,7 +29,9 @@ public final class VectorShuffleBatchDeserializer {
   private static final int HAS_NULLS = 2;
   private static final int IS_DECIMAL_64 = 4;
 
-  private final DataInputBuffer input = new DataInputBuffer();
+  private byte[] buffer;
+  private int position;
+  private int limit;
 
   public void deserialize(BytesWritable serialized, VectorizedRowBatch destination)
       throws IOException {
@@ -39,9 +39,11 @@ public final class VectorShuffleBatchDeserializer {
       throw new IllegalArgumentException("Serialized batch and destination are required");
     }
 
-    input.reset(serialized.getBytes(), serialized.getLength());
-    final int rowCount = WritableUtils.readVInt(input);
-    final int columnCount = WritableUtils.readVInt(input);
+    buffer = serialized.getBytes();
+    position = 0;
+    limit = serialized.getLength();
+    final int rowCount = readInt();
+    final int columnCount = readInt();
     if (rowCount < 0 || columnCount < 0 || columnCount > destination.cols.length) {
       throw new IOException("Invalid vector shuffle batch dimensions: " + rowCount + " rows, "
           + columnCount + " columns");
@@ -64,9 +66,8 @@ public final class VectorShuffleBatchDeserializer {
       }
       readColumn(column, rowCount);
     }
-    if (input.getPosition() != serialized.getLength()) {
-      throw new IOException("Vector shuffle batch has "
-          + (serialized.getLength() - input.getPosition()) + " trailing bytes");
+    if (position != limit) {
+      throw new IOException("Vector shuffle batch has " + (limit - position) + " trailing bytes");
     }
   }
 
@@ -76,7 +77,7 @@ public final class VectorShuffleBatchDeserializer {
 
   private void readColumn(ColumnVector column, int[] destinationIndices, int rowCount)
       throws IOException {
-    final int flags = input.readUnsignedByte();
+    final int flags = readUnsignedByte();
     final boolean repeating = (flags & IS_REPEATING) != 0;
     final boolean hasNulls = (flags & HAS_NULLS) != 0;
     final boolean sourceIsDecimal64 = (flags & IS_DECIMAL_64) != 0;
@@ -91,7 +92,7 @@ public final class VectorShuffleBatchDeserializer {
     byte[] nullBitmap = null;
     if (hasNulls) {
       nullBitmap = new byte[(valueCount + 7) / 8];
-      input.readFully(nullBitmap);
+      readFully(nullBitmap);
     }
 
     column.isRepeating = repeating;
@@ -159,7 +160,7 @@ public final class VectorShuffleBatchDeserializer {
     for (int logical = 0; logical < valueCount; logical++) {
       int destinationIndex = destinationIndex(destinationIndices, logical, repeating);
       if (!union.isNull[destinationIndex]) {
-        int tag = WritableUtils.readVInt(input);
+        int tag = readInt();
         if (tag < 0 || tag >= union.fields.length) {
           throw new IOException("Invalid union tag " + tag + " for " + union.fields.length
               + " fields");
@@ -196,7 +197,7 @@ public final class VectorShuffleBatchDeserializer {
       int destinationIndex = destinationIndex(destinationIndices, logical, repeating);
       column.offsets[destinationIndex] = childCount;
       if (!column.isNull[destinationIndex]) {
-        int length = WritableUtils.readVInt(input);
+        int length = readInt();
         if (length < 0) {
           throw new IOException("Negative multi-valued vector length " + length);
         }
@@ -208,6 +209,55 @@ public final class VectorShuffleBatchDeserializer {
     }
     column.childCount = childCount;
     return childCount;
+  }
+
+  private void requireAvailable(int bytes) throws IOException {
+    if (position + bytes > limit) {
+      throw new IOException("Vector shuffle batch ended while reading " + bytes + " bytes");
+    }
+  }
+
+  private int readUnsignedByte() throws IOException {
+    requireAvailable(1);
+    return buffer[position++] & 0xff;
+  }
+
+  private boolean readBoolean() throws IOException {
+    return readUnsignedByte() != 0;
+  }
+
+  private int readInt() throws IOException {
+    requireAvailable(4);
+    return ((buffer[position++] & 0xff) << 24)
+        | ((buffer[position++] & 0xff) << 16)
+        | ((buffer[position++] & 0xff) << 8)
+        | (buffer[position++] & 0xff);
+  }
+
+  private long readLong() throws IOException {
+    requireAvailable(8);
+    return ((long) (buffer[position++] & 0xff) << 56)
+        | ((long) (buffer[position++] & 0xff) << 48)
+        | ((long) (buffer[position++] & 0xff) << 40)
+        | ((long) (buffer[position++] & 0xff) << 32)
+        | ((long) (buffer[position++] & 0xff) << 24)
+        | ((long) (buffer[position++] & 0xff) << 16)
+        | ((long) (buffer[position++] & 0xff) << 8)
+        | ((long) buffer[position++] & 0xff);
+  }
+
+  private double readDouble() throws IOException {
+    return Double.longBitsToDouble(readLong());
+  }
+
+  private void readFully(byte[] bytes) throws IOException {
+    readFully(bytes, 0, bytes.length);
+  }
+
+  private void readFully(byte[] bytes, int offset, int length) throws IOException {
+    requireAvailable(length);
+    System.arraycopy(buffer, position, bytes, offset, length);
+    position += length;
   }
 
   private boolean isNull(byte[] nullBitmap, int logical) {
@@ -231,18 +281,18 @@ public final class VectorShuffleBatchDeserializer {
 
   private void readTypeMetadata(ColumnVector column) throws IOException {
     if (column instanceof DateColumnVector) {
-      ((DateColumnVector) column).setUsingProlepticCalendar(input.readBoolean());
+      ((DateColumnVector) column).setUsingProlepticCalendar(readBoolean());
     } else if (column instanceof TimestampColumnVector) {
       TimestampColumnVector timestamp = (TimestampColumnVector) column;
-      timestamp.setIsUTC(input.readBoolean());
-      timestamp.setUsingProlepticCalendar(input.readBoolean());
+      timestamp.setIsUTC(readBoolean());
+      timestamp.setUsingProlepticCalendar(readBoolean());
     }
   }
 
   private void readValue(ColumnVector column, int index, boolean sourceIsDecimal64)
       throws IOException {
     if (sourceIsDecimal64) {
-      long decimal64 = input.readLong();
+      long decimal64 = readLong();
       if (column instanceof Decimal64ColumnVector) {
         ((Decimal64ColumnVector) column).vector[index] = decimal64;
       } else {
@@ -252,31 +302,31 @@ public final class VectorShuffleBatchDeserializer {
       return;
     }
     if (column instanceof BytesColumnVector) {
-      int length = WritableUtils.readVInt(input);
+      int length = readInt();
       if (length < 0) {
         throw new IOException("Negative byte-vector value length " + length);
       }
       byte[] bytes = new byte[length];
-      input.readFully(bytes);
+      readFully(bytes);
       ((BytesColumnVector) column).setVal(index, bytes);
     } else if (column instanceof TimestampColumnVector) {
       TimestampColumnVector timestamp = (TimestampColumnVector) column;
-      timestamp.time[index] = input.readLong();
-      timestamp.nanos[index] = input.readInt();
+      timestamp.time[index] = readLong();
+      timestamp.nanos[index] = readInt();
     } else if (column instanceof IntervalDayTimeColumnVector) {
       ((IntervalDayTimeColumnVector) column).set(index,
-          new HiveIntervalDayTime(input.readLong(), input.readInt()));
+          new HiveIntervalDayTime(readLong(), readInt()));
     } else if (column instanceof Decimal64ColumnVector) {
       HiveDecimalWritable decimal = new HiveDecimalWritable();
-      decimal.readFields(input);
+      position += decimal.readDirect(buffer, position);
       ((Decimal64ColumnVector) column).set(index, decimal);
     } else if (column instanceof DecimalColumnVector) {
-      ((DecimalColumnVector) column).vector[index].readFields(input);
+      position += ((DecimalColumnVector) column).vector[index].readDirect(buffer, position);
     } else if (column instanceof LongColumnVector) {
       // Decimal64ColumnVector extends LongColumnVector, so this branch covers it.
-      ((LongColumnVector) column).vector[index] = input.readLong();
+      ((LongColumnVector) column).vector[index] = readLong();
     } else if (column instanceof DoubleColumnVector) {
-      ((DoubleColumnVector) column).vector[index] = input.readDouble();
+      ((DoubleColumnVector) column).vector[index] = readDouble();
     } else if (column instanceof VoidColumnVector) {
       // VOID has no value payload.
     } else {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorShuffleBatchSerializer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorShuffleBatchSerializer.java
@@ -21,8 +21,6 @@ import java.io.IOException;
 
 import org.apache.hadoop.hive.common.type.HiveIntervalDayTime;
 import org.apache.hadoop.io.BytesWritable;
-import org.apache.hadoop.io.DataOutputBuffer;
-import org.apache.hadoop.io.WritableUtils;
 
 /**
  * Serializes the active rows of selected columns from a {@link VectorizedRowBatch}.
@@ -37,7 +35,10 @@ public final class VectorShuffleBatchSerializer {
   private static final int HAS_NULLS = 2;
   private static final int IS_DECIMAL_64 = 4;
 
-  private final DataOutputBuffer buffer = new DataOutputBuffer();
+  private static final int INITIAL_BUFFER_SIZE = 102400;
+
+  private final byte[] buffer = new byte[INITIAL_BUFFER_SIZE];
+  private int position;
 
   public void serialize(VectorizedRowBatch source, int[] sourceColumnMap, BytesWritable output)
       throws IOException {
@@ -46,13 +47,13 @@ public final class VectorShuffleBatchSerializer {
       logicalRows[logical] = source.selectedInUse ? source.selected[logical] : logical;
     }
 
-    buffer.reset();
-    WritableUtils.writeVInt(buffer, source.size);
-    WritableUtils.writeVInt(buffer, sourceColumnMap.length);
+    reset();
+    writeInt(source.size);
+    writeInt(sourceColumnMap.length);
     for (int sourceColumn : sourceColumnMap) {
       writeColumn(source.cols[sourceColumn], logicalRows, source.size);
     }
-    output.set(buffer.getData(), 0, buffer.getLength());
+    output.set(buffer, 0, position);
   }
 
   public void serialize(VectorizedRowBatch source, int[] sourceColumnMap, int[] rowIndices,
@@ -65,20 +66,20 @@ public final class VectorShuffleBatchSerializer {
       System.arraycopy(rowIndices, rowOffset, logicalRows, 0, rowCount);
     }
 
-    buffer.reset();
-    WritableUtils.writeVInt(buffer, rowCount);
-    WritableUtils.writeVInt(buffer, sourceColumnMap.length);
+    reset();
+    writeInt(rowCount);
+    writeInt(sourceColumnMap.length);
     for (int sourceColumn : sourceColumnMap) {
       writeColumn(source.cols[sourceColumn], logicalRows, rowCount);
     }
-    output.set(buffer.getData(), 0, buffer.getLength());
+    output.set(buffer, 0, position);
   }
 
   private void writeColumn(ColumnVector column, int[] indices, int count) throws IOException {
     final boolean repeating = column.isRepeating;
     final int valueCount = repeating ? Math.min(count, 1) : count;
     final boolean hasNulls = hasNulls(column, indices, valueCount, repeating);
-    buffer.writeByte((repeating ? IS_REPEATING : 0) | (hasNulls ? HAS_NULLS : 0)
+    writeByte((repeating ? IS_REPEATING : 0) | (hasNulls ? HAS_NULLS : 0)
         | (column instanceof Decimal64ColumnVector ? IS_DECIMAL_64 : 0));
 
     byte[] nullBitmap = null;
@@ -89,7 +90,7 @@ public final class VectorShuffleBatchSerializer {
           nullBitmap[logical >>> 3] |= 1 << (logical & 7);
         }
       }
-      buffer.write(nullBitmap);
+      writeBytes(nullBitmap);
     }
 
     writeTypeMetadata(column);
@@ -144,7 +145,7 @@ public final class VectorShuffleBatchSerializer {
       if (nullBitmap == null || (nullBitmap[logical >>> 3] & (1 << (logical & 7))) == 0) {
         int tag = union.tags[physicalIndex(indices, logical, repeating)];
         validateUnionTag(tag, union.fields.length);
-        WritableUtils.writeVInt(buffer, tag);
+        writeInt(tag);
         fieldCounts[tag]++;
       }
     }
@@ -182,7 +183,7 @@ public final class VectorShuffleBatchSerializer {
       if (nullBitmap == null || (nullBitmap[logical >>> 3] & (1 << (logical & 7))) == 0) {
         int index = physicalIndex(indices, logical, repeating);
         int length = Math.toIntExact(parent.lengths[index]);
-        WritableUtils.writeVInt(buffer, length);
+        writeInt(length);
         childCount = Math.addExact(childCount, length);
       }
     }
@@ -203,6 +204,49 @@ public final class VectorShuffleBatchSerializer {
     if (secondChild != null) {
       writeColumn(secondChild, childIndices, childCount);
     }
+  }
+
+  private void reset() {
+    position = 0;
+  }
+
+  private void writeByte(int value) {
+    buffer[position++] = (byte) value;
+  }
+
+  private void writeBoolean(boolean value) {
+    writeByte(value ? 1 : 0);
+  }
+
+  private void writeInt(int value) {
+    buffer[position++] = (byte) (value >>> 24);
+    buffer[position++] = (byte) (value >>> 16);
+    buffer[position++] = (byte) (value >>> 8);
+    buffer[position++] = (byte) value;
+  }
+
+  private void writeLong(long value) {
+    buffer[position++] = (byte) (value >>> 56);
+    buffer[position++] = (byte) (value >>> 48);
+    buffer[position++] = (byte) (value >>> 40);
+    buffer[position++] = (byte) (value >>> 32);
+    buffer[position++] = (byte) (value >>> 24);
+    buffer[position++] = (byte) (value >>> 16);
+    buffer[position++] = (byte) (value >>> 8);
+    buffer[position++] = (byte) value;
+  }
+
+  private void writeDouble(double value) {
+    writeLong(Double.doubleToLongBits(value));
+  }
+
+  private void writeBytes(byte[] bytes) {
+    writeBytes(bytes, 0, bytes.length);
+  }
+
+  private void writeBytes(byte[] bytes, int offset, int length) {
+    System.arraycopy(bytes, offset, buffer, position, length);
+    position += length;
   }
 
   private boolean hasNulls(ColumnVector column, int[] indices, int valueCount,
@@ -228,35 +272,35 @@ public final class VectorShuffleBatchSerializer {
 
   private void writeTypeMetadata(ColumnVector column) throws IOException {
     if (column instanceof DateColumnVector) {
-      buffer.writeBoolean(((DateColumnVector) column).isUsingProlepticCalendar());
+      writeBoolean(((DateColumnVector) column).isUsingProlepticCalendar());
     } else if (column instanceof TimestampColumnVector) {
       TimestampColumnVector timestamp = (TimestampColumnVector) column;
-      buffer.writeBoolean(timestamp.isUTC());
-      buffer.writeBoolean(timestamp.usingProlepticCalendar());
+      writeBoolean(timestamp.isUTC());
+      writeBoolean(timestamp.usingProlepticCalendar());
     }
   }
 
   private void writeValue(ColumnVector column, int index) throws IOException {
     if (column instanceof BytesColumnVector) {
       BytesColumnVector bytes = (BytesColumnVector) column;
-      WritableUtils.writeVInt(buffer, bytes.length[index]);
-      buffer.write(bytes.vector[index], bytes.start[index], bytes.length[index]);
+      writeInt(bytes.length[index]);
+      writeBytes(bytes.vector[index], bytes.start[index], bytes.length[index]);
     } else if (column instanceof TimestampColumnVector) {
       TimestampColumnVector timestamp = (TimestampColumnVector) column;
-      buffer.writeLong(timestamp.time[index]);
-      buffer.writeInt(timestamp.nanos[index]);
+      writeLong(timestamp.time[index]);
+      writeInt(timestamp.nanos[index]);
     } else if (column instanceof IntervalDayTimeColumnVector) {
       HiveIntervalDayTime interval =
           ((IntervalDayTimeColumnVector) column).asScratchIntervalDayTime(index);
-      buffer.writeLong(interval.getTotalSeconds());
-      buffer.writeInt(interval.getNanos());
+      writeLong(interval.getTotalSeconds());
+      writeInt(interval.getNanos());
     } else if (column instanceof DecimalColumnVector) {
-      ((DecimalColumnVector) column).vector[index].write(buffer);
+      position += ((DecimalColumnVector) column).vector[index].writeDirect(buffer, position);
     } else if (column instanceof LongColumnVector) {
       // Decimal64ColumnVector extends LongColumnVector, so this branch covers it.
-      buffer.writeLong(((LongColumnVector) column).vector[index]);
+      writeLong(((LongColumnVector) column).vector[index]);
     } else if (column instanceof DoubleColumnVector) {
-      buffer.writeDouble(((DoubleColumnVector) column).vector[index]);
+      writeDouble(((DoubleColumnVector) column).vector[index]);
     } else if (column instanceof VoidColumnVector) {
       // VOID has no value payload.
     } else {

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorShuffleBatchSerde.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorShuffleBatchSerde.java
@@ -479,14 +479,24 @@ public class TestVectorShuffleBatchSerde {
 
   @Test
   public void testDeserializerRejectsInvalidEncodedUnionTag() {
-    BytesWritable invalid = new BytesWritable(new byte[] {1, 1, 0, 1});
+    BytesWritable invalid = new BytesWritable(new byte[] {
+        0, 0, 0, 1,  // row count
+        0, 0, 0, 1,  // column count
+        0,           // column flags
+        0, 0, 0, 1   // invalid union tag
+    });
     assertThrows(IOException.class, () -> deserializer.deserialize(invalid,
         batchWithColumn(unionOf(new LongColumnVector()), 0)));
   }
 
   @Test
   public void testDeserializerRejectsTruncatedUnionTagSequence() {
-    BytesWritable truncated = new BytesWritable(new byte[] {2, 1, 0, 0});
+    BytesWritable truncated = new BytesWritable(new byte[] {
+        0, 0, 0, 1,  // row count
+        0, 0, 0, 1,  // column count
+        0,           // column flags
+        0, 0         // truncated union tag
+    });
     assertThrows(IOException.class, () -> deserializer.deserialize(truncated,
         batchWithColumn(unionOf(new LongColumnVector()), 0)));
   }

--- a/storage-api/src/java/org/apache/hadoop/hive/serde2/io/HiveDecimalWritable.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/serde2/io/HiveDecimalWritable.java
@@ -386,6 +386,69 @@ public final class HiveDecimalWritable extends FastHiveDecimal
   }
 
   /**
+   * Serialize this object directly to a byte array using fixed-width integers.
+   *
+   * @return the number of bytes written
+   */
+  @HiveDecimalWritableVersionV1
+  public int writeDirect(byte[] output, int offset) {
+    if (!isSet()) {
+      throw new RuntimeException("no value set");
+    }
+
+    if (internalScratchLongs == null) {
+      internalScratchLongs = new long[FastHiveDecimal.FAST_SCRATCH_LONGS_LEN];
+      internalScratchBuffer = new byte[FastHiveDecimal.FAST_SCRATCH_BUFFER_LEN_BIG_INTEGER_BYTES];
+    }
+
+    int position = offset;
+    int scale = fastScale();
+    output[position++] = (byte) (scale >>> 24);
+    output[position++] = (byte) (scale >>> 16);
+    output[position++] = (byte) (scale >>> 8);
+    output[position++] = (byte) scale;
+
+    int byteLength = fastBigIntegerBytes(internalScratchLongs, internalScratchBuffer);
+    if (byteLength == 0) {
+      throw new RuntimeException("Couldn't convert decimal to binary");
+    }
+
+    output[position++] = (byte) (byteLength >>> 24);
+    output[position++] = (byte) (byteLength >>> 16);
+    output[position++] = (byte) (byteLength >>> 8);
+    output[position++] = (byte) byteLength;
+    System.arraycopy(internalScratchBuffer, 0, output, position, byteLength);
+    position += byteLength;
+    return position - offset;
+  }
+
+  /**
+   * Deserialize this object directly from a byte array using fixed-width integers.
+   *
+   * @return the number of bytes read
+   */
+  @HiveDecimalWritableVersionV1
+  public int readDirect(byte[] input, int offset) throws IOException {
+    int position = offset;
+    int scale = ((input[position++] & 0xff) << 24)
+        | ((input[position++] & 0xff) << 16)
+        | ((input[position++] & 0xff) << 8)
+        | (input[position++] & 0xff);
+    int byteArrayLen = ((input[position++] & 0xff) << 24)
+        | ((input[position++] & 0xff) << 16)
+        | ((input[position++] & 0xff) << 8)
+        | (input[position++] & 0xff);
+
+    fastReset();
+    if (!fastSetFromBigIntegerBytesAndScale(input, position, byteArrayLen, scale)) {
+      throw new IOException("Couldn't convert decimal");
+    }
+    position += byteArrayLen;
+    isSet = true;
+    return position - offset;
+  }
+
+  /**
    * Standard Writable method that deserialize the fields of this object from a DataInput.
    * 
    */


### PR DESCRIPTION
### Motivation

- Replace varint-based `WritableUtils` and Hadoop `DataInputBuffer`/`DataOutputBuffer` usage with a compact, fixed-width byte-buffer protocol to simplify parsing and avoid per-IO-object allocations. 
- Add direct decimal (de)serialization to allow writing/reading `HiveDecimalWritable` values straight to/from byte arrays used by the vector shuffle serializer/deserializer. 

### Description

- Replaced `DataInputBuffer`/`WritableUtils` in `VectorShuffleBatchDeserializer` with a `byte[]` buffer and manual cursor (`position`/`limit`) and implemented `readUnsignedByte`, `readBoolean`, `readInt`, `readLong`, `readDouble`, `readFully`, and `requireAvailable` used throughout the deserializer.  
- Replaced `DataOutputBuffer`/`WritableUtils` in `VectorShuffleBatchSerializer` with a reusable `byte[]` buffer and `position` pointer and added `reset`, `writeByte`, `writeBoolean`, `writeInt`, `writeLong`, `writeDouble`, and `writeBytes` helpers; output is set with `output.set(buffer, 0, position)`.  
- Added `writeDirect` and `readDirect` methods to `HiveDecimalWritable` to support direct fixed-width serialization into/from byte arrays, and switched decimal read/write sites in the serializer/deserializer to use these direct methods.  
- Updated tests in `TestVectorShuffleBatchSerde` to emit/expect the new fixed-width encodings for small crafted payloads (e.g. invalid/truncated union tag cases).  

### Testing

- Ran the `TestVectorShuffleBatchSerde` unit test class which was updated to match the new encoding, and the tests passed.  
- Ran the vector shuffle serializer/deserializer tests producing/consuming real serialized payloads and they passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3525adf5c48328a59abfb4bd752774)