### PR TITLE
Use Unsafe fast memory ops for VectorShuffle serializer/deserializer

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorShuffleBatchDeserializer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorShuffleBatchDeserializer.java
@@ -17,6 +17,9 @@
  */
 package org.apache.hadoop.hive.ql.exec.vector;
 
+import static org.apache.tez.util.FastByteComparisons.BYTE_ARRAY_BASE_OFFSET;
+import static org.apache.tez.util.FastByteComparisons.theUnsafe;
+
 import java.io.IOException;
 
 import org.apache.hadoop.hive.common.type.HiveIntervalDayTime;
@@ -205,14 +208,7 @@ public final class VectorShuffleBatchDeserializer {
     return childCount;
   }
 
-  private void requireAvailable(int bytes) throws IOException {
-    if (position + bytes > limit) {
-      throw new IOException("Vector shuffle batch ended while reading " + bytes + " bytes");
-    }
-  }
-
   private int readUnsignedByte() throws IOException {
-    requireAvailable(1);
     return buffer[position++] & 0xff;
   }
 
@@ -221,23 +217,15 @@ public final class VectorShuffleBatchDeserializer {
   }
 
   private int readInt() throws IOException {
-    requireAvailable(4);
-    return ((buffer[position++] & 0xff) << 24)
-        | ((buffer[position++] & 0xff) << 16)
-        | ((buffer[position++] & 0xff) << 8)
-        | (buffer[position++] & 0xff);
+    int value = theUnsafe.getInt(buffer, BYTE_ARRAY_BASE_OFFSET + position);
+    position += Integer.BYTES;
+    return value;
   }
 
   private long readLong() throws IOException {
-    requireAvailable(8);
-    return ((long) (buffer[position++] & 0xff) << 56)
-        | ((long) (buffer[position++] & 0xff) << 48)
-        | ((long) (buffer[position++] & 0xff) << 40)
-        | ((long) (buffer[position++] & 0xff) << 32)
-        | ((long) (buffer[position++] & 0xff) << 24)
-        | ((long) (buffer[position++] & 0xff) << 16)
-        | ((long) (buffer[position++] & 0xff) << 8)
-        | ((long) buffer[position++] & 0xff);
+    long value = theUnsafe.getLong(buffer, BYTE_ARRAY_BASE_OFFSET + position);
+    position += Long.BYTES;
+    return value;
   }
 
   private double readDouble() throws IOException {
@@ -249,7 +237,6 @@ public final class VectorShuffleBatchDeserializer {
   }
 
   private void readFully(byte[] bytes, int offset, int length) throws IOException {
-    requireAvailable(length);
     System.arraycopy(buffer, position, bytes, offset, length);
     position += length;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorShuffleBatchSerializer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorShuffleBatchSerializer.java
@@ -17,6 +17,9 @@
  */
 package org.apache.hadoop.hive.ql.exec.vector;
 
+import static org.apache.tez.util.FastByteComparisons.BYTE_ARRAY_BASE_OFFSET;
+import static org.apache.tez.util.FastByteComparisons.theUnsafe;
+
 import org.apache.hadoop.hive.common.type.HiveIntervalDayTime;
 
 /**
@@ -210,21 +213,13 @@ public final class VectorShuffleBatchSerializer {
   }
 
   private void writeInt(int value) {
-    buffer[position++] = (byte) (value >>> 24);
-    buffer[position++] = (byte) (value >>> 16);
-    buffer[position++] = (byte) (value >>> 8);
-    buffer[position++] = (byte) value;
+    theUnsafe.putInt(buffer, BYTE_ARRAY_BASE_OFFSET + position, value);
+    position += Integer.BYTES;
   }
 
   private void writeLong(long value) {
-    buffer[position++] = (byte) (value >>> 56);
-    buffer[position++] = (byte) (value >>> 48);
-    buffer[position++] = (byte) (value >>> 40);
-    buffer[position++] = (byte) (value >>> 32);
-    buffer[position++] = (byte) (value >>> 24);
-    buffer[position++] = (byte) (value >>> 16);
-    buffer[position++] = (byte) (value >>> 8);
-    buffer[position++] = (byte) value;
+    theUnsafe.putLong(buffer, BYTE_ARRAY_BASE_OFFSET + position, value);
+    position += Long.BYTES;
   }
 
   private void writeDouble(double value) {


### PR DESCRIPTION
### Motivation
- Improve performance of the compact vector shuffle `serialize`/`deserialize` paths by replacing byte-wise manual reads and writes with fast primitive memory operations.
- Reduce per-value overhead and array-indexing work in hot paths for serializing/deserializing `VectorizedRowBatch` payloads.

### Description
- Add static imports for `BYTE_ARRAY_BASE_OFFSET` and `theUnsafe` from `org.apache.tez.util.FastByteComparisons` and use them in both `VectorShuffleBatchSerializer` and `VectorShuffleBatchDeserializer`.
- Replace manual byte composition/decomposition in `readInt`, `readLong`, `writeInt`, and `writeLong` with `theUnsafe.getInt/putInt` and `theUnsafe.getLong/putLong`, and advance `position` by `Integer.BYTES`/`Long.BYTES` accordingly.
- Replace `readFully` and byte writes to use `System.arraycopy` and direct `Unsafe` writes for primitives, and remove the `requireAvailable` bounds-check helper and its calls.
- Keep all vector logic unchanged and make symmetric changes in serializer and deserializer to preserve the wire format between them.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3754eda8308328bb637e1d0c695292)