### PR TITLE
Introduce per-type uniform key hash-code computers for vectorized reduce-sink

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/AbstractVectorUniformKeyHashCodeComputer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/AbstractVectorUniformKeyHashCodeComputer.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.vector.reducesink;
+
+import org.apache.hadoop.hive.serde2.ByteStream.Output;
+import org.apache.hadoop.hive.serde2.binarysortable.fast.BinarySortableSerializeWrite;
+import org.apache.hive.common.util.Murmur3;
+
+/**
+ * Base class for computing uniform reduce-sink key hash codes by serializing one key at a time
+ * into a small scratch buffer and hashing the resulting BinarySortable bytes.
+ */
+abstract class AbstractVectorUniformKeyHashCodeComputer implements VectorUniformKeyHashCodeComputer {
+
+  protected final BinarySortableSerializeWrite serializeWrite;
+  protected final Output output;
+
+  AbstractVectorUniformKeyHashCodeComputer(BinarySortableSerializeWrite serializeWrite) {
+    this.serializeWrite = serializeWrite;
+    output = new Output();
+  }
+
+  protected void reset() {
+    serializeWrite.set(output);
+  }
+
+  protected int hash() {
+    return Murmur3.hash32(output.getData(), 0, output.getLength(), 0);
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorBytesUniformKeyHashCodeComputer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorBytesUniformKeyHashCodeComputer.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.vector.reducesink;
+
+import java.io.IOException;
+
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hadoop.hive.serde2.binarysortable.fast.BinarySortableSerializeWrite;
+
+final class VectorBytesUniformKeyHashCodeComputer extends AbstractVectorUniformKeyHashCodeComputer {
+
+  private final int columnNum;
+
+  VectorBytesUniformKeyHashCodeComputer(int columnNum, BinarySortableSerializeWrite serializeWrite) {
+    super(serializeWrite);
+    this.columnNum = columnNum;
+  }
+
+  @Override
+  public void computeHashCodes(VectorizedRowBatch batch, int[] hashCodes) throws IOException {
+    BytesColumnVector bytesColVector = (BytesColumnVector) batch.cols[columnNum];
+    final int size = batch.size;
+    final boolean selectedInUse = batch.selectedInUse;
+    final int[] selected = batch.selected;
+
+    if (bytesColVector.isRepeating) {
+      final int hashCode = computeHashCode(bytesColVector, 0);
+      for (int logical = 0; logical < size; logical++) {
+        final int batchIndex = selectedInUse ? selected[logical] : logical;
+        hashCodes[batchIndex] = hashCode;
+      }
+      return;
+    }
+
+    for (int logical = 0; logical < size; logical++) {
+      final int batchIndex = selectedInUse ? selected[logical] : logical;
+      hashCodes[batchIndex] = computeHashCode(bytesColVector, batchIndex);
+    }
+  }
+
+  private int computeHashCode(BytesColumnVector bytesColVector, int batchIndex) throws IOException {
+    reset();
+    if (!bytesColVector.noNulls && bytesColVector.isNull[batchIndex]) {
+      serializeWrite.writeNull();
+    } else {
+      serializeWrite.writeString(bytesColVector.vector[batchIndex], bytesColVector.start[batchIndex],
+          bytesColVector.length[batchIndex]);
+    }
+    return hash();
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorLongUniformKeyHashCodeComputer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorLongUniformKeyHashCodeComputer.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.vector.reducesink;
+
+import java.io.IOException;
+
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hadoop.hive.serde2.binarysortable.fast.BinarySortableSerializeWrite;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory;
+import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
+
+final class VectorLongUniformKeyHashCodeComputer extends AbstractVectorUniformKeyHashCodeComputer {
+
+  private final int columnNum;
+  private final PrimitiveCategory primitiveCategory;
+
+  VectorLongUniformKeyHashCodeComputer(int columnNum, PrimitiveTypeInfo primitiveTypeInfo,
+      BinarySortableSerializeWrite serializeWrite) {
+    super(serializeWrite);
+    this.columnNum = columnNum;
+    primitiveCategory = primitiveTypeInfo.getPrimitiveCategory();
+  }
+
+  @Override
+  public void computeHashCodes(VectorizedRowBatch batch, int[] hashCodes) throws IOException {
+    LongColumnVector longColVector = (LongColumnVector) batch.cols[columnNum];
+    final int size = batch.size;
+    final boolean selectedInUse = batch.selectedInUse;
+    final int[] selected = batch.selected;
+
+    if (longColVector.isRepeating) {
+      final int hashCode = computeHashCode(longColVector, 0);
+      for (int logical = 0; logical < size; logical++) {
+        final int batchIndex = selectedInUse ? selected[logical] : logical;
+        hashCodes[batchIndex] = hashCode;
+      }
+      return;
+    }
+
+    for (int logical = 0; logical < size; logical++) {
+      final int batchIndex = selectedInUse ? selected[logical] : logical;
+      hashCodes[batchIndex] = computeHashCode(longColVector, batchIndex);
+    }
+  }
+
+  private int computeHashCode(LongColumnVector longColVector, int batchIndex) throws IOException {
+    reset();
+    if (!longColVector.noNulls && longColVector.isNull[batchIndex]) {
+      serializeWrite.writeNull();
+    } else {
+      final long value = longColVector.vector[batchIndex];
+      switch (primitiveCategory) {
+      case BOOLEAN:
+        serializeWrite.writeBoolean(value != 0);
+        break;
+      case BYTE:
+        serializeWrite.writeByte((byte) value);
+        break;
+      case SHORT:
+        serializeWrite.writeShort((short) value);
+        break;
+      case INT:
+        serializeWrite.writeInt((int) value);
+        break;
+      case DATE:
+        serializeWrite.writeDate((int) value);
+        break;
+      case LONG:
+        serializeWrite.writeLong(value);
+        break;
+      default:
+        throw new IOException("Unexpected primitive category " + primitiveCategory.name());
+      }
+    }
+    return hash();
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorMultiUniformKeyHashCodeComputer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorMultiUniformKeyHashCodeComputer.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.vector.reducesink;
+
+import java.io.IOException;
+
+import org.apache.hadoop.hive.ql.exec.vector.VectorSerializeRow;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.serde2.binarysortable.fast.BinarySortableSerializeWrite;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+
+final class VectorMultiUniformKeyHashCodeComputer extends AbstractVectorUniformKeyHashCodeComputer {
+
+  private final VectorSerializeRow<BinarySortableSerializeWrite> keySerializeRow;
+
+  VectorMultiUniformKeyHashCodeComputer(TypeInfo[] typeInfos, int[] columnNums,
+      BinarySortableSerializeWrite serializeWrite) throws HiveException {
+    super(serializeWrite);
+    keySerializeRow = new VectorSerializeRow<>(serializeWrite);
+    keySerializeRow.init(typeInfos, columnNums);
+  }
+
+  @Override
+  public void computeHashCodes(VectorizedRowBatch batch, int[] hashCodes) throws IOException {
+    final int size = batch.size;
+    final boolean selectedInUse = batch.selectedInUse;
+    final int[] selected = batch.selected;
+
+    for (int logical = 0; logical < size; logical++) {
+      final int batchIndex = selectedInUse ? selected[logical] : logical;
+      keySerializeRow.setOutput(output);
+      keySerializeRow.serializeWrite(batch, batchIndex);
+      hashCodes[batchIndex] = hash();
+    }
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
@@ -392,8 +392,6 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
 
   private void collectPartitionedVectorShuffleBatch(VectorizedRowBatch batch,
       int numUnorderedPartitions, int tag) throws HiveException, IOException {
-    clearVectorShuffleRowKeyBatchCache();
-
     final int[] hashCodes;
     final int partitionerType = vectorShufflePartitionerType;
     if (partitionerType == 0) {
@@ -540,8 +538,6 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
     try {
       if (isEmptyKey) {
         initializeEmptyKey(tag);
-      } else if (hasVectorShuffleRowKeyBatchCache()) {
-        serializeVectorShuffleRowKeyFromBatchCache(batchIndex, tag);
       } else {
         vectorShuffleRowKeySerializeWrite.reset();
         vectorShuffleRowKeySerializeRow.serializeWrite(batch, batchIndex);
@@ -561,16 +557,6 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
     } catch (Exception e) {
       throw new IOException("Failed to serialize vector shuffle row", e);
     }
-  }
-
-  protected void clearVectorShuffleRowKeyBatchCache() {
-  }
-
-  protected boolean hasVectorShuffleRowKeyBatchCache() {
-    return false;
-  }
-
-  protected void serializeVectorShuffleRowKeyFromBatchCache(int batchIndex, int tag) {
   }
 
   protected void setVectorShuffleRowKey(byte[] keyBytes, int keyStart, int keyLength,

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkLongOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkLongOperator.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.hive.ql.exec.vector.reducesink;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.CompilationOpContext;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizationContext;
-import org.apache.hadoop.hive.ql.exec.vector.keyseries.VectorKeySeriesLongSerialized;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.VectorDesc;
@@ -69,8 +68,9 @@ public class VectorReduceSinkLongOperator extends VectorReduceSinkUniformHashOpe
     singleKeyColumn = reduceSinkKeyColumnMap[0];
     singleKeyColumnPrimitiveTypeInfo = (PrimitiveTypeInfo) reduceSinkKeyTypeInfos[0];
 
-    serializedKeySeries =
-        new VectorKeySeriesLongSerialized<BinarySortableSerializeWrite>(
-            singleKeyColumn, singleKeyColumnPrimitiveTypeInfo, keyBinarySortableSerializeWrite);
+    setKeyHashCodeComputer(new VectorLongUniformKeyHashCodeComputer(singleKeyColumn,
+        singleKeyColumnPrimitiveTypeInfo,
+        BinarySortableSerializeWrite.with(conf.getKeySerializeInfo().getProperties(),
+            reduceSinkKeyColumnMap.length)));
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkMultiKeyOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkMultiKeyOperator.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.hive.ql.exec.vector.reducesink;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.CompilationOpContext;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizationContext;
-import org.apache.hadoop.hive.ql.exec.vector.keyseries.VectorKeySeriesMultiSerialized;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.VectorDesc;
@@ -61,11 +60,9 @@ public class VectorReduceSinkMultiKeyOperator extends VectorReduceSinkUniformHas
   protected void initializeOp(Configuration hconf) throws HiveException {
     super.initializeOp(hconf);
 
-    VectorKeySeriesMultiSerialized<BinarySortableSerializeWrite> serializedMultiKeySeries =
-        new VectorKeySeriesMultiSerialized<BinarySortableSerializeWrite>(
-            keyBinarySortableSerializeWrite);
-    serializedMultiKeySeries.init(reduceSinkKeyTypeInfos, reduceSinkKeyColumnMap);
-
-    serializedKeySeries = serializedMultiKeySeries;
+    setKeyHashCodeComputer(new VectorMultiUniformKeyHashCodeComputer(reduceSinkKeyTypeInfos,
+        reduceSinkKeyColumnMap,
+        BinarySortableSerializeWrite.with(conf.getKeySerializeInfo().getProperties(),
+            reduceSinkKeyColumnMap.length)));
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkStringOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkStringOperator.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.hive.ql.exec.vector.reducesink;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.CompilationOpContext;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizationContext;
-import org.apache.hadoop.hive.ql.exec.vector.keyseries.VectorKeySeriesBytesSerialized;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.VectorDesc;
@@ -66,8 +65,8 @@ public class VectorReduceSinkStringOperator extends VectorReduceSinkUniformHashO
 
     singleKeyColumn = reduceSinkKeyColumnMap[0];
 
-    serializedKeySeries =
-        new VectorKeySeriesBytesSerialized<BinarySortableSerializeWrite>(
-            singleKeyColumn, keyBinarySortableSerializeWrite);
+    setKeyHashCodeComputer(new VectorBytesUniformKeyHashCodeComputer(singleKeyColumn,
+        BinarySortableSerializeWrite.with(conf.getKeySerializeInfo().getProperties(),
+            reduceSinkKeyColumnMap.length)));
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkUniformHashOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkUniformHashOperator.java
@@ -22,13 +22,14 @@ import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.CompilationOpContext;
+import org.apache.hadoop.hive.ql.exec.vector.VectorSerializeRow;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizationContext;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.ql.exec.vector.expressions.VectorExpression;
-import org.apache.hadoop.hive.ql.exec.vector.keyseries.VectorKeySeriesSerialized;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.VectorDesc;
+import org.apache.hadoop.hive.serde2.binarysortable.fast.BinarySortableSerializeWrite;
 import org.apache.hadoop.hive.serde2.ByteStream.Output;
 import org.apache.hive.common.util.Murmur3;
 import org.slf4j.Logger;
@@ -51,20 +52,9 @@ public abstract class VectorReduceSinkUniformHashOperator extends VectorReduceSi
   // transient.
   //---------------------------------------------------------------------------
 
-  // The serialized all null key and its hash code.
-  private transient byte[] nullBytes;
-  private transient int nullKeyHashCode;
-
-  // The object that determines equal key series.
-  protected transient VectorKeySeriesSerialized serializedKeySeries;
-
-  // Cached serialized keys from the most recent computeKeyHashCodes call, indexed by physical row.
-  private transient byte[][] serializedKeyBytesByRow;
-  private transient int[] serializedKeyStartsByRow;
-  private transient int[] serializedKeyLengthsByRow;
-  private transient int[] serializedKeyHashCodesByRow;
-  private transient boolean serializedKeyCacheValid;
-
+  private transient VectorUniformKeyHashCodeComputer keyHashCodeComputer;
+  private transient Output keyOutput;
+  private transient VectorSerializeRow<BinarySortableSerializeWrite> keyVectorSerializeRow;
 
   /** Kryo ctor. */
   protected VectorReduceSinkUniformHashOperator() {
@@ -85,69 +75,23 @@ public abstract class VectorReduceSinkUniformHashOperator extends VectorReduceSi
     super.initializeOp(hconf);
 
     Preconditions.checkState(!isEmptyKey);
-    // Create all nulls key.
     try {
-      Output nullKeyOutput = new Output();
-      keyBinarySortableSerializeWrite.set(nullKeyOutput);
-      for (int i = 0; i < reduceSinkKeyColumnMap.length; i++) {
-        keyBinarySortableSerializeWrite.writeNull();
-      }
-      int nullBytesLength = nullKeyOutput.getLength();
-      nullBytes = new byte[nullBytesLength];
-      System.arraycopy(nullKeyOutput.getData(), 0, nullBytes, 0, nullBytesLength);
-      nullKeyHashCode = Murmur3.hash32(nullBytes, 0, nullBytesLength, 0);
-      serializedKeyBytesByRow = new byte[VectorizedRowBatch.DEFAULT_SIZE][];
-      serializedKeyStartsByRow = new int[VectorizedRowBatch.DEFAULT_SIZE];
-      serializedKeyLengthsByRow = new int[VectorizedRowBatch.DEFAULT_SIZE];
-      serializedKeyHashCodesByRow = new int[VectorizedRowBatch.DEFAULT_SIZE];
+      keyOutput = new Output();
+      keyVectorSerializeRow = new VectorSerializeRow<>(keyBinarySortableSerializeWrite);
+      keyVectorSerializeRow.init(reduceSinkKeyTypeInfos, reduceSinkKeyColumnMap);
 
     } catch (Exception e) {
       throw new HiveException(e);
     }
   }
 
+  protected void setKeyHashCodeComputer(VectorUniformKeyHashCodeComputer keyHashCodeComputer) {
+    this.keyHashCodeComputer = keyHashCodeComputer;
+  }
+
   @Override
   protected void computeKeyHashCodes(VectorizedRowBatch batch, int[] hashCodes) throws IOException {
-    serializedKeySeries.processBatch(batch);
-    serializedKeyCacheValid = true;
-
-    final boolean selectedInUse = batch.selectedInUse;
-    final int[] selected = batch.selected;
-    final byte[] serializedBytes = serializedKeySeries.getSerializedBytes();
-
-    do {
-      final boolean isAllNull = serializedKeySeries.getCurrentIsAllNull();
-      final byte[] keyBytes = isAllNull ? nullBytes : serializedBytes;
-      final int keyStart = isAllNull ? 0 : serializedKeySeries.getSerializedStart();
-      final int keyLength = isAllNull ? nullBytes.length : serializedKeySeries.getSerializedLength();
-      final int hashCode = isAllNull ? nullKeyHashCode : serializedKeySeries.getCurrentHashCode();
-      final int end = serializedKeySeries.getCurrentLogical()
-          + serializedKeySeries.getCurrentDuplicateCount();
-      for (int logical = serializedKeySeries.getCurrentLogical(); logical < end; logical++) {
-        final int batchIndex = selectedInUse ? selected[logical] : logical;
-        hashCodes[batchIndex] = hashCode;
-        serializedKeyBytesByRow[batchIndex] = keyBytes;
-        serializedKeyStartsByRow[batchIndex] = keyStart;
-        serializedKeyLengthsByRow[batchIndex] = keyLength;
-        serializedKeyHashCodesByRow[batchIndex] = hashCode;
-      }
-    } while (serializedKeySeries.next());
-  }
-
-  @Override
-  protected void clearVectorShuffleRowKeyBatchCache() {
-    serializedKeyCacheValid = false;
-  }
-
-  @Override
-  protected boolean hasVectorShuffleRowKeyBatchCache() {
-    return serializedKeyCacheValid;
-  }
-
-  @Override
-  protected void serializeVectorShuffleRowKeyFromBatchCache(int batchIndex, int tag) {
-    setVectorShuffleRowKey(serializedKeyBytesByRow[batchIndex], serializedKeyStartsByRow[batchIndex],
-        serializedKeyLengthsByRow[batchIndex], serializedKeyHashCodesByRow[batchIndex], tag);
+    keyHashCodeComputer.computeHashCodes(batch, hashCodes);
   }
 
   @Override
@@ -183,83 +127,27 @@ public abstract class VectorReduceSinkUniformHashOperator extends VectorReduceSi
         return;
       }
 
-      serializedKeySeries.processBatch(batch);
-
       boolean selectedInUse = batch.selectedInUse;
       int[] selected = batch.selected;
+      final int size = batch.size;
+      for (int logical = 0; logical < size; logical++) {
+        final int batchIndex = selectedInUse ? selected[logical] : logical;
 
-      int logical;
-      do {
-        if (serializedKeySeries.getCurrentIsAllNull()) {
+        keyVectorSerializeRow.setOutput(keyOutput);
+        keyVectorSerializeRow.serializeWrite(batch, batchIndex);
+        final int keyLength = keyOutput.getLength();
+        setVectorShuffleRowKey(keyOutput.getData(), 0, keyLength,
+            Murmur3.hash32(keyOutput.getData(), 0, keyLength, 0), tag);
 
-          // Use the same logic as ReduceSinkOperator.toHiveKey.
-          //
-          if (tag == -1 || reduceSkipTag) {
-            keyWritable.set(nullBytes, 0, nullBytes.length);
-          } else {
-            keyWritable.setSize(nullBytes.length + 1);
-            System.arraycopy(nullBytes, 0, keyWritable.get(), 0, nullBytes.length);
-            keyWritable.get()[nullBytes.length] = reduceTagByte;
-          }
-          keyWritable.setDistKeyLength(nullBytes.length);
-          keyWritable.setHashCode(nullKeyHashCode);
-
-        } else {
-
-          // One serialized key for 1 or more rows for the duplicate keys.
-          // LOG.info("reduceSkipTag " + reduceSkipTag + " tag " + tag + " reduceTagByte " + (int) reduceTagByte + " keyLength " + serializedKeySeries.getSerializedLength());
-          // LOG.info("process offset " + serializedKeySeries.getSerializedStart() + " length " + serializedKeySeries.getSerializedLength());
-          final int keyLength = serializedKeySeries.getSerializedLength();
-          if (tag == -1 || reduceSkipTag) {
-            keyWritable.set(serializedKeySeries.getSerializedBytes(),
-                serializedKeySeries.getSerializedStart(), keyLength);
-          } else {
-            keyWritable.setSize(keyLength + 1);
-            System.arraycopy(serializedKeySeries.getSerializedBytes(),
-                serializedKeySeries.getSerializedStart(), keyWritable.get(), 0, keyLength);
-            keyWritable.get()[keyLength] = reduceTagByte;
-          }
-          keyWritable.setDistKeyLength(keyLength);
-          keyWritable.setHashCode(serializedKeySeries.getCurrentHashCode());
-        }
-
-        logical = serializedKeySeries.getCurrentLogical();
-        final int end = logical + serializedKeySeries.getCurrentDuplicateCount();
         if (!isEmptyValue) {
-          if (selectedInUse) {
-            do {
-              final int batchIndex = selected[logical];
-
-              valueLazyBinarySerializeWrite.reset();
-              valueVectorSerializeRow.serializeWrite(batch, batchIndex);
-
-              valueBytesWritable.set(valueOutput.getData(), 0, valueOutput.getLength());
-
-              collect(keyWritable, valueBytesWritable);
-            } while (++logical < end);
-          } else {
-            do {
-              valueLazyBinarySerializeWrite.reset();
-              valueVectorSerializeRow.serializeWrite(batch, logical);
-
-              valueBytesWritable.set(valueOutput.getData(), 0, valueOutput.getLength());
-
-              collect(keyWritable, valueBytesWritable);
-            } while (++logical < end);
-
-          }
+          valueLazyBinarySerializeWrite.reset();
+          valueVectorSerializeRow.serializeWrite(batch, batchIndex);
+          valueBytesWritable.set(valueOutput.getData(), 0, valueOutput.getLength());
+          collect(keyWritable, valueBytesWritable);
         } else {
-
-          // Empty value, too.
-          do {
-            collect(keyWritable, valueBytesWritable);
-          } while (++logical < end);
+          collect(keyWritable, valueBytesWritable);
         }
-
-        if (!serializedKeySeries.next()) {
-          break;
-        }
-      } while (true);
+      }
 
     } catch (Exception e) {
       throw new HiveException(e);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorUniformKeyHashCodeComputer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorUniformKeyHashCodeComputer.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.vector.reducesink;
+
+import java.io.IOException;
+
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+
+interface VectorUniformKeyHashCodeComputer {
+  void computeHashCodes(VectorizedRowBatch batch, int[] hashCodes) throws IOException;
+}


### PR DESCRIPTION
### Motivation
- Replace the previous serialized-key-series caching and monolithic serialization logic with per-type hash-code computers that serialize one key at a time into a small buffer and compute a Murmur3 hash for uniform partitioning.
- Simplify and consolidate key serialization paths for Long, Bytes (String), and multi-column keys to make the code easier to maintain and to reduce memory/cache complexity.

### Description
- Add a `VectorUniformKeyHashCodeComputer` interface and an abstract base `AbstractVectorUniformKeyHashCodeComputer` that uses `BinarySortableSerializeWrite` and `Murmur3` to compute hashes from a small scratch `Output` buffer.
- Add concrete implementations: `VectorBytesUniformKeyHashCodeComputer`, `VectorLongUniformKeyHashCodeComputer`, and `VectorMultiUniformKeyHashCodeComputer`, each serializing the appropriate column(s) per-row and computing hash codes into a provided `int[]`.
- Refactor `VectorReduceSinkUniformHashOperator` to use a `VectorUniformKeyHashCodeComputer` and `VectorSerializeRow<BinarySortableSerializeWrite>` instead of the previous `serializedKeySeries` cache, and simplify the row processing and serialization paths (including removal of batch key cache helpers).
- Update operator initializers to create and install the appropriate hash-code computer: `VectorReduceSinkLongOperator`, `VectorReduceSinkStringOperator`, and `VectorReduceSinkMultiKeyOperator` now call `setKeyHashCodeComputer(...)` with `BinarySortableSerializeWrite.with(...)` configured for the key columns.

### Testing
- Ran the project's unit test suite with `mvn -DskipTests=false test`, which completed successfully.
- Executed the vectorized reduce-sink related unit tests to validate serialization and partitioning behavior, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a378abb39208328b6f7093f376ca9d2)