### PR TITLE
Plan QueryResultOperator for top-level SELECTs, avoid staging, and add result logging

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -5952,7 +5952,7 @@ public class HiveConf extends Configuration {
     HIVE_MR3_LOCALIZE_SESSION_JARS("hive.mr3.localize.session.jars", true,
         "Localize session jars"),
 
-    // Additional jars to include as initial session resoures
+    // Additional jars to include as initial session resources
     HIVE_MR3_AUX_JARS("hive.mr3.aux.jars", "",
       "Additional jars relative to the directory where Hive-exec-jar is located."),
 
@@ -5963,14 +5963,17 @@ public class HiveConf extends Configuration {
     HIVE_MR3_QUERY_DAG_ID_ID("hive.mr3.query.dag.id.id", -1, "DAGID.id for internal use"),
 
     HIVE_MR3_CONFIG_REMOVE_KEYS("hive.mr3.config.remove.keys", "",
-      "Comman-separated list of config keys to remove from JobConf for DAG"),
+      "Comma-separated list of config keys to remove from JobConf for DAG"),
     HIVE_MR3_DAG_CONFIG_REMOVE_PREFIXES("hive.mr3.dag.config.remove.prefixes", "",
       "Comma-separated list of key prefixes to remove from JobConf for DAG"),
     HIVE_MR3_SESSION_CONFIG_REMOVE_PREFIXES("hive.mr3.session.config.remove.prefixes", "",
       "Comma-separated list of key prefixes to remove from JobConf for MR3 session"),
 
+    HIVE_MR3_QUERY_RESULT_TASK_MAX_BYTES("hive.mr3.query.result.task.max.bytes",256 * 1024L * 1024L,
+      "Max number of bytes per task to keep in memory when using QueryResultOperator"),
+
     HIVE_MR3_UI_INCLUDE_OPERATOR_EXTRA("hive.mr3.ui.include.operator.extra", false,
-      "Include the details of each operator in JSON ojbect for DAG");
+      "Include the details of each operator in JSON object for DAG");
 
     public final String varname;
     public final String altName;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorFactory.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorFileSinkOperator;
 import org.apache.hadoop.hive.ql.exec.vector.VectorFilterOperator;
 import org.apache.hadoop.hive.ql.exec.vector.VectorGroupByOperator;
 import org.apache.hadoop.hive.ql.exec.vector.VectorLimitOperator;
+import org.apache.hadoop.hive.ql.exec.vector.VectorQueryResultOperator;
 import org.apache.hadoop.hive.ql.exec.vector.VectorMapJoinOperator;
 import org.apache.hadoop.hive.ql.exec.vector.VectorReduceSinkOperator;
 import org.apache.hadoop.hive.ql.exec.vector.VectorSMBMapJoinOperator;
@@ -63,6 +64,7 @@ import org.apache.hadoop.hive.ql.plan.MuxDesc;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.OrcFileMergeDesc;
 import org.apache.hadoop.hive.ql.plan.PTFDesc;
+import org.apache.hadoop.hive.ql.plan.QueryResultDesc;
 import org.apache.hadoop.hive.ql.plan.RCFileMergeDesc;
 import org.apache.hadoop.hive.ql.plan.ReduceSinkDesc;
 import org.apache.hadoop.hive.ql.plan.SMBJoinDesc;
@@ -118,6 +120,7 @@ public final class OperatorFactory {
     opvec.put(OrcFileMergeDesc.class, OrcFileMergeOperator.class);
     opvec.put(CommonMergeJoinDesc.class, CommonMergeJoinOperator.class);
     opvec.put(ListSinkDesc.class, ListSinkOperator.class);
+    opvec.put(QueryResultDesc.class, QueryResultOperator.class);
     opvec.put(TopNKeyDesc.class, TopNKeyOperator.class);
   }
 
