### PR TITLE
Add QueryResultOperator and QueryResultDesc to commit in-memory query results to Tez processor

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorFactory.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorFileSinkOperator;
 import org.apache.hadoop.hive.ql.exec.vector.VectorFilterOperator;
 import org.apache.hadoop.hive.ql.exec.vector.VectorGroupByOperator;
 import org.apache.hadoop.hive.ql.exec.vector.VectorLimitOperator;
+import org.apache.hadoop.hive.ql.exec.vector.VectorQueryResultOperator;
 import org.apache.hadoop.hive.ql.exec.vector.VectorMapJoinOperator;
 import org.apache.hadoop.hive.ql.exec.vector.VectorReduceSinkOperator;
 import org.apache.hadoop.hive.ql.exec.vector.VectorSMBMapJoinOperator;
@@ -63,6 +64,7 @@ import org.apache.hadoop.hive.ql.plan.MuxDesc;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.OrcFileMergeDesc;
 import org.apache.hadoop.hive.ql.plan.PTFDesc;
+import org.apache.hadoop.hive.ql.plan.QueryResultDesc;
 import org.apache.hadoop.hive.ql.plan.RCFileMergeDesc;
 import org.apache.hadoop.hive.ql.plan.ReduceSinkDesc;
 import org.apache.hadoop.hive.ql.plan.SMBJoinDesc;
@@ -118,6 +120,7 @@ public final class OperatorFactory {
     opvec.put(OrcFileMergeDesc.class, OrcFileMergeOperator.class);
     opvec.put(CommonMergeJoinDesc.class, CommonMergeJoinOperator.class);
     opvec.put(ListSinkDesc.class, ListSinkOperator.class);
+    opvec.put(QueryResultDesc.class, QueryResultOperator.class);
     opvec.put(TopNKeyDesc.class, TopNKeyOperator.class);
   }
 
