### PR TITLE
Use Tez WriteValueBytes for vector shuffle batches and add direct-write APIs to Tez processor

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.io.BytesWritable;
 import org.apache.tez.mapreduce.output.MROutput;
 import org.apache.tez.runtime.api.TaskFailureType;
 import org.apache.tez.runtime.api.events.CustomProcessorEvent;
+import org.apache.tez.runtime.library.api.KeyValueWriterEdge.WriteValueBytes;
 import org.apache.tez.runtime.library.api.KeyValuesWriterEdge;
 import org.apache.tez.runtime.library.api.LogicalOutputEdge;
 import org.slf4j.Logger;
@@ -431,6 +432,15 @@ public class TezProcessor extends AbstractLogicalIOProcessor {
     public void writeWithPartition(BytesWritable key, BytesWritable value, int partition)
         throws IOException {
       writer.writeWithPartition(key, value, partition);
+    }
+
+    public WriteValueBytes requestWriteValueBytes(BytesWritable key, int partition) throws IOException {
+      return writer.requestWriteValueBytes(key, partition);
+    }
+
+    public void completeWriteValueBytes(BytesWritable key, int valLen, int partition)
+        throws IOException {
+      writer.completeWriteValueBytes(key, valLen, partition);
     }
 
     public void close() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorShuffleBatchSerializer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorShuffleBatchSerializer.java
@@ -34,7 +34,6 @@ public final class VectorShuffleBatchSerializer {
   private static final int IS_REPEATING = 1;
   private static final int HAS_NULLS = 2;
   private static final int IS_DECIMAL_64 = 4;
-  private static final int MAX_DECIMAL_DIRECT_BYTES = 4 + 4 + 49;
 
   private byte[] buffer;
   private int position;
@@ -312,7 +311,6 @@ public final class VectorShuffleBatchSerializer {
       DecimalColumnVector decimal = (DecimalColumnVector) column;
       for (int logical = 0; logical < valueCount; logical++) {
         if (!isNull(nullBitmap, logical)) {
-          ensureCapacity(MAX_DECIMAL_DIRECT_BYTES);
           position += decimal.vector[physicalIndex(indices, logical, repeating)]
               .writeDirect(buffer, position);
         }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorShuffleBatchSerializer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorShuffleBatchSerializer.java
@@ -34,6 +34,7 @@ public final class VectorShuffleBatchSerializer {
   private static final int IS_REPEATING = 1;
   private static final int HAS_NULLS = 2;
   private static final int IS_DECIMAL_64 = 4;
+  private static final int MAX_DECIMAL_DIRECT_BYTES = 4 + 4 + 49;
 
   private byte[] buffer;
   private int position;
@@ -205,6 +206,7 @@ public final class VectorShuffleBatchSerializer {
   }
 
   private void writeByte(int value) {
+    ensureCapacity(Byte.BYTES);
     buffer[position++] = (byte) value;
   }
 
@@ -213,11 +215,13 @@ public final class VectorShuffleBatchSerializer {
   }
 
   private void writeInt(int value) {
+    ensureCapacity(Integer.BYTES);
     theUnsafe.putInt(buffer, BYTE_ARRAY_BASE_OFFSET + position, value);
     position += Integer.BYTES;
   }
 
   private void writeLong(long value) {
+    ensureCapacity(Long.BYTES);
     theUnsafe.putLong(buffer, BYTE_ARRAY_BASE_OFFSET + position, value);
     position += Long.BYTES;
   }
@@ -231,8 +235,16 @@ public final class VectorShuffleBatchSerializer {
   }
 
   private void writeBytes(byte[] bytes, int offset, int length) {
+    ensureCapacity(length);
     System.arraycopy(bytes, offset, buffer, position, length);
     position += length;
+  }
+
+  private void ensureCapacity(int length) {
+    if (position > buffer.length - length) {
+      throw new ArrayIndexOutOfBoundsException(
+          "position=" + position + ", length=" + length + ", limit=" + buffer.length);
+    }
   }
 
   private boolean hasNulls(ColumnVector column, int[] indices, int valueCount,
@@ -300,6 +312,7 @@ public final class VectorShuffleBatchSerializer {
       DecimalColumnVector decimal = (DecimalColumnVector) column;
       for (int logical = 0; logical < valueCount; logical++) {
         if (!isNull(nullBitmap, logical)) {
+          ensureCapacity(MAX_DECIMAL_DIRECT_BYTES);
           position += decimal.vector[physicalIndex(indices, logical, repeating)]
               .writeDirect(buffer, position);
         }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorShuffleBatchSerializer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorShuffleBatchSerializer.java
@@ -234,7 +234,6 @@ public final class VectorShuffleBatchSerializer {
   }
 
   private void writeBytes(byte[] bytes, int offset, int length) {
-    ensureCapacity(length);
     System.arraycopy(bytes, offset, buffer, position, length);
     position += length;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
@@ -447,9 +447,9 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
         }
         final int valueLength;
         try {
-          valueLength = serializeVectorShuffleBatch(batch, vectorShufflePartitionRowIndices,
-              vectorShufflePartitionOffsets[partition], rowCount, valueBytes.buffer,
-              valueBytes.offsetToValueBytes);
+          valueLength = vectorShuffleBatchSerializer.serialize(batch, vectorShuffleBatchColumnMap,
+              vectorShufflePartitionRowIndices, vectorShufflePartitionOffsets[partition], rowCount,
+              valueBytes.buffer, valueBytes.offsetToValueBytes);
         } catch (ArrayIndexOutOfBoundsException ex) {
           collectVectorShuffleRows(batch, vectorShufflePartitionRowIndices,
               vectorShufflePartitionOffsets[partition], rowCount, partition, tag);
@@ -520,15 +520,9 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
 
   private void serializeVectorShuffleBatch(VectorizedRowBatch batch, int[] rowIndices,
       int rowOffset, int rowCount) {
-    int length = serializeVectorShuffleBatch(batch, rowIndices, rowOffset, rowCount,
-        vectorShuffleSerializeBuffer, 0);
+    int length = vectorShuffleBatchSerializer.serialize(batch, vectorShuffleBatchColumnMap,
+        rowIndices, rowOffset, rowCount, vectorShuffleSerializeBuffer, 0);
     valueBytesWritable.set(vectorShuffleSerializeBuffer, 0, length);
-  }
-
-  private int serializeVectorShuffleBatch(VectorizedRowBatch batch, int[] rowIndices,
-      int rowOffset, int rowCount, byte[] buffer, int offset) {
-    return vectorShuffleBatchSerializer.serialize(batch, vectorShuffleBatchColumnMap,
-        rowIndices, rowOffset, rowCount, buffer, offset);
   }
 
   private void growVectorShuffleSerializeBuffer() throws HiveException {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
@@ -455,6 +455,13 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
               vectorShufflePartitionOffsets[partition], rowCount, partition, tag);
           continue;
         }
+        // The exposed byte array can be larger than the writable value region.  Verify the
+        // serialized value length before completing the direct write.
+        if (valueLength > valueBytes.maxValueBytes) {
+          collectVectorShuffleRows(batch, vectorShufflePartitionRowIndices,
+              vectorShufflePartitionOffsets[partition], rowCount, partition, tag);
+          continue;
+        }
         out.completeWriteValueBytes(vectorShuffleBatchKey, valueLength, partition);
         recordCollectedBatch(rowCount);
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/reducesink/VectorReduceSinkCommonOperator.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hive.common.util.Murmur3;
 import org.apache.hadoop.mapred.OutputCollector;
+import org.apache.tez.runtime.library.api.KeyValueWriterEdge.WriteValueBytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,6 +74,7 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
 
   private static final int NUM_ROWS_THRESHOLD_FOR_BATCH = 1;
   private static final int SERIALIZE_BUFFER_SIZE = 100 * 1024;
+  private static final int MIN_VALUE_BYTES_THRESHOLD = 24;
 
   /**
    * Information about our native vectorized reduce sink created by the Vectorizer class during
@@ -437,15 +439,24 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
         collectVectorShuffleRows(batch, vectorShufflePartitionRowIndices,
             vectorShufflePartitionOffsets[partition], rowCount, partition, tag);
       } else {
+        WriteValueBytes valueBytes = out.requestWriteValueBytes(vectorShuffleBatchKey, partition);
+        if (valueBytes == null || valueBytes.maxValueBytes <= MIN_VALUE_BYTES_THRESHOLD) {
+          collectVectorShuffleRows(batch, vectorShufflePartitionRowIndices,
+              vectorShufflePartitionOffsets[partition], rowCount, partition, tag);
+          continue;
+        }
+        final int valueLength;
         try {
-          serializeVectorShuffleBatch(batch, vectorShufflePartitionRowIndices,
-              vectorShufflePartitionOffsets[partition], rowCount);
+          valueLength = serializeVectorShuffleBatch(batch, vectorShufflePartitionRowIndices,
+              vectorShufflePartitionOffsets[partition], rowCount, valueBytes.buffer,
+              valueBytes.offsetToValueBytes);
         } catch (ArrayIndexOutOfBoundsException ex) {
           collectVectorShuffleRows(batch, vectorShufflePartitionRowIndices,
               vectorShufflePartitionOffsets[partition], rowCount, partition, tag);
           continue;
         }
-        doCollectBatch(vectorShuffleBatchKey, valueBytesWritable, partition, rowCount);
+        out.completeWriteValueBytes(vectorShuffleBatchKey, valueLength, partition);
+        recordCollectedBatch(rowCount);
       }
     }
   }
@@ -457,8 +468,6 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
     vectorShuffleBatchSerializer = new VectorShuffleBatchSerializer();
     if (vectorShuffleNumUnorderedPartitions == 1) {
       vectorShuffleSerializeBuffer = new byte[SERIALIZE_BUFFER_SIZE];
-    } else {
-      vectorShuffleSerializeBuffer = new byte[SERIALIZE_BUFFER_SIZE / 2];
     }
 
     final int keyColumnCount = isEmptyKey ? 0 : reduceSinkKeyColumnMap.length;
@@ -511,9 +520,15 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
 
   private void serializeVectorShuffleBatch(VectorizedRowBatch batch, int[] rowIndices,
       int rowOffset, int rowCount) {
-    int length = vectorShuffleBatchSerializer.serialize(batch, vectorShuffleBatchColumnMap,
-        rowIndices, rowOffset, rowCount, vectorShuffleSerializeBuffer, 0);
+    int length = serializeVectorShuffleBatch(batch, rowIndices, rowOffset, rowCount,
+        vectorShuffleSerializeBuffer, 0);
     valueBytesWritable.set(vectorShuffleSerializeBuffer, 0, length);
+  }
+
+  private int serializeVectorShuffleBatch(VectorizedRowBatch batch, int[] rowIndices,
+      int rowOffset, int rowCount, byte[] buffer, int offset) {
+    return vectorShuffleBatchSerializer.serialize(batch, vectorShuffleBatchColumnMap,
+        rowIndices, rowOffset, rowCount, buffer, offset);
   }
 
   private void growVectorShuffleSerializeBuffer() throws HiveException {
@@ -708,16 +723,20 @@ public abstract class VectorReduceSinkCommonOperator extends TerminalOperator<Re
     }
   }
 
+  private void recordCollectedBatch(long logicalRecordCount) {
+    numRows += logicalRecordCount;
+    if (LOG.isDebugEnabled()) {
+      if (numRows >= cntr) {
+        cntr = cntr * 10;
+        LOG.debug("{}:: records written - {}", this, numRows);
+      }
+    }
+  }
+
   private void doCollectBatch(HiveKey keyWritable, BytesWritable valueWritable, int partition,
                               long logicalRecordCount) throws IOException {
     if (null != out) {
-      numRows += logicalRecordCount;
-      if (LOG.isDebugEnabled()) {
-        if (numRows >= cntr) {
-          cntr = cntr * 10;
-          LOG.debug("{}:: records written - {}", this, numRows);
-        }
-      }
+      recordCollectedBatch(logicalRecordCount);
       out.writeWithPartition(keyWritable, valueWritable, partition);
     }
   }


### PR DESCRIPTION
### Motivation
- Reduce serialization/copy overhead for vectorized reduce-sink by writing batch bytes directly into Tez outputs when possible.
- Expose Tez writer methods to request and complete value-byte writes from the processor to enable zero-copy or fewer-copy paths.

### Description
- Added import and two passthrough methods `requestWriteValueBytes` and `completeWriteValueBytes` to `TezKVOutputCollector` in `TezProcessor.java` to expose `WriteValueBytes` usage to callers.
- Introduced `MIN_VALUE_BYTES_THRESHOLD` and logic in `VectorReduceSinkCommonOperator` to request a `WriteValueBytes` buffer via `out.requestWriteValueBytes(...)`, serialize the vector batch directly into the provided buffer, and call `out.completeWriteValueBytes(...)` when beneficial, falling back to row-by-row collection when the buffer is unavailable or too small.
- Refactored `serializeVectorShuffleBatch` to add an overload that serializes into a provided `byte[]`/offset and return the serialized length, and added `recordCollectedBatch` to centralize counter updates.
- Simplified initial serialize buffer allocation and removed the previous conditional branch that created a smaller buffer for multi-partition cases.

### Testing
- Built the modified modules containing `ql` to validate compilation without errors.
- Ran the existing unit tests for the vector reduce-sink and Tez-related code paths and observed that the test suite completed successfully.
- No new automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a391d0608f08328a4b3693d5209dccb)