@@ -132,6 +135,7 @@ public final class OperatorFactory {
     vectorOpvec.put(FileSinkDesc.class, VectorFileSinkOperator.class);
     vectorOpvec.put(FilterDesc.class, VectorFilterOperator.class);
     vectorOpvec.put(LimitDesc.class, VectorLimitOperator.class);
+    vectorOpvec.put(QueryResultDesc.class, VectorQueryResultOperator.class);
     vectorOpvec.put(PTFDesc.class, VectorPTFOperator.class);
     vectorOpvec.put(TopNKeyDesc.class, VectorTopNKeyOperator.class);
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/QueryResultOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/QueryResultOperator.java
@@ -151,10 +151,12 @@ public class QueryResultOperator extends Operator<QueryResultDesc> {
   private void writeRecord(Writable writable) throws IOException, HiveException {
     if (writable instanceof Text) {
       Text text = (Text) writable;
+      LOG.info("QueryResultOperator record resultId={}: {}", conf.getResultId(), text.toString());
       dataOut.write(text.getBytes(), 0, text.getLength());
     } else {
       // Binary SerDes always write out BytesWritable.
       BytesWritable bytes = (BytesWritable) writable;
+      LOG.info("QueryResultOperator record resultId={}: {}", conf.getResultId(), bytes.toString());
       dataOut.write(bytes.get(), 0, bytes.getSize());
     }
     dataOut.write(rowSeparator);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/QueryResultOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/QueryResultOperator.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.UnsafeByteOperations;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.CompilationOpContext;
+import org.apache.hadoop.hive.ql.exec.tez.TezContext;
+import org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.plan.QueryResultDesc;
+import org.apache.hadoop.hive.ql.plan.api.OperatorType;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
+import org.apache.hadoop.hive.serde2.SerDeException;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+import org.apache.tez.runtime.api.ProcessorContext;
+
+/**
+ * QueryResultOperator is a distilled FileSinkOperator for user-visible query results.
+ *
+ * It preserves the FileSinkOperator row serialization path, but replaces the
+ * file-backed RecordWriter with an in-memory buffer that is committed to the
+ * Tez/MR3 processor context when the task attempt is allowed to commit.
+ */
+public class QueryResultOperator extends Operator<QueryResultDesc> {
+  private static final long serialVersionUID = 1L;
+
+  private transient AbstractSerDe serializer;
+  private transient ObjectInspector inputOI;
+  private transient Writable recordValue;
+  private transient int rowSeparator;
+
+  private transient ByteArrayOutputStream writer;
+  private transient DataOutputStream dataOut;
+  private transient ProcessorContext processorContext;
+  private transient long maxBytes;
+
+  /** Kryo ctor. */
+  protected QueryResultOperator() {
+    super();
+  }
+
+  public QueryResultOperator(CompilationOpContext ctx) {
+    super(ctx);
+  }
+
+  @Override
+  protected void initializeOp(Configuration hconf) throws HiveException {
+    super.initializeOp(hconf);
+
+    try {
+      serializer = conf.getTableInfo().getSerDeClass().newInstance();
+      serializer.initialize(hconf, conf.getTableInfo().getProperties(), null);
+    } catch (InstantiationException | IllegalAccessException | SerDeException e) {
+      throw new HiveException("Unable to initialize QueryResultOperator serializer", e);
+    }
+    inputOI = inputObjInspectors[0];
+
+    writer = new ByteArrayOutputStream();
+    dataOut = new DataOutputStream(writer);
+    maxBytes = HiveConf.getLongVar(hconf, HiveConf.ConfVars.HIVE_MR3_QUERY_RESULT_TASK_MAX_BYTES);
+    rowSeparator = HiveIgnoreKeyTextOutputFormat.getRowSeparator(conf.getTableInfo().getProperties());
+
+    MapredContext mapredContext = MapredContext.get();
+    processorContext = ((TezContext) mapredContext).getTezProcessorContext();
+  }
+
+  @Override
+  public void process(Object row, int tag) throws HiveException {
+    runTimeNumRows++;
+    try {
+      recordValue = serializer.serialize(row, inputObjInspectors[tag]);
+      if (recordValue == null) {
+        return;
+      }
+      writeRecord(recordValue);
+      numRows++;
+    } catch (SerDeException | IOException e) {
+      throw new HiveException("Error writing query result row", e);
+    }
+  }
+
+  @Override
+  protected void closeOp(boolean abort) throws HiveException {
+    try {
+      if (!abort && conf.isUsingBatchingSerDe()) {
+        recordValue = serializer.serialize(null, inputOI);
+        if (recordValue != null) {
+          writeRecord(recordValue);
+        }
+      }
+
+      if (dataOut != null) {
+        dataOut.flush();
+      }
+
+      if (abort) {
+        return;
+      }
+
+      if (!processorContext.canCommit()) {
+        LOG.info("QueryResultOperator is not allowed to commit resultId={}", conf.getResultId());
+        return;
+      }
+
+      commitDagOutput();
+    } catch (IOException | SerDeException e) {
+      throw new HiveException("Error closing QueryResultOperator", e);
+    }
+  }
+
+  @Override
+  public String getName() {
+    return QueryResultOperator.getOperatorName();
+  }
+
+  static public String getOperatorName() {
+    return "QRO";
+  }
+
+  @Override
+  public OperatorType getType() {
+    return OperatorType.FILESINK;
+  }
+
+  private void writeRecord(Writable writable) throws IOException, HiveException {
+    if (writable instanceof Text) {
+      Text text = (Text) writable;
+      dataOut.write(text.getBytes(), 0, text.getLength());
+    } else {
+      // Binary SerDes always write out BytesWritable.
+      BytesWritable bytes = (BytesWritable) writable;
+      dataOut.write(bytes.get(), 0, bytes.getSize());
+    }
+    dataOut.write(rowSeparator);
+    enforceMaxBytes();
+  }
+
+  private void enforceMaxBytes() throws HiveException {
+    if (maxBytes >= 0 && writer.size() > maxBytes) {
+      throw new HiveException("Query result for resultId=" + conf.getResultId()
+          + " exceeded per-task limit " + maxBytes + " bytes");
+    }
+  }
+
+  private void commitDagOutput() throws IOException, HiveException {
+    byte[] payload = writer.toByteArray();
+    ByteString dagOutput = UnsafeByteOperations.unsafeWrap(payload);
+    processorContext.sendEvents(null);
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorQueryResultOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorQueryResultOperator.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.vector;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.ql.CompilationOpContext;
+import org.apache.hadoop.hive.ql.exec.QueryResultOperator;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.plan.OperatorDesc;
+import org.apache.hadoop.hive.ql.plan.QueryResultDesc;
+import org.apache.hadoop.hive.ql.plan.VectorDesc;
+import org.apache.hadoop.hive.ql.plan.VectorQueryResultDesc;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * Vectorized QueryResult operator implementation.
+ *
+ * Like VectorFileSinkOperator, this class only converts VectorizedRowBatch rows
+ * into standard row objects and delegates the result serialization and commit
+ * behavior to the row-mode QueryResultOperator.
+ */
+public class VectorQueryResultOperator extends QueryResultOperator
+    implements VectorizationOperator {
+
+  private static final long serialVersionUID = 1L;
+
+  private VectorizationContext vContext;
+  private VectorQueryResultDesc vectorDesc;
+
+  private transient boolean firstBatch;
+
+  private transient VectorExtractRow vectorExtractRow;
+
+  protected transient Object[] singleRow;
+
+  public VectorQueryResultOperator(CompilationOpContext ctx, OperatorDesc conf,
+      VectorizationContext vContext, VectorDesc vectorDesc) {
+    this(ctx);
+    this.conf = (QueryResultDesc) conf;
+    this.vContext = vContext;
+    this.vectorDesc = (VectorQueryResultDesc) vectorDesc;
+  }
+
+  /** Kryo ctor. */
+  @VisibleForTesting
+  public VectorQueryResultOperator() {
+    super();
+  }
+
+  public VectorQueryResultOperator(CompilationOpContext ctx) {
+    super(ctx);
+  }
+
+  @Override
+  public VectorizationContext getInputVectorizationContext() {
+    return vContext;
+  }
+
+  @Override
+  protected void initializeOp(Configuration hconf) throws HiveException {
+
+    // We need an input object inspector for the row extracted from the
+    // vectorized row batch, not an inspector for the original vectorized input.
+    inputObjInspectors[0] =
+        VectorizedBatchUtil.convertToStandardStructObjectInspector(
+            (StructObjectInspector) inputObjInspectors[0]);
+    super.initializeOp(hconf);
+
+    firstBatch = true;
+  }
+
+  @Override
+  public void process(Object data, int tag) throws HiveException {
+    VectorizedRowBatch batch = (VectorizedRowBatch) data;
+    if (firstBatch) {
+      vectorExtractRow = new VectorExtractRow();
+      vectorExtractRow.init((StructObjectInspector) inputObjInspectors[0], vContext.getProjectedColumns());
+
+      singleRow = new Object[vectorExtractRow.getCount()];
+
+      firstBatch = false;
+    }
+
+    if (batch.selectedInUse) {
+      int selected[] = batch.selected;
+      for (int logical = 0; logical < batch.size; logical++) {
+        int batchIndex = selected[logical];
+        vectorExtractRow.extractRow(batch, batchIndex, singleRow);
+        super.process(singleRow, tag);
+      }
+    } else {
+      for (int batchIndex = 0; batchIndex < batch.size; batchIndex++) {
+        vectorExtractRow.extractRow(batch, batchIndex, singleRow);
+        super.process(singleRow, tag);
+      }
+    }
+  }
+
+  @Override
+  public VectorDesc getVectorDesc() {
+    return vectorDesc;
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/HiveIgnoreKeyTextOutputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/HiveIgnoreKeyTextOutputFormat.java
@@ -66,16 +66,7 @@ public class HiveIgnoreKeyTextOutputFormat<K extends WritableComparable, V exten
   public RecordWriter getHiveRecordWriter(JobConf jc, Path outPath,
       Class<? extends Writable> valueClass, boolean isCompressed,
       Properties tableProperties, Progressable progress) throws IOException {
-    int rowSeparator = 0;
-    String rowSeparatorString = tableProperties.getProperty(
-        serdeConstants.LINE_DELIM, "\n");
-    try {
-      rowSeparator = Byte.parseByte(rowSeparatorString);
-    } catch (NumberFormatException e) {
-      rowSeparator = rowSeparatorString.charAt(0);
-    }
-
-    final int finalRowSeparator = rowSeparator;
+    final int finalRowSeparator = getRowSeparator(tableProperties);
     FileSystem fs = outPath.getFileSystem(jc);
     final OutputStream outStream = Utilities.createCompressedStream(jc,
     fs.create(outPath, progress), isCompressed);
@@ -99,6 +90,16 @@ public class HiveIgnoreKeyTextOutputFormat<K extends WritableComparable, V exten
         outStream.close();
       }
     };
+  }
+
+  public static int getRowSeparator(Properties tableProperties) {
+    String rowSeparatorString = tableProperties.getProperty(
+        serdeConstants.LINE_DELIM, "\n");
+    try {
+      return Byte.parseByte(rowSeparatorString);
+    } catch (NumberFormatException e) {
+      return rowSeparatorString.charAt(0);
+    }
   }
 
   protected static class IgnoreKeyWriter<K extends WritableComparable, V extends Writable>

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
@@ -138,6 +138,7 @@ import org.apache.hadoop.hive.ql.plan.MapredWork;
 import org.apache.hadoop.hive.ql.plan.MergeJoinWork;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.PTFDesc;
+import org.apache.hadoop.hive.ql.plan.QueryResultDesc;
 import org.apache.hadoop.hive.ql.plan.SelectDesc;
 import org.apache.hadoop.hive.ql.plan.TopNKeyDesc;
 import org.apache.hadoop.hive.ql.plan.VectorAppMasterEventDesc;
@@ -145,6 +146,7 @@ import org.apache.hadoop.hive.ql.plan.VectorDesc;
 import org.apache.hadoop.hive.ql.plan.VectorFileSinkDesc;
 import org.apache.hadoop.hive.ql.plan.VectorFilterDesc;
 import org.apache.hadoop.hive.ql.plan.VectorPTFDesc;
+import org.apache.hadoop.hive.ql.plan.VectorQueryResultDesc;
 import org.apache.hadoop.hive.ql.plan.VectorPTFInfo;
 import org.apache.hadoop.hive.ql.plan.VectorPTFDesc.SupportedFunctionType;
 import org.apache.hadoop.hive.ql.plan.VectorTableScanDesc;
@@ -5344,6 +5346,15 @@ public class Vectorizer implements PhysicalPlanResolver {
 
     boolean isNative;
     try {
+      if (op instanceof QueryResultOperator) {
+        QueryResultDesc queryResultDesc = (QueryResultDesc) op.getConf();
+        VectorQueryResultDesc vectorQueryResultDesc = new VectorQueryResultDesc();
+        vectorOp = OperatorFactory.getVectorOperator(
+            op.getCompilationOpContext(), queryResultDesc, vContext, vectorQueryResultDesc);
+        isNative = false;
+        return vectorOp;
+      }
+
       switch (op.getType()) {
         case MAPJOIN:
           {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -260,6 +260,7 @@ import org.apache.hadoop.hive.ql.plan.MapJoinDesc;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.PTFDesc;
 import org.apache.hadoop.hive.ql.plan.PlanUtils;
+import org.apache.hadoop.hive.ql.plan.QueryResultDesc;
 import org.apache.hadoop.hive.ql.plan.ReduceSinkDesc;
 import org.apache.hadoop.hive.ql.plan.ScriptDesc;
 import org.apache.hadoop.hive.ql.plan.SelectDesc;
@@ -2668,9 +2669,10 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
           } else {
             // This is the only place where isQuery is set to true; it defaults to false.
             qb.setIsQuery(true);
-            Path stagingPath = getStagingDirectoryPathname(qb, conf, ctx);
-            fname = stagingPath.toString();
-            ctx.setResDir(stagingPath);
+            // QueryResultOperator does not write to a staging directory, but the destination
+            // metadata still needs a marker so planning can derive the query result schema.
+            fname = queryState.getQueryId();
+            ctx.setResDir(null);
           }
         }
 
@@ -2678,7 +2680,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         if (ast.getChildCount() >= 2 && ast.getChild(1).getText().toLowerCase().equals("local")) {
           isDfsFile = false;
         }
-        // Set the destination for the SELECT query inside the CTAS
+        // Set the destination metadata for CTAS and top-level SELECT queries. For top-level
+        // SELECT, QueryResultOperator uses this alias metadata for schema derivation only.
         qb.getMetaData().setDestForAlias(name, fname, isDfsFile);
 
         CreateTableDesc directoryDesc = new CreateTableDesc();
@@ -7875,33 +7878,35 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         isPartitioned = false;
       }
 
-      if (isLocal) {
-        assert !isMmTable;
-        // for local directory - we always write to map-red intermediate
-        // store and then copy to local fs
-        queryTmpdir = ctx.getMRTmpPath();
-        if (dpCtx != null && dpCtx.getSPPath() != null) {
-          queryTmpdir = new Path(queryTmpdir, dpCtx.getSPPath());
+      if (!qb.getIsQuery()) {
+        if (isLocal) {
+          assert !isMmTable;
+          // for local directory - we always write to map-red intermediate
+          // store and then copy to local fs
+          queryTmpdir = ctx.getMRTmpPath();
+          if (dpCtx != null && dpCtx.getSPPath() != null) {
+            queryTmpdir = new Path(queryTmpdir, dpCtx.getSPPath());
+          }
+        } else {
+          // otherwise write to the file system implied by the directory
+          // no copy is required. we may want to revisit this policy in future
+          try {
+            Path qPath = FileUtils.makeQualified(destinationPath, conf);
+            queryTmpdir = getTmpDir(false, isMmTable, isDirectInsert, qPath, dpCtx);
+          } catch (Exception e) {
+            throw new SemanticException("Error creating "
+                + destinationPath, e);
+          }
         }
-      } else {
-        // otherwise write to the file system implied by the directory
-        // no copy is required. we may want to revisit this policy in future
-        try {
-          Path qPath = FileUtils.makeQualified(destinationPath, conf);
-          queryTmpdir = getTmpDir(false, isMmTable, isDirectInsert, qPath, dpCtx);
-        } catch (Exception e) {
-          throw new SemanticException("Error creating "
-              + destinationPath, e);
+        // set the root of the temporary path where dynamic partition columns will populate
+        if (dpCtx != null) {
+          dpCtx.setRootPath(queryTmpdir);
         }
-      }
-      // set the root of the temporary path where dynamic partition columns will populate
-      if (dpCtx != null) {
-        dpCtx.setRootPath(queryTmpdir);
-      }
 
-      if (Utilities.FILE_OP_LOGGER.isTraceEnabled()) {
-        Utilities.FILE_OP_LOGGER.trace("Setting query directory " + queryTmpdir
-            + " from " + destinationPath + " (" + isMmTable + ")");
+        if (Utilities.FILE_OP_LOGGER.isTraceEnabled()) {
+          Utilities.FILE_OP_LOGGER.trace("Setting query directory " + queryTmpdir
+              + " from " + destinationPath + " (" + isMmTable + ")");
+        }
       }
 
       // update the create table descriptor with the resulting schema.
@@ -8048,7 +8053,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         ltd.setMdTable(destinationTable);
         WriteEntity output = generateTableWriteEntity(dest, destinationTable, dpCtx.getPartSpec(), ltd, dpCtx);
         ctx.getLoadTableOutputMap().put(ltd, output);
-      } else {
+      } else if (!qb.getIsQuery()) {
         // Create LFD even for MM CTAS - it's a no-op move, but it still seems to be used for stats.
         LoadFileDesc loadFileDesc = new LoadFileDesc(tblDesc, viewDesc, queryTmpdir, destinationPath, isDfsDir, cols,
             colTypes,
@@ -8148,6 +8153,17 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     // Generate the partition columns from the parent input
     if (destType == QBMetaData.DEST_TABLE || destType == QBMetaData.DEST_PARTITION) {
       genPartnCols(dest, input, qb, tableDescriptor, destinationTable, rsCtx);
+    }
+
+    if (qb.getIsQuery()) {
+      QueryResultDesc queryResultDesc = new QueryResultDesc(null, tableDescriptor,
+          null != tableDescriptor && useBatchingSerializer(tableDescriptor.getSerdeClassName()));
+      Operator output = putOpInsertMap(OperatorFactory.getAndMakeChild(
+          queryResultDesc, fsRS, input), inputRR);
+      queryResultDesc.setResultId(queryState.getQueryId() + "_" + output.getOperatorId());
+
+      LOG.debug("Created QueryResult Plan for clause: {} row schema: {}", dest, inputRR);
+      return output;
     }
 
     FileSinkDesc fileSinkDesc = createFileSinkDesc(dest, tableDescriptor, destinationPartition,

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
 import org.apache.hadoop.hive.ql.exec.MoveTask;
 import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.exec.OperatorUtils;
+import org.apache.hadoop.hive.ql.exec.QueryResultOperator;
 import org.apache.hadoop.hive.ql.exec.StatsTask;
 import org.apache.hadoop.hive.ql.exec.TableScanOperator;
 import org.apache.hadoop.hive.ql.exec.Task;
@@ -187,7 +188,7 @@ public abstract class TaskCompiler {
      * If the select is from analyze table column rewrite, don't create a fetch task. Instead create
      * a column stats task later.
      */
-    if (pCtx.getQueryProperties().isQuery() && !isCStats) {
+    if (pCtx.getQueryProperties().isQuery() && !isCStats && !hasQueryResultOperator(pCtx)) {
       if ((!loadTableWork.isEmpty()) || (loadFileWork.size() != 1)) {
         throw new SemanticException(ErrorMsg.INVALID_LOAD_TABLE_FILE_WORK.getMsg());
       }
@@ -643,6 +644,11 @@ public abstract class TaskCompiler {
         targetTask.addDependentTask(TaskFactory.get(ddlWork, conf));
       }
     }
+  }
+
+  private boolean hasQueryResultOperator(ParseContext pCtx) {
+    Collection<Operator<?>> topOps = Lists.<Operator<?>>newArrayList(pCtx.getTopOps().values());
+    return !OperatorUtils.findOperators(topOps, QueryResultOperator.class).isEmpty();
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/QueryResultDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/QueryResultDesc.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.plan;
+
+import java.util.Objects;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.plan.Explain.Level;
+
+/**
+ * QueryResultDesc.
+ */
+@Explain(displayName = "Query Result Operator", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
+public class QueryResultDesc extends AbstractOperatorDesc {
+  private static final long serialVersionUID = 1L;
+
+  private String resultId;
+  private TableDesc tableInfo;
+  private boolean isUsingBatchingSerDe;
+  private long maxBytes;
+
+  public QueryResultDesc() {
+  }
+
+  public QueryResultDesc(String resultId, TableDesc tableInfo, boolean usingBatchingSerDe) {
+    this(resultId, tableInfo, usingBatchingSerDe,
+        HiveConf.ConfVars.HIVE_MR3_QUERY_RESULT_TASK_MAX_BYTES.defaultLongVal);
+  }
+
+  public QueryResultDesc(String resultId, TableDesc tableInfo, boolean usingBatchingSerDe,
+      long maxBytes) {
+    this.resultId = resultId;
+    this.tableInfo = tableInfo;
+    this.isUsingBatchingSerDe = usingBatchingSerDe;
+    this.maxBytes = maxBytes;
+  }
+
+  @Override
+  public Object clone() {
+    QueryResultDesc ret = new QueryResultDesc(resultId, tableInfo, isUsingBatchingSerDe, maxBytes);
+    ret.setStatistics(getStatistics());
+    ret.setTraits(getTraits());
+    ret.setOpProps(getOpProps());
+    ret.setMemoryNeeded(getMemoryNeeded());
+    ret.setMaxMemoryAvailable(getMaxMemoryAvailable());
+    ret.setEstimateNumExecutors(getEstimateNumExecutors());
+    ret.setRuntimeStatsTmpDir(getRuntimeStatsTmpDir());
+    ret.setColumnExprMap(getColumnExprMap());
+    ret.setBucketingVersion(getBucketingVersion());
+    return ret;
+  }
+
+  @Explain(displayName = "result id")
+  public String getResultId() {
+    return resultId;
+  }
+
+  public void setResultId(String resultId) {
+    this.resultId = resultId;
+  }
+
+  public TableDesc getTableInfo() {
+    return tableInfo;
+  }
+
+  public void setTableInfo(TableDesc tableInfo) {
+    this.tableInfo = tableInfo;
+  }
+
+  @Explain(displayName = "using batching SerDe")
+  public boolean isUsingBatchingSerDe() {
+    return isUsingBatchingSerDe;
+  }
+
+  public void setIsUsingBatchingSerDe(boolean isUsingBatchingSerDe) {
+    this.isUsingBatchingSerDe = isUsingBatchingSerDe;
+  }
+
+  @Explain(displayName = "max bytes")
+  public long getMaxBytes() {
+    return maxBytes;
+  }
+
+  public void setMaxBytes(long maxBytes) {
+    this.maxBytes = maxBytes;
+  }
+
+  @Override
+  public boolean isSame(OperatorDesc other) {
+    if (!(other instanceof QueryResultDesc)) {
+      return false;
+    }
+    QueryResultDesc otherDesc = (QueryResultDesc) other;
+    return Objects.equals(resultId, otherDesc.resultId)
+        && Objects.equals(tableInfo, otherDesc.tableInfo)
+        && isUsingBatchingSerDe == otherDesc.isUsingBatchingSerDe
+        && maxBytes == otherDesc.maxBytes;
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/VectorQueryResultDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/VectorQueryResultDesc.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.plan;
+
+/**
+ * VectorQueryResultDesc.
+ *
+ * Extra parameters beyond QueryResultDesc just for the VectorQueryResultOperator.
+ *
+ * We don't extend QueryResultDesc because the base OperatorDesc doesn't support
+ * clone and adding it is a lot work for little gain.
+ */
+public class VectorQueryResultDesc extends AbstractVectorDesc {
+
+  private static final long serialVersionUID = 1L;
+
+  public VectorQueryResultDesc() {
+  }
+}


### PR DESCRIPTION
### Motivation
- Enable a dedicated `QueryResultOperator` plan for top-level `SELECT` queries so results can be emitted without writing to a staging directory. 
- Ensure query result metadata/schema is still available to the planner without creating a temporary staging path. 
- Add runtime logging of records emitted by `QueryResultOperator` and avoid generating an unnecessary fetch/move task when a `QueryResultOperator` is present.

### Description
- In `SemanticAnalyzer`, when `QB.setIsQuery(true)` the destination metadata now uses the query id via `fname = queryState.getQueryId()` and `ctx.setResDir(null)` so no staging directory is created for query-only results.  
- In `genFileSinkPlan`, the temporary-directory and `LoadFileDesc`/`FileSinkDesc` creation paths are guarded to run only for non-query sinks, and a `QueryResultDesc` + child operator is created and returned for `qb.getIsQuery()` queries with `queryResultDesc.setResultId(queryState.getQueryId() + "_" + output.getOperatorId())`.  
- In `TaskCompiler`, a helper `hasQueryResultOperator(ParseContext)` was added and the fetch-task creation condition now skips creating a fetch task when a `QueryResultOperator` is present.  
- In `QueryResultOperator`, record writes now log emitted records at INFO with the `resultId` for both `Text` and `BytesWritable` payloads.

### Testing
- Ran the Hive query planning and QL unit tests that exercise `SELECT`/fetch/CTAS paths with `mvn`-based unit test runs, and confirmed no regressions in the affected modules.  
- Verified the modified planning path produces a `QueryResultOperator` for top-level queries and that the fetch task is not created when a `QueryResultOperator` exists, with all automated tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e951b16c48328b686513e91cdb1ea)