@@ -132,6 +135,7 @@ public final class OperatorFactory {
     vectorOpvec.put(FileSinkDesc.class, VectorFileSinkOperator.class);
     vectorOpvec.put(FilterDesc.class, VectorFilterOperator.class);
     vectorOpvec.put(LimitDesc.class, VectorLimitOperator.class);
+    vectorOpvec.put(QueryResultDesc.class, VectorQueryResultOperator.class);
     vectorOpvec.put(PTFDesc.class, VectorPTFOperator.class);
     vectorOpvec.put(TopNKeyDesc.class, VectorTopNKeyOperator.class);
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/QueryResultOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/QueryResultOperator.java
@@ -43,7 +43,10 @@ import org.apache.hadoop.io.Writable;
 import org.apache.tez.runtime.api.ProcessorContext;
 
 /**
- * QueryResultOperator stores query-result rows in memory and commits them to the
+ * QueryResultOperator is a distilled FileSinkOperator for user-visible query results.
+ *
+ * It preserves the FileSinkOperator row serialization path, but replaces the
+ * file-backed RecordWriter with an in-memory buffer that is committed to the
  * Tez/MR3 processor context when the task attempt is allowed to commit.
  */
 public class QueryResultOperator extends Operator<QueryResultDesc> {
@@ -160,11 +163,10 @@ public class QueryResultOperator extends Operator<QueryResultDesc> {
     if (writable instanceof Text) {
       Text text = (Text) writable;
       dataOut.write(text.getBytes(), 0, text.getLength());
-    } else if (writable instanceof BytesWritable) {
-      BytesWritable bytes = (BytesWritable) writable;
-      dataOut.write(bytes.getBytes(), 0, bytes.getLength());
     } else {
-      writable.write(dataOut);
+      // Binary SerDes always write out BytesWritable.
+      BytesWritable bytes = (BytesWritable) writable;
+      dataOut.write(bytes.get(), 0, bytes.getSize());
     }
     dataOut.write(rowSeparator);
     enforceMaxBytes();

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/QueryResultOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/QueryResultOperator.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Properties;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.UnsafeByteOperations;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.ql.CompilationOpContext;
+import org.apache.hadoop.hive.ql.exec.tez.TezContext;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.plan.QueryResultDesc;
+import org.apache.hadoop.hive.ql.plan.api.OperatorType;
+import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
+import org.apache.hadoop.hive.serde2.SerDeException;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+import org.apache.tez.runtime.api.ProcessorContext;
+
+/**
+ * QueryResultOperator stores query-result rows in memory and commits them to the
+ * Tez/MR3 processor context when the task attempt is allowed to commit.
+ */
+public class QueryResultOperator extends Operator<QueryResultDesc> {
+  private static final long serialVersionUID = 1L;
+
+  private transient AbstractSerDe serializer;
+  private transient ObjectInspector inputOI;
+  private transient Writable recordValue;
+  private transient ByteArrayOutputStream writer;
+  private transient DataOutputStream dataOut;
+  private transient ProcessorContext processorContext;
+  private transient int rowSeparator;
+  private transient long maxBytes;
+
+  /** Kryo ctor. */
+  protected QueryResultOperator() {
+    super();
+  }
+
+  public QueryResultOperator(CompilationOpContext ctx) {
+    super(ctx);
+  }
+
+  @Override
+  protected void initializeOp(Configuration hconf) throws HiveException {
+    super.initializeOp(hconf);
+
+    if (conf.getTableInfo() == null) {
+      throw new HiveException("QueryResultOperator requires a TableDesc");
+    }
+
+    try {
+      serializer = conf.getTableInfo().getSerDeClass().newInstance();
+      serializer.initialize(hconf, conf.getTableInfo().getProperties(), null);
+    } catch (InstantiationException | IllegalAccessException | SerDeException e) {
+      throw new HiveException("Unable to initialize QueryResultOperator serializer", e);
+    }
+
+    inputOI = inputObjInspectors[0];
+    writer = new ByteArrayOutputStream();
+    dataOut = new DataOutputStream(writer);
+    maxBytes = hconf.getLong(QueryResultDesc.QUERY_RESULT_PER_TASK_MAX_BYTES, conf.getMaxBytes());
+    rowSeparator = getRowSeparator(conf.getTableInfo().getProperties());
+
+    MapredContext mapredContext = MapredContext.get();
+    if (!(mapredContext instanceof TezContext)) {
+      throw new HiveException("QueryResultOperator requires TezContext");
+    }
+    processorContext = ((TezContext) mapredContext).getTezProcessorContext();
+    if (processorContext == null) {
+      throw new HiveException("QueryResultOperator requires ProcessorContext");
+    }
+  }
+
+  @Override
+  public void process(Object row, int tag) throws HiveException {
+    runTimeNumRows++;
+    try {
+      recordValue = serializer.serialize(row, inputObjInspectors[tag]);
+      if (recordValue == null) {
+        return;
+      }
+      writeRecord(recordValue);
+      numRows++;
+    } catch (SerDeException | IOException e) {
+      throw new HiveException("Error writing query result row", e);
+    }
+  }
+
+  @Override
+  protected void closeOp(boolean abort) throws HiveException {
+    try {
+      if (!abort && conf.isUsingBatchingSerDe()) {
+        recordValue = serializer.serialize(null, inputOI);
+        if (recordValue != null) {
+          writeRecord(recordValue);
+        }
+      }
+
+      if (dataOut != null) {
+        dataOut.flush();
+      }
+
+      if (abort) {
+        return;
+      }
+
+      if (!processorContext.canCommit()) {
+        LOG.info("QueryResultOperator is not allowed to commit resultId={}", conf.getResultId());
+        return;
+      }
+
+      commitDagOutput();
+    } catch (IOException | SerDeException e) {
+      throw new HiveException("Error closing QueryResultOperator", e);
+    }
+  }
+
+  @Override
+  public String getName() {
+    return QueryResultOperator.getOperatorName();
+  }
+
+  static public String getOperatorName() {
+    return "QRO";
+  }
+
+  @Override
+  public OperatorType getType() {
+    return OperatorType.FILESINK;
+  }
+
+  private void writeRecord(Writable writable) throws IOException, HiveException {
+    if (writable instanceof Text) {
+      Text text = (Text) writable;
+      dataOut.write(text.getBytes(), 0, text.getLength());
+    } else if (writable instanceof BytesWritable) {
+      BytesWritable bytes = (BytesWritable) writable;
+      dataOut.write(bytes.getBytes(), 0, bytes.getLength());
+    } else {
+      writable.write(dataOut);
+    }
+    dataOut.write(rowSeparator);
+    enforceMaxBytes();
+  }
+
+  private void enforceMaxBytes() throws HiveException {
+    if (maxBytes >= 0 && writer.size() > maxBytes) {
+      throw new HiveException("Query result for resultId=" + conf.getResultId()
+          + " exceeded per-task limit " + maxBytes + " bytes");
+    }
+  }
+
+  private int getRowSeparator(Properties tableProperties) {
+    String rowSeparatorString = tableProperties.getProperty(serdeConstants.LINE_DELIM, "\n");
+    try {
+      return Byte.parseByte(rowSeparatorString);
+    } catch (NumberFormatException e) {
+      return rowSeparatorString.charAt(0);
+    }
+  }
+
+  private void commitDagOutput() throws IOException, HiveException {
+    byte[] payload = writer.toByteArray();
+    ByteString dagOutput = UnsafeByteOperations.unsafeWrap(payload);
+    Method commitMethod = findCommitDagOutput(ByteString.class);
+    Object argument = dagOutput;
+    if (commitMethod == null) {
+      commitMethod = findCommitDagOutput(byte[].class);
+      argument = payload;
+    }
+    if (commitMethod == null) {
+      throw new HiveException("ProcessorContext does not support commitDagOutput");
+    }
+
+    try {
+      commitMethod.invoke(processorContext, argument);
+    } catch (IllegalAccessException e) {
+      throw new HiveException("Unable to access commitDagOutput on ProcessorContext", e);
+    } catch (InvocationTargetException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof IOException) {
+        throw (IOException) cause;
+      }
+      if (cause instanceof RuntimeException) {
+        throw (RuntimeException) cause;
+      }
+      throw new HiveException("commitDagOutput failed", cause);
+    }
+  }
+
+  private Method findCommitDagOutput(Class<?> parameterType) {
+    try {
+      return processorContext.getClass().getMethod("commitDagOutput", parameterType);
+    } catch (NoSuchMethodException e) {
+      return null;
+    }
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/QueryResultOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/QueryResultOperator.java
@@ -23,17 +23,16 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Properties;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.UnsafeByteOperations;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.CompilationOpContext;
 import org.apache.hadoop.hive.ql.exec.tez.TezContext;
+import org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.plan.QueryResultDesc;
 import org.apache.hadoop.hive.ql.plan.api.OperatorType;
-import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -89,7 +88,8 @@ public class QueryResultOperator extends Operator<QueryResultDesc> {
     writer = new ByteArrayOutputStream();
     dataOut = new DataOutputStream(writer);
     maxBytes = hconf.getLong(QueryResultDesc.QUERY_RESULT_PER_TASK_MAX_BYTES, conf.getMaxBytes());
-    rowSeparator = getRowSeparator(conf.getTableInfo().getProperties());
+    rowSeparator =
+        HiveIgnoreKeyTextOutputFormat.getRowSeparator(conf.getTableInfo().getProperties());
 
     MapredContext mapredContext = MapredContext.get();
     if (!(mapredContext instanceof TezContext)) {
@@ -176,15 +176,6 @@ public class QueryResultOperator extends Operator<QueryResultDesc> {
     if (maxBytes >= 0 && writer.size() > maxBytes) {
       throw new HiveException("Query result for resultId=" + conf.getResultId()
           + " exceeded per-task limit " + maxBytes + " bytes");
-    }
-  }
-
-  private int getRowSeparator(Properties tableProperties) {
-    String rowSeparatorString = tableProperties.getProperty(serdeConstants.LINE_DELIM, "\n");
-    try {
-      return Byte.parseByte(rowSeparatorString);
-    } catch (NumberFormatException e) {
-      return rowSeparatorString.charAt(0);
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorQueryResultOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorQueryResultOperator.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.vector;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.ql.CompilationOpContext;
+import org.apache.hadoop.hive.ql.exec.QueryResultOperator;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.plan.OperatorDesc;
+import org.apache.hadoop.hive.ql.plan.QueryResultDesc;
+import org.apache.hadoop.hive.ql.plan.VectorDesc;
+import org.apache.hadoop.hive.ql.plan.VectorQueryResultDesc;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * Vectorized QueryResult operator implementation.
+ *
+ * Like VectorFileSinkOperator, this class only converts VectorizedRowBatch rows
+ * into standard row objects and delegates the result serialization and commit
+ * behavior to the row-mode QueryResultOperator.
+ */
+public class VectorQueryResultOperator extends QueryResultOperator
+    implements VectorizationOperator {
+
+  private static final long serialVersionUID = 1L;
+
+  private VectorizationContext vContext;
+  private VectorQueryResultDesc vectorDesc;
+
+  private transient boolean firstBatch;
+
+  private transient VectorExtractRow vectorExtractRow;
+
+  protected transient Object[] singleRow;
+
+  public VectorQueryResultOperator(CompilationOpContext ctx, OperatorDesc conf,
+      VectorizationContext vContext, VectorDesc vectorDesc) {
+    this(ctx);
+    this.conf = (QueryResultDesc) conf;
+    this.vContext = vContext;
+    this.vectorDesc = (VectorQueryResultDesc) vectorDesc;
+  }
+
+  /** Kryo ctor. */
+  @VisibleForTesting
+  public VectorQueryResultOperator() {
+    super();
+  }
+
+  public VectorQueryResultOperator(CompilationOpContext ctx) {
+    super(ctx);
+  }
+
+  @Override
+  public VectorizationContext getInputVectorizationContext() {
+    return vContext;
+  }
+
+  @Override
+  protected void initializeOp(Configuration hconf) throws HiveException {
+
+    // We need an input object inspector for the row extracted from the
+    // vectorized row batch, not an inspector for the original vectorized input.
+    inputObjInspectors[0] =
+        VectorizedBatchUtil.convertToStandardStructObjectInspector(
+            (StructObjectInspector) inputObjInspectors[0]);
+    super.initializeOp(hconf);
+
+    firstBatch = true;
+  }
+
+  @Override
+  public void process(Object data, int tag) throws HiveException {
+    VectorizedRowBatch batch = (VectorizedRowBatch) data;
+    if (firstBatch) {
+      vectorExtractRow = new VectorExtractRow();
+      vectorExtractRow.init((StructObjectInspector) inputObjInspectors[0], vContext.getProjectedColumns());
+
+      singleRow = new Object[vectorExtractRow.getCount()];
+
+      firstBatch = false;
+    }
+
+    if (batch.selectedInUse) {
+      int selected[] = batch.selected;
+      for (int logical = 0; logical < batch.size; logical++) {
+        int batchIndex = selected[logical];
+        vectorExtractRow.extractRow(batch, batchIndex, singleRow);
+        super.process(singleRow, tag);
+      }
+    } else {
+      for (int batchIndex = 0; batchIndex < batch.size; batchIndex++) {
+        vectorExtractRow.extractRow(batch, batchIndex, singleRow);
+        super.process(singleRow, tag);
+      }
+    }
+  }
+
+  @Override
+  public VectorDesc getVectorDesc() {
+    return vectorDesc;
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/HiveIgnoreKeyTextOutputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/HiveIgnoreKeyTextOutputFormat.java
@@ -66,16 +66,7 @@ public class HiveIgnoreKeyTextOutputFormat<K extends WritableComparable, V exten
   public RecordWriter getHiveRecordWriter(JobConf jc, Path outPath,
       Class<? extends Writable> valueClass, boolean isCompressed,
       Properties tableProperties, Progressable progress) throws IOException {
-    int rowSeparator = 0;
-    String rowSeparatorString = tableProperties.getProperty(
-        serdeConstants.LINE_DELIM, "\n");
-    try {
-      rowSeparator = Byte.parseByte(rowSeparatorString);
-    } catch (NumberFormatException e) {
-      rowSeparator = rowSeparatorString.charAt(0);
-    }
-
-    final int finalRowSeparator = rowSeparator;
+    final int finalRowSeparator = getRowSeparator(tableProperties);
     FileSystem fs = outPath.getFileSystem(jc);
     final OutputStream outStream = Utilities.createCompressedStream(jc,
     fs.create(outPath, progress), isCompressed);
@@ -99,6 +90,16 @@ public class HiveIgnoreKeyTextOutputFormat<K extends WritableComparable, V exten
         outStream.close();
       }
     };
+  }
+
+  public static int getRowSeparator(Properties tableProperties) {
+    String rowSeparatorString = tableProperties.getProperty(
+        serdeConstants.LINE_DELIM, "\n");
+    try {
+      return Byte.parseByte(rowSeparatorString);
+    } catch (NumberFormatException e) {
+      return rowSeparatorString.charAt(0);
+    }
   }
 
   protected static class IgnoreKeyWriter<K extends WritableComparable, V extends Writable>

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
@@ -138,6 +138,7 @@ import org.apache.hadoop.hive.ql.plan.MapredWork;
 import org.apache.hadoop.hive.ql.plan.MergeJoinWork;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.PTFDesc;
+import org.apache.hadoop.hive.ql.plan.QueryResultDesc;
 import org.apache.hadoop.hive.ql.plan.SelectDesc;
 import org.apache.hadoop.hive.ql.plan.TopNKeyDesc;
 import org.apache.hadoop.hive.ql.plan.VectorAppMasterEventDesc;
@@ -145,6 +146,7 @@ import org.apache.hadoop.hive.ql.plan.VectorDesc;
 import org.apache.hadoop.hive.ql.plan.VectorFileSinkDesc;
 import org.apache.hadoop.hive.ql.plan.VectorFilterDesc;
 import org.apache.hadoop.hive.ql.plan.VectorPTFDesc;
+import org.apache.hadoop.hive.ql.plan.VectorQueryResultDesc;
 import org.apache.hadoop.hive.ql.plan.VectorPTFInfo;
 import org.apache.hadoop.hive.ql.plan.VectorPTFDesc.SupportedFunctionType;
 import org.apache.hadoop.hive.ql.plan.VectorTableScanDesc;
@@ -5344,6 +5346,15 @@ public class Vectorizer implements PhysicalPlanResolver {
 
     boolean isNative;
     try {
+      if (op instanceof QueryResultOperator) {
+        QueryResultDesc queryResultDesc = (QueryResultDesc) op.getConf();
+        VectorQueryResultDesc vectorQueryResultDesc = new VectorQueryResultDesc();
+        vectorOp = OperatorFactory.getVectorOperator(
+            op.getCompilationOpContext(), queryResultDesc, vContext, vectorQueryResultDesc);
+        isNative = false;
+        return vectorOp;
+      }
+
       switch (op.getType()) {
         case MAPJOIN:
           {

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/QueryResultDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/QueryResultDesc.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.plan;
+
+import java.util.Objects;
+
+import org.apache.hadoop.hive.ql.plan.Explain.Level;
+
+/**
+ * QueryResultDesc.
+ */
+@Explain(displayName = "Query Result Operator", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
+public class QueryResultDesc extends AbstractOperatorDesc {
+  private static final long serialVersionUID = 1L;
+
+  public static final String QUERY_RESULT_PER_TASK_MAX_BYTES =
+      "hive.mr3.query.result.per.task.max.bytes";
+  public static final long DEFAULT_QUERY_RESULT_PER_TASK_MAX_BYTES = 64L * 1024L * 1024L;
+
+  private String resultId;
+  private TableDesc tableInfo;
+  private boolean usingBatchingSerDe;
+  private long maxBytes = DEFAULT_QUERY_RESULT_PER_TASK_MAX_BYTES;
+
+  public QueryResultDesc() {
+  }
+
+  public QueryResultDesc(String resultId, TableDesc tableInfo, boolean usingBatchingSerDe) {
+    this(resultId, tableInfo, usingBatchingSerDe, DEFAULT_QUERY_RESULT_PER_TASK_MAX_BYTES);
+  }
+
+  public QueryResultDesc(String resultId, TableDesc tableInfo, boolean usingBatchingSerDe,
+      long maxBytes) {
+    this.resultId = resultId;
+    this.tableInfo = tableInfo;
+    this.usingBatchingSerDe = usingBatchingSerDe;
+    this.maxBytes = maxBytes;
+  }
+
+  @Override
+  public Object clone() {
+    QueryResultDesc ret = new QueryResultDesc(resultId, tableInfo, usingBatchingSerDe, maxBytes);
+    ret.setStatistics(getStatistics());
+    ret.setTraits(getTraits());
+    ret.setOpProps(getOpProps());
+    ret.setMemoryNeeded(getMemoryNeeded());
+    ret.setMaxMemoryAvailable(getMaxMemoryAvailable());
+    ret.setEstimateNumExecutors(getEstimateNumExecutors());
+    ret.setRuntimeStatsTmpDir(getRuntimeStatsTmpDir());
+    ret.setColumnExprMap(getColumnExprMap());
+    ret.setBucketingVersion(getBucketingVersion());
+    return ret;
+  }
+
+  @Explain(displayName = "result id")
+  public String getResultId() {
+    return resultId;
+  }
+
+  public void setResultId(String resultId) {
+    this.resultId = resultId;
+  }
+
+  public TableDesc getTableInfo() {
+    return tableInfo;
+  }
+
+  public void setTableInfo(TableDesc tableInfo) {
+    this.tableInfo = tableInfo;
+  }
+
+  @Explain(displayName = "using batching SerDe")
+  public boolean isUsingBatchingSerDe() {
+    return usingBatchingSerDe;
+  }
+
+  public void setUsingBatchingSerDe(boolean usingBatchingSerDe) {
+    this.usingBatchingSerDe = usingBatchingSerDe;
+  }
+
+  @Explain(displayName = "max bytes")
+  public long getMaxBytes() {
+    return maxBytes;
+  }
+
+  public void setMaxBytes(long maxBytes) {
+    this.maxBytes = maxBytes;
+  }
+
+  @Override
+  public boolean isSame(OperatorDesc other) {
+    if (!(other instanceof QueryResultDesc)) {
+      return false;
+    }
+    QueryResultDesc otherDesc = (QueryResultDesc) other;
+    return Objects.equals(resultId, otherDesc.resultId)
+        && Objects.equals(tableInfo, otherDesc.tableInfo)
+        && usingBatchingSerDe == otherDesc.usingBatchingSerDe
+        && maxBytes == otherDesc.maxBytes;
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/QueryResultDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/QueryResultDesc.java
@@ -35,7 +35,7 @@ public class QueryResultDesc extends AbstractOperatorDesc {
 
   private String resultId;
   private TableDesc tableInfo;
-  private boolean usingBatchingSerDe;
+  private boolean isUsingBatchingSerDe;
   private long maxBytes = DEFAULT_QUERY_RESULT_PER_TASK_MAX_BYTES;
 
   public QueryResultDesc() {
@@ -49,13 +49,13 @@ public class QueryResultDesc extends AbstractOperatorDesc {
       long maxBytes) {
     this.resultId = resultId;
     this.tableInfo = tableInfo;
-    this.usingBatchingSerDe = usingBatchingSerDe;
+    this.isUsingBatchingSerDe = usingBatchingSerDe;
     this.maxBytes = maxBytes;
   }
 
   @Override
   public Object clone() {
-    QueryResultDesc ret = new QueryResultDesc(resultId, tableInfo, usingBatchingSerDe, maxBytes);
+    QueryResultDesc ret = new QueryResultDesc(resultId, tableInfo, isUsingBatchingSerDe, maxBytes);
     ret.setStatistics(getStatistics());
     ret.setTraits(getTraits());
     ret.setOpProps(getOpProps());
@@ -87,11 +87,11 @@ public class QueryResultDesc extends AbstractOperatorDesc {
 
   @Explain(displayName = "using batching SerDe")
   public boolean isUsingBatchingSerDe() {
-    return usingBatchingSerDe;
+    return isUsingBatchingSerDe;
   }
 
-  public void setUsingBatchingSerDe(boolean usingBatchingSerDe) {
-    this.usingBatchingSerDe = usingBatchingSerDe;
+  public void setIsUsingBatchingSerDe(boolean isUsingBatchingSerDe) {
+    this.isUsingBatchingSerDe = isUsingBatchingSerDe;
   }
 
   @Explain(displayName = "max bytes")
@@ -111,7 +111,7 @@ public class QueryResultDesc extends AbstractOperatorDesc {
     QueryResultDesc otherDesc = (QueryResultDesc) other;
     return Objects.equals(resultId, otherDesc.resultId)
         && Objects.equals(tableInfo, otherDesc.tableInfo)
-        && usingBatchingSerDe == otherDesc.usingBatchingSerDe
+        && isUsingBatchingSerDe == otherDesc.isUsingBatchingSerDe
         && maxBytes == otherDesc.maxBytes;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/VectorQueryResultDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/VectorQueryResultDesc.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.plan;
+
+/**
+ * VectorQueryResultDesc.
+ *
+ * Extra parameters beyond QueryResultDesc just for the VectorQueryResultOperator.
+ *
+ * We don't extend QueryResultDesc because the base OperatorDesc doesn't support
+ * clone and adding it is a lot work for little gain.
+ */
+public class VectorQueryResultDesc extends AbstractVectorDesc {
+
+  private static final long serialVersionUID = 1L;
+
+  public VectorQueryResultDesc() {
+  }
+}


### PR DESCRIPTION
### Motivation

- Introduce a new operator to collect query-result rows in memory and emit them to the Tez/MR3 `ProcessorContext` when the task is allowed to commit.
- Provide a descriptor carrying result metadata, SerDe/table information, and per-task size limits for query results.
- Support batching SerDe output and multiple `ProcessorContext.commitDagOutput` signatures (`ByteString` or `byte[]`).

### Description

- Add `QueryResultOperator` which serializes rows using the configured `SerDe`, accumulates them in-memory, enforces a per-task byte limit, and invokes `ProcessorContext.commitDagOutput` (using reflection to support either `ByteString` or `byte[]`).
- Add `QueryResultDesc` with fields for `resultId`, `TableDesc` (`tableInfo`), `usingBatchingSerDe`, and `maxBytes`, plus constants and accessors including `QUERY_RESULT_PER_TASK_MAX_BYTES` and `DEFAULT_QUERY_RESULT_PER_TASK_MAX_BYTES`.
- Handle batching SerDe finalization, row separators from SerDe properties, and error paths when `TezContext`/`ProcessorContext` or required `TableDesc` are missing.

### Testing

- Local compilation of the `ql` module was performed using `mvn -pl ql -am -DskipTests package` and completed successfully.
- No new automated unit tests were added in this change.
- Full Hive automated test suite was not run as part of this change (recommend running CI to exercise Tez end-to-end behavior).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b295c2c208328bd2d8e1a8787bd3e)