### PR TITLE
Reduce metastore string interning overhead

### DIFF
--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/FieldSchema.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/FieldSchema.java
@@ -113,7 +113,7 @@ package org.apache.hadoop.hive.metastore.api;
     this();
     this.name = org.apache.hadoop.hive.metastore.utils.StringUtils.intern(name);
     this.type = org.apache.hadoop.hive.metastore.utils.StringUtils.intern(type);
-    this.comment = org.apache.hadoop.hive.metastore.utils.StringUtils.intern(comment);
+    this.comment = comment;
   }
 
   /**
@@ -127,7 +127,7 @@ package org.apache.hadoop.hive.metastore.api;
       this.type = org.apache.hadoop.hive.metastore.utils.StringUtils.intern(other.type);
     }
     if (other.isSetComment()) {
-      this.comment = org.apache.hadoop.hive.metastore.utils.StringUtils.intern(other.comment);
+      this.comment = other.comment;
     }
   }
 
@@ -196,7 +196,7 @@ package org.apache.hadoop.hive.metastore.api;
   }
 
   public void setComment(@org.apache.thrift.annotation.Nullable java.lang.String comment) {
-    this.comment = org.apache.hadoop.hive.metastore.utils.StringUtils.intern(comment);
+    this.comment = comment;
   }
 
   public void unsetComment() {
@@ -481,7 +481,7 @@ package org.apache.hadoop.hive.metastore.api;
             break;
           case 3: // COMMENT
             if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
-              struct.comment = org.apache.hadoop.hive.metastore.utils.StringUtils.intern(iprot.readString());
+              struct.comment = iprot.readString();
               struct.setCommentIsSet(true);
             } else { 
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
@@ -567,7 +567,7 @@ package org.apache.hadoop.hive.metastore.api;
         struct.setTypeIsSet(true);
       }
       if (incoming.get(2)) {
-        struct.comment = org.apache.hadoop.hive.metastore.utils.StringUtils.intern(iprot.readString());
+        struct.comment = iprot.readString();
         struct.setCommentIsSet(true);
       }
     }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Partition.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Partition.java
@@ -436,7 +436,7 @@ package org.apache.hadoop.hive.metastore.api;
     if (this.parameters == null) {
       this.parameters = new java.util.HashMap<java.lang.String,java.lang.String>();
     }
-    this.parameters.put(org.apache.hadoop.hive.metastore.utils.StringUtils.intern(key), org.apache.hadoop.hive.metastore.utils.StringUtils.intern(val));
+    this.parameters.put(org.apache.hadoop.hive.metastore.utils.StringUtils.intern(key), val);
   }
 
   @org.apache.thrift.annotation.Nullable

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/SerDeInfo.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/SerDeInfo.java
@@ -250,7 +250,7 @@ package org.apache.hadoop.hive.metastore.api;
     if (this.parameters == null) {
       this.parameters = new java.util.HashMap<java.lang.String,java.lang.String>();
     }
-    this.parameters.put(org.apache.hadoop.hive.metastore.utils.StringUtils.intern(key), org.apache.hadoop.hive.metastore.utils.StringUtils.intern(val));
+    this.parameters.put(org.apache.hadoop.hive.metastore.utils.StringUtils.intern(key), val);
   }
 
   @org.apache.thrift.annotation.Nullable

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/StorageDescriptor.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/StorageDescriptor.java
@@ -192,7 +192,7 @@ package org.apache.hadoop.hive.metastore.api;
   {
     this();
     this.cols = cols;
-    this.location = org.apache.hadoop.hive.metastore.utils.StringUtils.intern(location);
+    this.location = location;
     this.inputFormat = org.apache.hadoop.hive.metastore.utils.StringUtils.intern(inputFormat);
     this.outputFormat = org.apache.hadoop.hive.metastore.utils.StringUtils.intern(outputFormat);
     this.compressed = compressed;
@@ -218,7 +218,7 @@ package org.apache.hadoop.hive.metastore.api;
       this.cols = __this__cols;
     }
     if (other.isSetLocation()) {
-      this.location = org.apache.hadoop.hive.metastore.utils.StringUtils.intern(other.location);
+      this.location = other.location;
     }
     if (other.isSetInputFormat()) {
       this.inputFormat = org.apache.hadoop.hive.metastore.utils.StringUtils.intern(other.inputFormat);
@@ -321,7 +321,7 @@ package org.apache.hadoop.hive.metastore.api;
   }
 
   public void setLocation(@org.apache.thrift.annotation.Nullable java.lang.String location) {
-    this.location = org.apache.hadoop.hive.metastore.utils.StringUtils.intern(location);
+    this.location = location;
   }
 
   public void unsetLocation() {
@@ -543,7 +543,7 @@ package org.apache.hadoop.hive.metastore.api;
     if (this.parameters == null) {
       this.parameters = new java.util.HashMap<java.lang.String,java.lang.String>();
     }
-    this.parameters.put(org.apache.hadoop.hive.metastore.utils.StringUtils.intern(key), org.apache.hadoop.hive.metastore.utils.StringUtils.intern(val));
+    this.parameters.put(org.apache.hadoop.hive.metastore.utils.StringUtils.intern(key), val);
   }
 
   @org.apache.thrift.annotation.Nullable
@@ -1278,7 +1278,7 @@ package org.apache.hadoop.hive.metastore.api;
             break;
           case 2: // LOCATION
             if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
-              struct.location = org.apache.hadoop.hive.metastore.utils.StringUtils.intern(iprot.readString());
+              struct.location = iprot.readString();
               struct.setLocationIsSet(true);
             } else { 
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
@@ -1636,7 +1636,7 @@ package org.apache.hadoop.hive.metastore.api;
         struct.setColsIsSet(true);
       }
       if (incoming.get(1)) {
-        struct.location = org.apache.hadoop.hive.metastore.utils.StringUtils.intern(iprot.readString());
+        struct.location = iprot.readString();
         struct.setLocationIsSet(true);
       }
       if (incoming.get(2)) {

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/StringUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/StringUtils.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hive.metastore.utils;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -27,18 +28,31 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
+
 public class StringUtils {
+  private static final Interner<String> STRING_INTERNER = Interners.newWeakInterner();
 
   /**
-   * Return the internalized string, or null if the given string is null.
+   * Return an internalized string, or null if the given string is null.
+   *
+   * <p>This intentionally uses a Hive-local weak interner instead of
+   * {@link String#intern()}. Metastore thrift objects call this method for many
+   * fields while deserializing and copying objects (partition parameters, field
+   * schemas, storage descriptor locations, etc). Routing every value through
+   * the JVM string pool can make {@code String.intern()} a profiling hotspot. A
+   * weak interner keeps the memory-deduplication benefit for equal live strings
+   * without paying the cost of the JVM-wide string table.</p>
+   *
    * @param str The string to intern
-   * @return The identical string cached in the string pool.
+   * @return An equal canonical string cached by the metastore interner.
    */
   public static String intern(String str) {
     if (str == null) {
       return null;
     }
-    return str.intern();
+    return STRING_INTERNER.intern(str);
   }
 
   /**
@@ -58,9 +72,15 @@ public class StringUtils {
   }
 
   /**
-   * Return an interned map with identical contents as the given map.
-   * @param map The map whose strings will be interned
-   * @return An identical map with its strings interned.
+   * Return a map with interned keys and identical values.
+   *
+   * <p>Metastore parameter maps have a small set of repeated keys, but their
+   * values are often table/partition-specific. Interning only the keys keeps the
+   * high-value deduplication while avoiding many low-value interner lookups for
+   * values.</p>
+   *
+   * @param map The map whose keys will be interned
+   * @return An identical map with its keys interned.
    */
   public static Map<String, String> intern(Map<String, String> map) {
     if (map == null) {
@@ -73,7 +93,7 @@ public class StringUtils {
     }
     Map<String, String> newMap = new HashMap<>(map.size());
     for (Map.Entry<String, String> entry : map.entrySet()) {
-      newMap.put(intern(entry.getKey()), intern(entry.getValue()));
+      newMap.put(intern(entry.getKey()), entry.getValue());
     }
     return newMap;
   }

--- a/standalone-metastore/metastore-common/src/main/resources/thrift-replacements.txt
+++ b/standalone-metastore/metastore-common/src/main/resources/thrift-replacements.txt
@@ -29,8 +29,8 @@ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(name);
 this\.name\ \=\ name;=this.name\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(name);
 this\.serializationLib\ \=\ serializationLib;=this.serializationLib\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(serializationLib);
 this\.type\ \=\ type;=this.type\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(type);
-this\.comment\ \=\ comment;=this.comment\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(comment);
-this\.location\ \=\ location;=this.location\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(location);
+this\.comment\ \=\ comment;=this.comment\ \=\ comment;
+this\.location\ \=\ location;=this.location\ \=\ location;
 this\.inputFormat\ \=\ inputFormat;=this.inputFormat\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(inputFormat);
 this\.outputFormat\ \=\ outputFormat;=this.outputFormat\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(outputFormat);
 this\.dbName\ \=\ dbName;=this.dbName\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(dbName);
@@ -54,8 +54,8 @@ this\.parameters\ \=\ parameters;=this.parameters\ \=\ org.apache.hadoop.hive.me
 this\.name\ \=\ other\.name;=this.name\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(other.name);
 this\.serializationLib\ \=\ other\.serializationLib;=this.serializationLib\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(other.serializationLib);
 this\.type\ \=\ other\.type;=this.type\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(other.type);
-this\.comment\ \=\ other\.comment;=this.comment\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(other.comment);
-this\.location\ \=\ other\.location;=this.location\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(other.location);
+this\.comment\ \=\ other\.comment;=this.comment\ \=\ other.comment;
+this\.location\ \=\ other\.location;=this.location\ \=\ other.location;
 this\.inputFormat\ \=\ other\.inputFormat;=this.inputFormat\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(other.inputFormat);
 this\.outputFormat\ \=\ other\.outputFormat;=this.outputFormat\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(other.outputFormat);
 this\.dbName\ \=\ other\.dbName;=this.dbName\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(other.dbName);
@@ -67,12 +67,12 @@ this\.colName\ \=\ other\.colName;=this\.colName\ \=\ org.apache.hadoop.hive.met
 this\.colType\ \=\ other\.colType;=this\.colType\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(other.colType);
 
 __this__parameters_copy_key\ \=\ other_element_key;=__this__parameters_copy_key\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(other_element_key);
-__this__parameters_copy_value\ \=\ other_element_value;=__this__parameters_copy_value\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(other_element_value);
+__this__parameters_copy_value\ \=\ other_element_value;=__this__parameters_copy_value\ \=\ other_element_value;
 __this_values\.add(other_element);=__this_values.add(org.apache.hadoop.hive.metastore.utils.StringUtils.intern(other_element));
 
 # Fix methods in Partition.java that call Map.put(String key, String value)
 
-this\.parameters\.put\(key,\ val\);=this.parameters.put(org.apache.hadoop.hive.metastore.utils.StringUtils.intern(key),\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(val));
+this\.parameters\.put\(key,\ val\);=this.parameters.put(org.apache.hadoop.hive.metastore.utils.StringUtils.intern(key),\ val);
 
 # Fix the deserialization methods in Partitions.java: intern parameters after it's deserialized
 
@@ -86,7 +86,7 @@ struct\.tableName\ \=\ iprot\.readString\(\);=struct\.tableName\ \=\ org.apache.
 struct\.catName\ \=\ iprot\.readString\(\);=struct\.catName\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(iprot\.readString\(\));
 
 # StorageDescriptorStandardScheme - parameters are already interned above
-struct\.location\ \=\ iprot\.readString\(\);=struct\.location\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(iprot\.readString\(\));
+struct\.location\ \=\ iprot\.readString\(\);=struct\.location\ \=\ iprot.readString();
 struct\.inputFormat\ \=\ iprot\.readString\(\);=struct\.inputFormat\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(iprot\.readString\(\));
 struct\.outputFormat\ \=\ iprot\.readString\(\);=struct\.outputFormat\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(iprot\.readString\(\));
 struct\.setBucketColsIsSet\(true\);=struct\.bucketCols\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(struct.bucketCols);\ struct.setBucketColsIsSet(true);
@@ -99,7 +99,7 @@ struct\.deserializerClass\ \=\ iprot\.readString\(\);=struct\.deserializerClass\
 
 # FieldSchemaStandardScheme - name field gets automatically handled above
 struct\.type\ \=\ iprot\.readString\(\);=struct\.type\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(iprot\.readString\(\));
-struct\.comment\ \=\ iprot\.readString\(\);=struct\.comment\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(iprot\.readString\(\));
+struct\.comment\ \=\ iprot\.readString\(\);=struct\.comment\ \=\ iprot.readString();
 
 # ColumnStatisticsObjStandardScheme
 struct\.colName\ \=\ iprot\.readString\(\);=struct\.colName\ \=\ org.apache.hadoop.hive.metastore.utils.StringUtils.intern(iprot\.readString\(\));

--- a/standalone-metastore/metastore-common/src/test/java/org/apache/hadoop/hive/metastore/utils/TestStringUtils.java
+++ b/standalone-metastore/metastore-common/src/test/java/org/apache/hadoop/hive/metastore/utils/TestStringUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.metastore.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestStringUtils {
+  @Test
+  public void testInternCanonicalizesEqualStrings() {
+    String first = new String("partition_parameter");
+    String second = new String("partition_parameter");
+
+    Assert.assertNotSame(first, second);
+    Assert.assertSame(StringUtils.intern(first), StringUtils.intern(second));
+  }
+
+  @Test
+  public void testInternMapCanonicalizesKeysOnly() {
+    Map<String, String> map = new HashMap<>();
+    String value = new String("value");
+    map.put(new String("key"), value);
+
+    Map<String, String> interned = StringUtils.intern(map);
+
+    Assert.assertSame(StringUtils.intern("key"), interned.keySet().iterator().next());
+    Assert.assertSame(value, interned.values().iterator().next());
+  }
+}


### PR DESCRIPTION
### Motivation
- Profiling showed frequent calls to `StringUtils.intern()` (which used `String.intern()`) are a hotspot in metastore hot paths such as partition parameter handling, `FieldSchema`, and `StorageDescriptor` fields.  
- Routing many transient or unique strings through the JVM-wide string pool is expensive and can dominate CPU time during deserialization and object copying.  
- The goal is to keep the memory-deduplication benefit for frequently repeated strings while avoiding the cost of `String.intern()` for high-volume/low-reuse values.

### Description
- Replace the `intern(String)` implementation in `StringUtils` with a Hive-local weak interner using Guava `Interners.newWeakInterner()` and switch call sites to use `StringUtils.intern(...)`.  
- Change `StringUtils.intern(Map<String,String>)` so it canonicalizes only map keys and preserves map values as-is to avoid many low-value interner lookups.  
- Stop interning commonly-unique/free-form hot-path fields by updating generated thrift classes and replacement rules so `FieldSchema.comment` and `StorageDescriptor.location` are stored without interning, while preserving interning for highly-repeated fields (names, types, input/output formats, parameter keys, etc.).  
- Add `TestStringUtils` unit tests that validate canonicalization behavior for equal strings and that parameter-map interning canonicalizes keys only.

### Testing
- Ran `git diff --check` to validate the working tree changes and found no whitespace/merge issues.  
- Added unit tests at `standalone-metastore/metastore-common/src/test/java/org/apache/hadoop/hive/metastore/utils/TestStringUtils.java`, but running them with `mvn -pl standalone-metastore/metastore-common -Dtest=TestStringUtils test -DskipSparkTests` was blocked by the environment because Maven failed to resolve the parent POM (`org.apache:apache:pom:23`) due to repository access (HTTP 403), so the unit tests could not be executed here.  
- No other automated test runs completed in this environment due to repository/network resolution limitations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4396e458cc8328b9ca59b764fe1e9f)