### PR TITLE
Use direct value-byte writes for partitioned vector shuffle batches

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.io.BytesWritable;
 import org.apache.tez.mapreduce.output.MROutput;
 import org.apache.tez.runtime.api.TaskFailureType;
 import org.apache.tez.runtime.api.events.CustomProcessorEvent;
+import org.apache.tez.runtime.library.api.KeyValueWriterEdge.WriteValueBytes;
 import org.apache.tez.runtime.library.api.KeyValuesWriterEdge;
 import org.apache.tez.runtime.library.api.LogicalOutputEdge;
 import org.slf4j.Logger;
@@ -431,6 +432,15 @@ public class TezProcessor extends AbstractLogicalIOProcessor {
     public void writeWithPartition(BytesWritable key, BytesWritable value, int partition)
         throws IOException {
       writer.writeWithPartition(key, value, partition);
+    }
+
+    public WriteValueBytes requestWriteValueBytes(BytesWritable key, int partition) throws IOException {
+      return writer.requestWriteValueBytes(key, partition);
+    }
+
+    public void completeWriteValueBytes(BytesWritable key, int valLen, int partition)
+        throws IOException {
+      writer.completeWriteValueBytes(key, valLen, partition);
     }
 
     public void close() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hive.common.util.Murmur3;
 import org.apache.hadoop.mapred.OutputCollector;
+import org.apache.tez.runtime.library.api.KeyValueWriterEdge.WriteValueBytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,6 +74,7 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
 
   private static final int NUM_ROWS_THRESHOLD_FOR_BATCH = 1;
   private static final int SERIALIZE_BUFFER_SIZE = 100 * 1024;
+  private static final int MIN_VALUE_BYTES_THRESHOLD = 24;
 
   /**
    * Information about our native vectorized reduce sink created by the Vectorizer class during
@@ -437,15 +439,24 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
         collectVectorShuffleRows(batch, vectorShufflePartitionRowIndices,
             vectorShufflePartitionOffsets[partition], rowCount, partition, tag);
       } else {
+        WriteValueBytes valueBytes = out.requestWriteValueBytes(vectorShuffleBatchKey, partition);
+        if (valueBytes == null || valueBytes.maxValueBytes <= MIN_VALUE_BYTES_THRESHOLD) {
+          collectVectorShuffleRows(batch, vectorShufflePartitionRowIndices,
+              vectorShufflePartitionOffsets[partition], rowCount, partition, tag);
+          continue;
+        }
+        final int valueLength;
         try {
-          serializeVectorShuffleBatch(batch, vectorShufflePartitionRowIndices,
-              vectorShufflePartitionOffsets[partition], rowCount);
+          valueLength = serializeVectorShuffleBatch(batch, vectorShufflePartitionRowIndices,
+              vectorShufflePartitionOffsets[partition], rowCount, valueBytes.buffer,
+              valueBytes.offsetToValueBytes);
         } catch (ArrayIndexOutOfBoundsException ex) {
           collectVectorShuffleRows(batch, vectorShufflePartitionRowIndices,
               vectorShufflePartitionOffsets[partition], rowCount, partition, tag);
           continue;
         }
-        doCollectBatch(vectorShuffleBatchKey, valueBytesWritable, partition, rowCount);
+        out.completeWriteValueBytes(vectorShuffleBatchKey, valueLength, partition);
+        recordCollectedBatch(rowCount);
       }
     }
   }
@@ -457,8 +468,6 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
     vectorShuffleBatchSerializer = new VectorShuffleBatchSerializer();
     if (vectorShuffleNumUnorderedPartitions == 1) {
       vectorShuffleSerializeBuffer = new byte[SERIALIZE_BUFFER_SIZE];
-    } else {
-      vectorShuffleSerializeBuffer = new byte[SERIALIZE_BUFFER_SIZE / 2];
     }
 
     final int keyColumnCount = isEmptyKey ? 0 : reduceSinkKeyColumnMap.length;
@@ -511,9 +520,15 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
 
   private void serializeVectorShuffleBatch(VectorizedRowBatch batch, int[] rowIndices,
       int rowOffset, int rowCount) {
-    int length = vectorShuffleBatchSerializer.serialize(batch, vectorShuffleBatchColumnMap,
-        rowIndices, rowOffset, rowCount, vectorShuffleSerializeBuffer, 0);
+    int length = serializeVectorShuffleBatch(batch, rowIndices, rowOffset, rowCount,
+        vectorShuffleSerializeBuffer, 0);
     valueBytesWritable.set(vectorShuffleSerializeBuffer, 0, length);
+  }
+
+  private int serializeVectorShuffleBatch(VectorizedRowBatch batch, int[] rowIndices,
+      int rowOffset, int rowCount, byte[] buffer, int offset) {
+    return vectorShuffleBatchSerializer.serialize(batch, vectorShuffleBatchColumnMap,
+        rowIndices, rowOffset, rowCount, buffer, offset);
   }
 
   private void growVectorShuffleSerializeBuffer() throws HiveException {
@@ -715,12 +730,16 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
   private void doCollectBatch(HiveKey keyWritable, BytesWritable valueWritable, int partition,
                               long logicalRecordCount) throws IOException {
     if (null != out) {
-      numRows += logicalRecordCount;
-      if (numRows >= cntr) {
-        cntr = cntr * 10;
-        LOG.info("{}:: records written - {}", this, numRows);
-      }
+      recordCollectedBatch(logicalRecordCount);
       out.writeWithPartition(keyWritable, valueWritable, partition);
+    }
+  }
+
+  private void recordCollectedBatch(long logicalRecordCount) {
+    numRows += logicalRecordCount;
+    if (numRows >= cntr) {
+      cntr = cntr * 10;
+      LOG.info("{}:: records written - {}", this, numRows);
     }
   }
 


### PR DESCRIPTION
### Motivation
- Reduce copy overhead when emitting unordered multi-partition vector shuffle batches by using the new direct value-byte write API on writer edges.
- Avoid allocating the per-task vector shuffle serialize scratch buffer when it will not be used for multi-partition unordered outputs.

### Description
- Expose `requestWriteValueBytes(...)` and `completeWriteValueBytes(...)` via `TezProcessor.TezKVOutputCollector` and delegate to the underlying writer writer API by importing `KeyValueWriterEdge.WriteValueBytes` and calling the corresponding writer methods.
- In `VectorReduceSinkCommonOperator` add `MIN_VALUE_BYTES_THRESHOLD` and change the partitioned-batch path to call `out.requestWriteValueBytes(vectorShuffleBatchKey, partition)`, fall back to `collectVectorShuffleRows(...)` when no region is available or the returned region is too small, serialize directly into the supplied `buffer`/`offset`, and complete with `out.completeWriteValueBytes(...)` instead of copying into `valueBytesWritable` and calling `doCollectBatch(...)`.
- Allocate `vectorShuffleSerializeBuffer` only when `vectorShuffleNumUnorderedPartitions == 1` so multi-partition unordered outputs do not reserve the scratch buffer unnecessarily.
- Add a helper `serializeVectorShuffleBatch(..., byte[] buffer, int offset)` overload to serialize into a caller-provided buffer and factor batch record-count bookkeeping into `recordCollectedBatch(...)` used by both regular and direct-write flows.

### Testing
- Ran `git diff --check` to verify there were no whitespace/error diffs and it passed.
- Attempted to compile the `ql` module with `mvn -pl ql -DskipTests -DskipSparkTests -DskipRat -Dmaven.javadoc.skip=true compile` but the build was blocked by repository resolution (Maven Central returned `403 Forbidden` while resolving parent POM `org.apache:apache:pom:23`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36ad91c3b483288a0b1d39dc357d24)