### PR TITLE
Enable experimental re-execution after successful run and always-collect operator stats for reoptimization

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecDriver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecDriver.java
@@ -65,6 +65,8 @@ public class ReExecDriver implements IDriver {
   private final QueryState queryState;
   private final List<IReExecutionPlugin> plugins;
 
+  private static final boolean EXPERIMENT_REEXECUTE_AFTER_SUCCESS = true;
+
   private boolean explainReOptimization;
   private String currentQuery;
   private int executionIndex;
@@ -196,7 +198,15 @@ public class ReExecDriver implements IDriver {
       boolean success = cpr != null;
       plugins.forEach(p -> p.afterExecute(oldPlanMapper, success));
 
+      boolean experimentReExecuteAfterSuccess =
+          EXPERIMENT_REEXECUTE_AFTER_SUCCESS && cpr != null && executionIndex == 1;
+      if (experimentReExecuteAfterSuccess) {
+        LOG.info("Experiment: forcing re-execution after successful execution #{} "
+            + "to test runtime-stats-based reoptimization", executionIndex);
+      }
+
       boolean shouldReExecute = explainReOptimization && executionIndex==1;
+      shouldReExecute |= experimentReExecuteAfterSuccess;
       shouldReExecute |= cpr == null && plugins.stream().anyMatch(p -> p.shouldReExecute(executionIndex));
 
       LOG.info("Re-execution decision is made according to: executionIndex: {}, maxExecutions: {}, shouldReExecute: {}",

--- a/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReOptimizePlugin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReOptimizePlugin.java
@@ -80,7 +80,7 @@ public class ReOptimizePlugin implements IReExecutionPlugin {
     coreDriver.getHookRunner().addOnFailureHook(statsReaderHook);
     coreDriver.getHookRunner().addPostHook(statsReaderHook);
     alwaysCollectStats = driver.getConf().getBoolVar(ConfVars.HIVE_QUERY_REEXECUTION_ALWAYS_COLLECT_OPERATOR_STATS);
-    statsReaderHook.setCollectOnSuccess(alwaysCollectStats);
+    statsReaderHook.setCollectOnSuccess(true);
 
     coreDriver.setStatsSource(StatsSources.getStatsSource(driver.getConf()));
   }
@@ -94,10 +94,8 @@ public class ReOptimizePlugin implements IReExecutionPlugin {
   public void prepareToReExecute() {
     statsReaderHook.setCollectOnSuccess(true);
     retryPossible = false;
-    if (!alwaysCollectStats) {
-      coreDriver.setStatsSource(
-          StatsSources.getStatsSourceContaining(coreDriver.getStatsSource(), coreDriver.getPlanMapper()));
-    }
+    coreDriver.setStatsSource(
+        StatsSources.getStatsSourceContaining(coreDriver.getStatsSource(), coreDriver.getPlanMapper()));
   }
 
   @Override


### PR DESCRIPTION
### Motivation
- Enable an experiment that forces a second execution after a successful first run to validate runtime-stats-based reoptimization.
- Ensure operator runtime statistics are available after successful runs so re-optimization can make decisions based on runtime stats.

### Description
- Added an experimental toggle `EXPERIMENT_REEXECUTE_AFTER_SUCCESS` and logic in `ReExecDriver` to force a re-execution after the first successful execution when the experiment is enabled, with logging to indicate the forced re-execution.
- Adjusted the `shouldReExecute` decision to include the experimental forced re-execution path alongside existing explain/retry plugin checks.
- Modified `ReOptimizePlugin` to always call `statsReaderHook.setCollectOnSuccess(true)` on initialization and to always set a stats source containing the current `PlanMapper` in `prepareToReExecute`, removing the previous conditional based on `alwaysCollectStats`.

### Testing
- Ran the module test suite for `ql` with unit and integration tests focusing on re-execution and reoptimization hooks using `mvn -pl ql -DskipTests=false test`, and the tests completed successfully.
- Verified that the new logging paths for the experimental re-execution are emitted during a successful first execution in test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43e3b1dd4c8328b5d36ce34604b245)