### PR TITLE
Expose MR3 DAG outputs as DataInput streams and integrate with Driver/TezTask

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/DagOutputResultReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/DagOutputResultReader.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql;
+
+import com.google.protobuf.ByteString;
+
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Presents MR3 DAG output payloads as the same DataInput streams used by the
+ * legacy file-backed result reader.
+ */
+public class DagOutputResultReader {
+  private final List<ByteString> payloads;
+  private int nextPayloadIndex;
+
+  public DagOutputResultReader(List<ByteString> payloads) {
+    this.payloads = Collections.unmodifiableList(new ArrayList<>(payloads));
+    this.nextPayloadIndex = 0;
+  }
+
+  public synchronized DataInput nextStream() {
+    if (nextPayloadIndex >= payloads.size()) {
+      return null;
+    }
+    return new DataInputStream(payloads.get(nextPayloadIndex++).newInput());
+  }
+
+  public synchronized void reset() {
+    nextPayloadIndex = 0;
+  }
+
+  public synchronized boolean hasPayloads() {
+    return !payloads.isEmpty();
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
@@ -659,6 +659,7 @@ public class Driver implements IDriver {
         throw new IOException("Error resetting the current fetch task", e);
       }
     } else {
+      driverContext.resetDagOutputResultReader();
       context.resetStream();
       driverContext.setResStream(null);
     }
@@ -684,12 +685,11 @@ public class Driver implements IDriver {
     }
 
     if (driverContext.getResStream() == null) {
-      // If the driver does not have a stream and neither does the context, return
-      DataInput contextStream = context.getStream();
-      if (contextStream == null) {
+      DataInput resultStream = getNextResultStream();
+      if (resultStream == null) {
         return false;
       }
-      driverContext.setResStream(contextStream);
+      driverContext.setResStream(resultStream);
     }
 
     int numRows = 0;
@@ -714,10 +714,17 @@ public class Driver implements IDriver {
       }
 
       if (streamStatus == Utilities.StreamStatus.EOF) {
-        driverContext.setResStream(context.getStream());
+        driverContext.setResStream(getNextResultStream());
       }
     }
     return true;
+  }
+
+  private DataInput getNextResultStream() {
+    if (driverContext.hasDagOutputResultReader()) {
+      return driverContext.getDagOutputResultStream();
+    }
+    return context.getStream();
   }
 
   @SuppressWarnings("rawtypes")

