### PR TITLE
Avoid repeated Hive conf lookup for PartitionDesc storage handler setup

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
@@ -788,9 +788,19 @@ public final class Utilities {
     return new PartitionDesc(part, tableDesc);
   }
 
+  public static PartitionDesc getPartitionDesc(Partition part, TableDesc tableDesc,
+      Configuration conf) throws HiveException {
+    return new PartitionDesc(part, tableDesc, conf);
+  }
+
   public static PartitionDesc getPartitionDescFromTableDesc(TableDesc tblDesc, Partition part,
     boolean usePartSchemaProperties) throws HiveException {
     return new PartitionDesc(part, tblDesc, usePartSchemaProperties);
+  }
+
+  public static PartitionDesc getPartitionDescFromTableDesc(TableDesc tblDesc, Partition part,
+    boolean usePartSchemaProperties, Configuration conf) throws HiveException {
+    return new PartitionDesc(part, tblDesc, usePartSchemaProperties, conf);
   }
 
   private static boolean isWhitespace(int c) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
@@ -2686,7 +2686,7 @@ public final class Utilities {
                   TableScanOperator scanOp = (TableScanOperator) aliasToWork.get(alias);
                   Utilities.setColumnNameList(jobConf, scanOp, true);
                   Utilities.setColumnTypeList(jobConf, scanOp, true);
-                  PlanUtils.configureInputJobPropertiesForStorageHandler(tableDesc);
+                  PlanUtils.configureInputJobPropertiesForStorageHandler(tableDesc, myConf);
                   Utilities.copyTableJobPropertiesToConf(tableDesc, jobConf);
                   total += estimator.estimate(jobConf, scanOp, -1).getTotalLength();
                 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMapRedUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMapRedUtils.java
@@ -523,10 +523,11 @@ public final class GenMapRedUtils {
     // framework
     Set<Partition> parts = partsList.getPartitions();
     TableDesc tableSpec = Utilities.getTableDesc(tsOp.getConf().getTableMetadata());
+    Configuration conf = parseCtx.getConf();
     PartitionDesc aliasPartnDesc = null;
     try {
       if (!parts.isEmpty()) {
-        aliasPartnDesc = Utilities.getPartitionDesc(parts.iterator().next(), tableSpec);
+        aliasPartnDesc = Utilities.getPartitionDesc(parts.iterator().next(), tableSpec, conf);
       }
     } catch (HiveException e) {
       LOG.error("Failed getPartitionDesc", e);
@@ -691,10 +692,10 @@ public final class GenMapRedUtils {
         partDir.add(p);
         try {
           if (part.getTable().isPartitioned()) {
-            partDesc.add(Utilities.getPartitionDesc(part, tblDesc));
+            partDesc.add(Utilities.getPartitionDesc(part, tblDesc, conf));
           }
           else {
-            partDesc.add(Utilities.getPartitionDescFromTableDesc(tblDesc, part, false));
+            partDesc.add(Utilities.getPartitionDescFromTableDesc(tblDesc, part, false, conf));
           }
         } catch (HiveException e) {
           LOG.error("Failed to add partition description", e);

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SimpleFetchOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SimpleFetchOptimizer.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.hive.common.StatsSetupConst;
@@ -144,7 +145,7 @@ public class SimpleFetchOptimizer extends Transform {
     }
     FetchData fetch = checkTree(aggressive, pctx, alias, source);
     if (fetch != null && checkThreshold(fetch, limit, pctx)) {
-      FetchWork fetchWork = fetch.convertToWork();
+      FetchWork fetchWork = fetch.convertToWork(pctx);
       FetchTask fetchTask = (FetchTask) TaskFactory.get(fetchWork);
       fetchTask.setCachingEnabled(HiveConf.getBoolVar(pctx.getConf(),
               HiveConf.ConfVars.HIVE_FETCH_TASK_CACHING));
@@ -418,14 +419,15 @@ public class SimpleFetchOptimizer extends Transform {
       this.filtered = filtered;
     }
 
-    private FetchWork convertToWork() throws HiveException {
+    private FetchWork convertToWork(ParseContext pctx) throws HiveException {
       inputs.clear();
       Utilities.addSchemaEvolutionToTableScanOperator(table, scanOp);
       TableDesc tableDesc = Utilities.getTableDesc(table);
+      Configuration conf = pctx.getConf();
       if (!table.isPartitioned() || table.hasNonNativePartitionSupport()) {
         inputs.add(new ReadEntity(table, parent, !table.isView() && parent == null));
         FetchWork work = new FetchWork(table.getPath(), tableDesc);
-        PlanUtils.configureInputJobPropertiesForStorageHandler(work.getTblDesc());
+        PlanUtils.configureInputJobPropertiesForStorageHandler(work.getTblDesc(), conf);
         work.setSplitSample(splitSample);
         return work;
       }
@@ -435,7 +437,7 @@ public class SimpleFetchOptimizer extends Transform {
       for (Partition partition : partsList.getNotDeniedPartns()) {
         inputs.add(new ReadEntity(partition, parent, parent == null));
         listP.add(partition.getDataLocation());
-        partP.add(Utilities.getPartitionDescFromTableDesc(tableDesc, partition, true));
+        partP.add(Utilities.getPartitionDescFromTableDesc(tableDesc, partition, true, conf));
       }
       Table sourceTable = partsList.getSourceTable();
       inputs.add(new ReadEntity(sourceTable, parent, parent == null));
@@ -443,7 +445,7 @@ public class SimpleFetchOptimizer extends Transform {
       FetchWork work = new FetchWork(listP, partP, table);
       if (!work.getPartDesc().isEmpty()) {
         PartitionDesc part0 = work.getPartDesc().get(0);
-        PlanUtils.configureInputJobPropertiesForStorageHandler(part0.getTableDesc());
+        PlanUtils.configureInputJobPropertiesForStorageHandler(part0.getTableDesc(), conf);
         work.setSplitSample(splitSample);
       }
       return work;
@@ -484,7 +486,7 @@ public class SimpleFetchOptimizer extends Transform {
         if (handler instanceof InputEstimator) {
           InputEstimator estimator = (InputEstimator) handler;
           TableDesc tableDesc = Utilities.getTableDesc(table);
-          PlanUtils.configureInputJobPropertiesForStorageHandler(tableDesc);
+          PlanUtils.configureInputJobPropertiesForStorageHandler(tableDesc, pctx.getConf());
           Utilities.copyTableJobPropertiesToConf(tableDesc, jobConf);
           long len = estimator.estimate(jobConf, scanOp, threshold).getTotalLength();
           LOG.debug("Threshold {} exceeded for pseudoMR mode", len);

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/MapredLocalWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/MapredLocalWork.java
@@ -28,9 +28,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.MapJoinOperator;
 import org.apache.hadoop.hive.ql.exec.Operator;
+import org.apache.hadoop.hive.ql.metadata.Hive;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.plan.Explain.Level;
 import org.apache.hadoop.hive.ql.plan.Explain.Vectorization;
 
@@ -134,9 +137,16 @@ public class MapredLocalWork implements Serializable {
     if (bucketMapjoinContext != null) {
       bucketMapjoinContext.deriveBucketMapJoinMapping();
     }
-    for (FetchWork fetchWork : aliasToFetchWork.values()) {
-      PlanUtils.configureInputJobPropertiesForStorageHandler(
-        fetchWork.getTblDesc());
+    if (!aliasToFetchWork.isEmpty()) {
+      try {
+        Configuration conf = Hive.get().getConf();
+        for (FetchWork fetchWork : aliasToFetchWork.values()) {
+          PlanUtils.configureInputJobPropertiesForStorageHandler(
+            fetchWork.getTblDesc(), conf);
+        }
+      } catch (HiveException ex) {
+        throw new RuntimeException(ex);
+      }
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/PartitionDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/PartitionDesc.java
@@ -79,7 +79,12 @@ public class PartitionDesc implements Serializable, Cloneable {
   }
 
   public PartitionDesc(final Partition part, final TableDesc tableDesc) throws HiveException {
-    PartitionDescConstructorHelper(part, tableDesc, true);
+    this(part, tableDesc, null);
+  }
+
+  public PartitionDesc(final Partition part, final TableDesc tableDesc, Configuration conf)
+    throws HiveException {
+    PartitionDescConstructorHelper(part, tableDesc, true, conf);
     if (Utilities.isInputFileFormatSelfDescribing(this)) {
       // if IF is self describing no need to send column info per partition, since its not used anyway.
       Table tbl = part.getTable();
@@ -101,21 +106,31 @@ public class PartitionDesc implements Serializable, Cloneable {
   public PartitionDesc(final Partition part,final TableDesc tblDesc,
     boolean usePartSchemaProperties)
     throws HiveException {
-    PartitionDescConstructorHelper(part, tblDesc, usePartSchemaProperties);
-    //We use partition schema properties to set the partition descriptor properties
-    // if usePartSchemaProperties is set to true.
-    if (usePartSchemaProperties) {
-      setProperties(part.getMetadataFromPartitionSchema());
-    } else {
-      // each partition maintains a large properties
-      setProperties(part.getSchemaFromTableSchema(tblDesc.getProperties()));
-    }
+    this(part, tblDesc, usePartSchemaProperties, null);
   }
 
-  private void PartitionDescConstructorHelper(final Partition part,final TableDesc tblDesc, boolean setInputFileFormat)
+  public PartitionDesc(final Partition part,final TableDesc tblDesc,
+    boolean usePartSchemaProperties, Configuration conf)
+    throws HiveException {
+    PartitionDescConstructorHelper(part, tblDesc, usePartSchemaProperties, conf);
+    setProperties(part, tblDesc, usePartSchemaProperties);
+  }
+
+  private void PartitionDescConstructorHelper(final Partition part,final TableDesc tblDesc,
+    boolean setInputFileFormat)
+    throws HiveException {
+    PartitionDescConstructorHelper(part, tblDesc, setInputFileFormat, null);
+  }
+
+  private void PartitionDescConstructorHelper(final Partition part,final TableDesc tblDesc,
+    boolean setInputFileFormat, Configuration conf)
     throws HiveException {
 
-    PlanUtils.configureInputJobPropertiesForStorageHandler(tblDesc);
+    if (conf == null) {
+      PlanUtils.configureInputJobPropertiesForStorageHandler(tblDesc);
+    } else {
+      PlanUtils.configureInputJobPropertiesForStorageHandler(tblDesc, conf);
+    }
 
     this.tableDesc = tblDesc;
 
@@ -126,6 +141,18 @@ public class PartitionDesc implements Serializable, Cloneable {
       setOutputFileFormatClass(part.getInputFormatClass());
     }
     setOutputFileFormatClass(part.getOutputFormatClass());
+  }
+
+  private void setProperties(final Partition part, final TableDesc tblDesc, boolean usePartSchemaProperties)
+    throws HiveException {
+    //We use partition schema properties to set the partition descriptor properties
+    // if usePartSchemaProperties is set to true.
+    if (usePartSchemaProperties) {
+      setProperties(part.getMetadataFromPartitionSchema());
+    } else {
+      // each partition maintains a large properties
+      setProperties(part.getSchemaFromTableSchema(tblDesc.getProperties()));
+    }
   }
 
   @Explain(displayName = "", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
@@ -911,7 +911,14 @@ public final class PlanUtils {
    * @param tableDesc table descriptor
    */
   public static void configureInputJobPropertiesForStorageHandler(TableDesc tableDesc) {
-      configureJobPropertiesForStorageHandler(true, tableDesc);
+    if (tableDesc == null) {
+      return;
+    }
+    try {
+      configureJobPropertiesForStorageHandler(true, tableDesc, Hive.get().getConf());
+    } catch (HiveException ex) {
+      throw new RuntimeException(ex);
+    }
   }
 
   /**
@@ -933,7 +940,14 @@ public final class PlanUtils {
    * @param tableDesc table descriptor
    */
   public static void configureOutputJobPropertiesForStorageHandler(TableDesc tableDesc) {
-      configureJobPropertiesForStorageHandler(false, tableDesc);
+    if (tableDesc == null) {
+      return;
+    }
+    try {
+      configureJobPropertiesForStorageHandler(false, tableDesc, Hive.get().getConf());
+    } catch (HiveException ex) {
+      throw new RuntimeException(ex);
+    }
   }
 
   /**
@@ -946,18 +960,6 @@ public final class PlanUtils {
   public static void configureOutputJobPropertiesForStorageHandler(TableDesc tableDesc,
       Configuration conf) {
       configureJobPropertiesForStorageHandler(false, tableDesc, conf);
-  }
-
-  private static void configureJobPropertiesForStorageHandler(boolean input,
-    TableDesc tableDesc) {
-    if (tableDesc == null) {
-      return;
-    }
-    try {
-      configureJobPropertiesForStorageHandler(input, tableDesc, Hive.get().getConf());
-    } catch (HiveException ex) {
-      throw new RuntimeException(ex);
-    }
   }
 
   private static void configureJobPropertiesForStorageHandler(boolean input,

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
@@ -911,7 +911,19 @@ public final class PlanUtils {
    * @param tableDesc table descriptor
    */
   public static void configureInputJobPropertiesForStorageHandler(TableDesc tableDesc) {
-      configureJobPropertiesForStorageHandler(true,tableDesc);
+      configureJobPropertiesForStorageHandler(true, tableDesc);
+  }
+
+  /**
+   * Loads the storage handler (if one exists) for the given table
+   * and invokes {@link HiveStorageHandler#configureInputJobProperties(TableDesc, java.util.Map)}.
+   *
+   * @param tableDesc table descriptor
+   * @param conf configuration to use while loading the storage handler
+   */
+  public static void configureInputJobPropertiesForStorageHandler(TableDesc tableDesc,
+      Configuration conf) {
+      configureJobPropertiesForStorageHandler(true, tableDesc, conf);
   }
 
   /**
@@ -921,11 +933,35 @@ public final class PlanUtils {
    * @param tableDesc table descriptor
    */
   public static void configureOutputJobPropertiesForStorageHandler(TableDesc tableDesc) {
-      configureJobPropertiesForStorageHandler(false,tableDesc);
+      configureJobPropertiesForStorageHandler(false, tableDesc);
+  }
+
+  /**
+   * Loads the storage handler (if one exists) for the given table
+   * and invokes {@link HiveStorageHandler#configureOutputJobProperties(TableDesc, java.util.Map)}.
+   *
+   * @param tableDesc table descriptor
+   * @param conf configuration to use while loading the storage handler
+   */
+  public static void configureOutputJobPropertiesForStorageHandler(TableDesc tableDesc,
+      Configuration conf) {
+      configureJobPropertiesForStorageHandler(false, tableDesc, conf);
   }
 
   private static void configureJobPropertiesForStorageHandler(boolean input,
     TableDesc tableDesc) {
+    if (tableDesc == null) {
+      return;
+    }
+    try {
+      configureJobPropertiesForStorageHandler(input, tableDesc, Hive.get().getConf());
+    } catch (HiveException ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+
+  private static void configureJobPropertiesForStorageHandler(boolean input,
+    TableDesc tableDesc, Configuration conf) {
 
     if (tableDesc == null) {
       return;
@@ -934,7 +970,7 @@ public final class PlanUtils {
     try {
       HiveStorageHandler storageHandler =
         HiveUtils.getStorageHandler(
-          Hive.get().getConf(),
+          conf,
           tableDesc.getProperties().getProperty(
             org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_STORAGE));
       if (storageHandler != null) {


### PR DESCRIPTION
### Motivation

- Profiling showed `PartitionDesc` construction is a hot path and repeatedly calls into storage-handler setup that invokes `Hive.get().getConf()` causing unnecessary lookups.
- The goal is to compute a `Configuration` once and thread it down the call chain so `configureJobPropertiesForStorageHandler()` can reuse it across many `PartitionDesc` constructions.

### Description

- Added overloaded `PlanUtils.configureInputJobPropertiesForStorageHandler(...)` and `PlanUtils.configureOutputJobPropertiesForStorageHandler(...)` that accept a `Configuration` and a new private helper `configureJobPropertiesForStorageHandler(..., Configuration)` that uses the provided `Configuration` when loading the `HiveStorageHandler`.
- Preserved existing APIs by keeping parameterless overloads that delegate to the new helper using `Hive.get().getConf()` while avoiding repeated null checks where possible.
- Added `PartitionDesc` constructor overloads and refactored its constructor helper to accept an optional `Configuration`, and added `Utilities` factory overloads to construct `PartitionDesc` with a `Configuration` so callers can opt-in to the optimized path without breaking existing code.
- Updated `GenMapRedUtils` to obtain `parseCtx.getConf()` once and pass it into `Utilities.getPartitionDesc(...)` calls so many `PartitionDesc` instances created during map-work construction reuse the same `Configuration`.

### Testing

- Ran `git diff --check` with no warnings reported.
- Attempted to compile `ql` with `mvn -pl ql -DskipTests -Dcheckstyle.skip -Drat.skip -Dspotbugs.skip compile`, but the build was blocked by external Maven repository access (parent POM `org.apache:apache:pom:23` could not be resolved; HTTP 403), so a full compile/test run could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43599a46908328af49966f934068b4)