### PR TITLE
Simplify vector reduce sink hash exception handling

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
@@ -386,16 +386,12 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
 
     final int[] hashCodes;
     final int partitionerType = vectorShufflePartitionerType;
-    try {
-      if (partitionerType == 0) {
-        hashCodes = batchKeyHashCodes;
-        computeKeyHashCodes(batch, hashCodes);
-      } else {
-        hashCodes = batchValueHashCodes;
-        computeValueHashCodes(batch, hashCodes);
-      }
-    } catch (HiveException e) {
-      throw new IOException("Failed to compute vector shuffle batch partition hashes", e);
+    if (partitionerType == 0) {
+      hashCodes = batchKeyHashCodes;
+      computeKeyHashCodes(batch, hashCodes);
+    } else {
+      hashCodes = batchValueHashCodes;
+      computeValueHashCodes(batch, hashCodes);
     }
 
     Arrays.fill(vectorShufflePartitionCounts, 0, numUnorderedPartitions, 0);
@@ -577,7 +573,7 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
    * only entries for batch.selected[0..batch.size) are required to be valid.
    */
   protected abstract void computeKeyHashCodes(VectorizedRowBatch batch, int[] hashCodes)
-      throws HiveException;
+      throws IOException;
 
   /**
    * Computes reducer-routing value hash codes for all active rows in the batch.
@@ -588,7 +584,7 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
    * are required to be valid.
    */
   protected void computeValueHashCodes(VectorizedRowBatch batch, int[] hashCodes)
-      throws HiveException {
+      throws IOException {
     final boolean selectedInUse = batch.selectedInUse;
     final int[] selected = batch.selected;
     final int size = batch.size;
@@ -610,7 +606,7 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
         hashCodes[batchIndex] = valueBytesWritable.hashCode();
       }
     } catch (Exception e) {
-      throw new HiveException(e);
+      throw new IOException("Failed to compute vector shuffle batch value hashes", e);
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkEmptyKeyOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkEmptyKeyOperator.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.hive.ql.exec.vector.reducesink;
 
+import java.io.IOException;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.CompilationOpContext;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizationContext;
@@ -74,7 +76,7 @@ public class VectorReduceSinkEmptyKeyOperator extends VectorReduceSinkCommonOper
   }
 
   @Override
-  protected void computeKeyHashCodes(VectorizedRowBatch batch, int[] hashCodes) throws HiveException {
+  protected void computeKeyHashCodes(VectorizedRowBatch batch, int[] hashCodes) throws IOException {
     final int size = batch.size;
     if (batch.selectedInUse) {
       final int[] selected = batch.selected;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkObjectHashOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkObjectHashOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hive.ql.exec.vector.reducesink;
 
+import java.io.IOException;
 import java.util.Random;
 
 import java.util.function.ToIntFunction;
@@ -294,7 +295,7 @@ public class VectorReduceSinkObjectHashOperator extends VectorReduceSinkCommonOp
 
 
   @Override
-  protected void computeKeyHashCodes(VectorizedRowBatch batch, int[] hashCodes) throws HiveException {
+  protected void computeKeyHashCodes(VectorizedRowBatch batch, int[] hashCodes) throws IOException {
     final boolean selectedInUse = batch.selectedInUse;
     final int[] selected = batch.selected;
     final int size = batch.size;
@@ -322,7 +323,11 @@ public class VectorReduceSinkObjectHashOperator extends VectorReduceSinkCommonOp
         final int bucketNum = ObjectInspectorUtils.getBucketNumber(
             bucketHashFunc.applyAsInt(bucketFieldValues), numBuckets);
         if (bucketExpr != null) {
-          evaluateBucketExpr(batch, batchIndex, bucketNum);
+          try {
+            evaluateBucketExpr(batch, batchIndex, bucketNum);
+          } catch (HiveException e) {
+            throw new IOException("Failed to evaluate bucket expression", e);
+          }
         }
         hashCode = hashCode * 31 + bucketNum;
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkUniformHashOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkUniformHashOperator.java
@@ -96,6 +96,10 @@ public abstract class VectorReduceSinkUniformHashOperator extends VectorReduceSi
       nullBytes = new byte[nullBytesLength];
       System.arraycopy(nullKeyOutput.getData(), 0, nullBytes, 0, nullBytesLength);
       nullKeyHashCode = Murmur3.hash32(nullBytes, 0, nullBytesLength, 0);
+      serializedKeyBytesByRow = new byte[VectorizedRowBatch.DEFAULT_SIZE][];
+      serializedKeyStartsByRow = new int[VectorizedRowBatch.DEFAULT_SIZE];
+      serializedKeyLengthsByRow = new int[VectorizedRowBatch.DEFAULT_SIZE];
+      serializedKeyHashCodesByRow = new int[VectorizedRowBatch.DEFAULT_SIZE];
 
     } catch (Exception e) {
       throw new HiveException(e);
@@ -103,15 +107,10 @@ public abstract class VectorReduceSinkUniformHashOperator extends VectorReduceSi
   }
 
   @Override
-  protected void computeKeyHashCodes(VectorizedRowBatch batch, int[] hashCodes) throws HiveException {
-    try {
-      serializedKeySeries.processBatch(batch);
-    } catch (IOException e) {
-      serializedKeyCacheValid = false;
-      throw new HiveException(e);
-    }
+  protected void computeKeyHashCodes(VectorizedRowBatch batch, int[] hashCodes) throws IOException {
+    serializedKeyCacheValid = false;
+    serializedKeySeries.processBatch(batch);
 
-    ensureSerializedKeyCache(batch.selected.length);
     serializedKeyCacheValid = true;
 
     final boolean selectedInUse = batch.selectedInUse;
@@ -134,15 +133,6 @@ public abstract class VectorReduceSinkUniformHashOperator extends VectorReduceSi
         serializedKeyHashCodesByRow[batchIndex] = hashCode;
       }
     } while (serializedKeySeries.next());
-  }
-
-  private void ensureSerializedKeyCache(int minimumLength) {
-    if (serializedKeyBytesByRow == null || serializedKeyBytesByRow.length < minimumLength) {
-      serializedKeyBytesByRow = new byte[minimumLength][];
-      serializedKeyStartsByRow = new int[minimumLength];
-      serializedKeyLengthsByRow = new int[minimumLength];
-      serializedKeyHashCodesByRow = new int[minimumLength];
-    }
   }
 
   @Override


### PR DESCRIPTION
### Motivation
- Reduce complexity around serialized-key cache management by preallocating per-row arrays sized to `VectorizedRowBatch.DEFAULT_SIZE` and remove dynamic resizing logic.
- Surface IO-related failures directly to vector shuffle callers by letting hash-computation methods throw `IOException` instead of wrapping `IOException` as `HiveException`.

### Description
- Initialize `serializedKeyBytesByRow`, `serializedKeyStartsByRow`, `serializedKeyLengthsByRow`, and `serializedKeyHashCodesByRow` in `VectorReduceSinkUniformHashOperator.initializeOp()` to `VectorizedRowBatch.DEFAULT_SIZE` and remove `ensureSerializedKeyCache()`.
- Change the abstract signature `computeKeyHashCodes` in `VectorReduceSinkCommonOperator` to `throws IOException` and update `computeValueHashCodes` to `throws IOException` so callers can handle IO failures directly.
- Update implementations in `VectorReduceSinkUniformHashOperator`, `VectorReduceSinkEmptyKeyOperator`, and `VectorReduceSinkObjectHashOperator` to match the new `IOException` signatures and to invalidate the serialized-key cache before `serializedKeySeries.processBatch()`.
- Remove the redundant `try/catch` wrapper in `collectPartitionedVectorShuffleBatch()` so key/value hash computation errors propagate as `IOException`, and convert `HiveException` from bucket-expression evaluation to `IOException` inside `VectorReduceSinkObjectHashOperator`.

### Testing
- Ran `git diff --check` to validate formatting and simple diffs, which passed.
- Attempted `mvn -pl ql -DskipTests compile`, which failed to complete due to an external Maven parent POM resolution error (`org.apache:apache:pom:23` HTTP 403) and therefore compilation could not be fully verified in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3614d55f548328a4893422f507fbef)