--- a/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
@@ -626,7 +626,7 @@ public class Driver implements IDriver {
 
   @Override
   public boolean isFetchingTable() {
-    return driverContext.getFetchTask() != null;
+    return driverContext.getFetchTask() != null && !driverContext.hasDagOutputResultReader();
   }
 
   @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
@@ -652,11 +652,7 @@ public class Driver implements IDriver {
     if (driverState.isDestroyed() || driverState.isClosed()) {
       throw new IOException("FAILED: driver has been cancelled, closed or destroyed.");
     }
-    if (driverContext.hasDagOutputResultReader()) {
-      driverContext.resetDagOutputResultReader();
-      context.resetStream();
-      driverContext.setResStream(null);
-    } else if (isFetchingTable()) {
+    if (!driverContext.hasDagOutputResultReader() && isFetchingTable()) {
       try {
         driverContext.getFetchTask().resetFetch();
       } catch (Exception e) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
@@ -626,7 +626,7 @@ public class Driver implements IDriver {
 
   @Override
   public boolean isFetchingTable() {
-    return driverContext.getFetchTask() != null && !driverContext.hasDagOutputResultReader();
+    return driverContext.getFetchTask() != null;
   }
 
   @Override
@@ -652,7 +652,11 @@ public class Driver implements IDriver {
     if (driverState.isDestroyed() || driverState.isClosed()) {
       throw new IOException("FAILED: driver has been cancelled, closed or destroyed.");
     }
-    if (isFetchingTable()) {
+    if (driverContext.hasDagOutputResultReader()) {
+      driverContext.resetDagOutputResultReader();
+      context.resetStream();
+      driverContext.setResStream(null);
+    } else if (isFetchingTable()) {
       try {
         driverContext.getFetchTask().resetFetch();
       } catch (Exception e) {
@@ -680,7 +684,7 @@ public class Driver implements IDriver {
       throw new IOException("FAILED: query has been cancelled, closed, or destroyed.");
     }
 
-    if (isFetchingTable()) {
+    if (!driverContext.hasDagOutputResultReader() && isFetchingTable()) {
       return getFetchingTableResults(results);
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/DriverContext.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/DriverContext.java
@@ -73,6 +73,7 @@ public class DriverContext {
   private boolean retrial = false;
 
   private DataInput resStream;
+  private DagOutputResultReader dagOutputResultReader;
 
   // HS2 operation handle guid string
   private String operationId;
@@ -213,6 +214,27 @@ public class DriverContext {
 
   public void setResStream(DataInput resStream) {
     this.resStream = resStream;
+  }
+
+  public void setDagOutputResultReader(DagOutputResultReader dagOutputResultReader) {
+    this.dagOutputResultReader = dagOutputResultReader;
+  }
+
+  public DataInput getDagOutputResultStream() {
+    if (dagOutputResultReader == null) {
+      return null;
+    }
+    return dagOutputResultReader.nextStream();
+  }
+
+  public boolean hasDagOutputResultReader() {
+    return dagOutputResultReader != null;
+  }
+
+  public void resetDagOutputResultReader() {
+    if (dagOutputResultReader != null) {
+      dagOutputResultReader.reset();
+    }
   }
 
   public String getOperationId() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/Executor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Executor.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hive.ql.exec.TaskFactory;
 import org.apache.hadoop.hive.ql.exec.TaskResult;
 import org.apache.hadoop.hive.ql.exec.TaskRunner;
 import org.apache.hadoop.hive.ql.exec.Utilities;
+import org.apache.hadoop.hive.ql.exec.tez.TezTask;
 import org.apache.hadoop.hive.ql.history.HiveHistory.Keys;
 import org.apache.hadoop.hive.ql.hooks.HookContext;
 import org.apache.hadoop.hive.ql.hooks.PrivateHookContext;
@@ -343,6 +344,9 @@ public class Executor {
     }
 
     task.initialize(driverContext.getQueryState(), driverContext.getPlan(), taskQueue, context);
+    if (task instanceof TezTask) {
+      ((TezTask) task).setDriverContext(driverContext);
+    }
     TaskRunner taskRun = new TaskRunner(task, taskQueue);
     taskQueue.launching(taskRun);
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/MR3Task.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/MR3Task.java
@@ -26,6 +26,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.Context;
+import org.apache.hadoop.hive.ql.DagOutputResultReader;
+import org.apache.hadoop.hive.ql.DriverContext;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
 import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.exec.OperatorUtils;
@@ -78,6 +80,8 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.Tuple2;
+import scala.collection.JavaConversions$;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -114,6 +118,7 @@ public class MR3Task {
   private final HiveConf conf;
   private final SessionState.LogHelper console;
   private final AtomicBoolean isShutdown;
+  private final DriverContext driverContext;
   private final DAGUtils dagUtils;
 
   private TezCounters counters;
@@ -132,9 +137,15 @@ public class MR3Task {
   private Map<BaseWork, JobConf> workToConf = null;
 
   public MR3Task(HiveConf conf, SessionState.LogHelper console, AtomicBoolean isShutdown) {
+    this(conf, console, isShutdown, null);
+  }
+
+  public MR3Task(HiveConf conf, SessionState.LogHelper console, AtomicBoolean isShutdown,
+      DriverContext driverContext) {
     this.conf = conf;
     this.console = console;
     this.isShutdown = isShutdown;
+    this.driverContext = driverContext;
     this.dagUtils = DAGUtils.getInstance();
     this.exception = null;
   }
@@ -237,6 +248,7 @@ public class MR3Task {
         }
         String dagIdStr = mr3JobRef.getDagIdStr();    // may throw MR3Exception
         collectCommitInformation(tezWork, dagStatus, dagIdStr);
+        collectDagOutputs(dagStatus);
         mr3Session.setAlreadyExecutedAnyDag();
       }
 
@@ -274,6 +286,25 @@ public class MR3Task {
     }
 
     return returnCode;
+  }
+
+  @SuppressWarnings("unchecked")
+  private void collectDagOutputs(DAGStatus dagStatus) {
+    if (driverContext == null) {
+      return;
+    }
+
+    String queryId = driverContext.getQueryState().getQueryId();
+    List<ByteString> payloads = new ArrayList<>();
+    for (Object dagOutputObj : JavaConversions$.MODULE$.asJavaCollection(dagStatus.dagOutputs())) {
+      Tuple2<String, ByteString> dagOutput = (Tuple2<String, ByteString>) dagOutputObj;
+      if (dagOutput._1().startsWith(queryId)) {
+        payloads.add(dagOutput._2());
+      }
+    }
+
+    LOG.info("Collected {} DAG output payload(s) for queryId={}", payloads.size(), queryId);
+    driverContext.setDagOutputResultReader(new DagOutputResultReader(payloads));
   }
 
   private void collectCommitInformation(TezWork work, DAGStatus dagStatus, String dagIdStr) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import org.apache.hadoop.hive.common.metrics.common.Metrics;
 import org.apache.hadoop.hive.common.metrics.common.MetricsConstant;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.DriverContext;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
 import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.exec.Task;
@@ -93,10 +94,15 @@ public class TezTask extends Task<TezWork> {
   }
 
   private java.util.concurrent.atomic.AtomicBoolean isShutdownMr3 = new java.util.concurrent.atomic.AtomicBoolean(false);
+  private transient DriverContext driverContext;
+
+  public void setDriverContext(DriverContext driverContext) {
+    this.driverContext = driverContext;
+  }
 
   private int executeMr3() {
     org.apache.hadoop.hive.ql.exec.mr3.MR3Task mr3Task =
-      new org.apache.hadoop.hive.ql.exec.mr3.MR3Task(conf, console, isShutdownMr3);
+      new org.apache.hadoop.hive.ql.exec.mr3.MR3Task(conf, console, isShutdownMr3, driverContext);
     int returnCode = mr3Task.execute(context, this.getWork());
     // Utils.mergeTezCounters is null-safe.
     counters = Utils.mergeTezCounters(mr3Task.getTezCounters(), counters);


### PR DESCRIPTION
### Motivation

- Allow MR3 DAG-produced output payloads to be consumed by the existing Driver `getResults` path using the same `DataInput`-based API as legacy file-backed results.
- Associate DAG outputs with the running query so `Driver` can read results produced by MR3 DAGs without changing the external fetch API.

### Description

- Add `DagOutputResultReader` (new class) that wraps a list of `ByteString` DAG payloads and presents them as `DataInput` streams with `nextStream()`, `reset()`, and `hasPayloads()` methods.
- Extend `DriverContext` to hold a `DagOutputResultReader` and expose `getDagOutputResultStream()`, `setDagOutputResultReader()`, `hasDagOutputResultReader()`, and `resetDagOutputResultReader()`.
- Update `Driver` to prefer DAG output streams when available by introducing `getNextResultStream()` and to reset DAG reader on `resetFetch()`; wire `driverContext.setResStream(...)` to use these streams during `getResults()`.
- In `MR3Task`, collect DAG outputs from `DAGStatus` that match the query id, build a `DagOutputResultReader` with the payloads, and attach it to the `DriverContext` via `setDagOutputResultReader()`.
- Propagate `DriverContext` into MR3 execution by adding a constructor overload to `MR3Task`, passing `DriverContext` from `TezTask`, and ensuring `Executor.launchTask()` sets the `DriverContext` on `TezTask` instances.

### Testing

- Compiled the `ql` module and ran unit tests with `mvn -pl ql -DskipTests=false test`; compilation and unit tests completed successfully.
- Verified basic `Driver.getResults()` flow reading from `DagOutputResultReader` streams in local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40e6eb2838832894337eccd5cafe18)