### PR TITLE
Update Hive service code for MR3

### DIFF
--- a/service/src/java/org/apache/hive/service/cli/CLIService.java
+++ b/service/src/java/org/apache/hive/service/cli/CLIService.java
@@ -75,6 +75,7 @@ public class CLIService extends CompositeService implements ICLIService {
   private int defaultFetchRows;
   // This is necessary for tests and embedded mode, where HS2 init is not executed.
   private boolean allowSessionsInitial;
+  private SessionState startupAuthorizationSessionState;
 
   public CLIService(HiveServer2 hiveServer2, boolean allowSessions) {
     super(CLIService.class.getSimpleName());
@@ -133,6 +134,20 @@ public class CLIService extends CompositeService implements ICLIService {
     ss.setIsHiveServerQuery(true);
     SessionState.start(ss);
     ss.applyAuthorizationPolicy();
+    startupAuthorizationSessionState = ss;
+  }
+
+  public synchronized void closeStartupAuthorizationSessionState() {
+    if (startupAuthorizationSessionState == null) {
+      return;
+    }
+    try {
+      startupAuthorizationSessionState.close();
+    } catch (IOException e) {
+      LOG.warn("Error closing startup authorization SessionState", e);
+    } finally {
+      startupAuthorizationSessionState = null;
+    }
   }
 
   private void setupBlockedUdfs() {

--- a/service/src/java/org/apache/hive/service/cli/MR3ProgressMonitorStatusMapper.java
+++ b/service/src/java/org/apache/hive/service/cli/MR3ProgressMonitorStatusMapper.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hive.service.cli;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hive.service.rpc.thrift.TJobExecutionStatus;
+
+public class MR3ProgressMonitorStatusMapper implements ProgressMonitorStatusMapper {
+
+  /**
+   * These states are taken form DAGStatus.State, could not use that here directly as it was
+   * optional dependency and did not want to include it just for the enum.
+   */
+  enum MR3Status {
+    New, Inited, Running, Succeeded, Failed, Killed
+
+  }
+
+  @Override
+  public TJobExecutionStatus forStatus(String status) {
+    if (StringUtils.isEmpty(status)) {
+      return TJobExecutionStatus.NOT_AVAILABLE;
+    }
+    MR3Status mr3Status = MR3Status.valueOf(status);
+    switch (mr3Status) {
+      case New:
+      case Inited:
+      case Running:
+        return TJobExecutionStatus.IN_PROGRESS;
+      default:
+        return TJobExecutionStatus.COMPLETE;
+    }
+  }
+}

--- a/service/src/java/org/apache/hive/service/cli/operation/SQLOperation.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/SQLOperation.java
@@ -253,7 +253,22 @@ public class SQLOperation extends ExecuteStatementOperation {
         throw new HiveSQLException("Error running query", e, queryState.getQueryId());
       }
     }
+    emitCompletionMessageToOperationLog();
     setState(OperationState.FINISHED);
+  }
+
+  private void emitCompletionMessageToOperationLog() {
+    String message = com.datamonad.mr3.common.Utils.getLicenseInfo();
+    if (StringUtils.isBlank(message)) {
+      return;
+    }
+
+    SessionState.LogHelper console = SessionState.getConsole();
+    if (console == null) {
+      log.info(message);
+      return;
+    }
+    console.printInfo(message);
   }
 
   @Override
@@ -390,13 +405,17 @@ public class SQLOperation extends ExecuteStatementOperation {
 
     //Need shut down background thread gracefully, driver.close will inform background thread
     //a cancel request is sent.
-    if (shouldRunAsync() && state != OperationState.CANCELED && state != OperationState.TIMEDOUT) {
+    // When Hue cancels a running query, we have state == OperationState.CLOSED. In this case, we want to
+    // avoid interrupting the background Future because it may interrupt MR3 DAGClientRPC.getDagStatusWait(),
+    // after which all other concurrent RPC connections to MR3 DAGAppMaster are also interrupted.
+    // Even when state == OperationState.CLOSED, we call driver.close() anyway, so the query is terminated gracefully.
+    if (shouldRunAsync() && state != OperationState.CLOSED && state != OperationState.CANCELED && state != OperationState.TIMEDOUT) {
       Future<?> backgroundHandle = getBackgroundHandle();
       if (backgroundHandle != null) {
         boolean success = backgroundHandle.cancel(true);
         String queryId = queryState.getQueryId();
         if (success) {
-          log.info("The running operation has been successfully interrupted: {}", queryId);
+          log.info("The running operation has been successfully interrupted: {}, state: {}", queryId, state);
         } else if (log.isDebugEnabled()) {
           log.debug("The running operation could not be cancelled, typically because it has already completed normally: {}", queryId);
         }
@@ -404,7 +423,7 @@ public class SQLOperation extends ExecuteStatementOperation {
     }
 
     if (driver != null) {
-      driver.close();
+      driver.close();     // eventually calls MR3Task.shutdown(), thus calling tryKillDag()
       driver.destroy();
     }
     driver = null;

--- a/service/src/java/org/apache/hive/service/cli/thrift/ThriftCLIService.java
+++ b/service/src/java/org/apache/hive/service/cli/thrift/ThriftCLIService.java
@@ -124,6 +124,7 @@ import org.apache.thrift.server.ServerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.hive.service.cli.MR3ProgressMonitorStatusMapper;
 
 /**
  * ThriftCLIService.
@@ -811,7 +812,7 @@ public abstract class ThriftCLIService extends AbstractService implements TCLISe
       JobProgressUpdate progressUpdate = operationStatus.jobProgressUpdate();
       ProgressMonitorStatusMapper mapper = ProgressMonitorStatusMapper.DEFAULT;
       if ("tez".equals(sessionConf.getVar(ConfVars.HIVE_EXECUTION_ENGINE))) {
-        mapper = new TezProgressMonitorStatusMapper();
+        mapper = new MR3ProgressMonitorStatusMapper();
       }
       TJobExecutionStatus executionStatus =
           mapper.forStatus(progressUpdate.status);

--- a/service/src/java/org/apache/hive/service/server/HiveServer2.java
+++ b/service/src/java/org/apache/hive/service/server/HiveServer2.java
@@ -150,6 +150,13 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import javax.servlet.jsp.JspFactory;
 
+import org.apache.curator.framework.api.CuratorWatcher;
+import org.apache.curator.framework.recipes.locks.InterProcessMutex;
+import org.apache.hadoop.hive.ql.exec.mr3.MR3ZooKeeperUtils;
+import org.apache.hadoop.hive.ql.exec.mr3.session.MR3SessionManagerImpl;
+import org.apache.tez.common.counters.Limits;
+import org.apache.tez.dag.api.TezConfiguration;
+
 /**
  * HiveServer2.
  *
@@ -182,6 +189,12 @@ public class HiveServer2 extends CompositeService {
   private Hive sessionHive;
   private String wmQueue;
   private AtomicBoolean isLeader = new AtomicBoolean(false);
+
+  // used only for MR3
+  private CuratorFramework zooKeeperClient;
+  private SessionState parentSession;
+  private ExecutorService watcherThreadExecutor;
+
   // used for testing
   private SettableFuture<Boolean> isLeaderTestFuture = SettableFuture.create();
   private SettableFuture<Boolean> notLeaderTestFuture = SettableFuture.create();
@@ -310,12 +323,6 @@ public class HiveServer2 extends CompositeService {
     // Initialize metadata provider class and trimmer
     CalcitePlanner.warmup();
 
-    try {
-      sessionHive = Hive.get(hiveConf);
-    } catch (HiveException e) {
-      throw new RuntimeException("Failed to get metastore connection", e);
-    }
-
     // Create views registry
     HiveMaterializedViewsRegistry.get().init();
 
@@ -361,6 +368,10 @@ public class HiveServer2 extends CompositeService {
           leaderActionsExecutorService = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setDaemon(true)
             .setNameFormat("Leader Actions Handler Thread").build());
           hs2HARegistry = HS2ActivePassiveHARegistry.create(hiveConf, false);
+
+          if (hiveConf.getVar(ConfVars.HIVE_EXECUTION_ENGINE).equals("tez")) {
+            watcherThreadExecutor = Executors.newSingleThreadExecutor();
+          }
         }
       }
     } catch (Exception e) {
@@ -521,6 +532,43 @@ public class HiveServer2 extends CompositeService {
       otelExporter.start();
 
       LOG.info("Started OTEL exporter with frequency {}", otelExporterFrequency);
+    }
+
+    if (serviceDiscovery && activePassiveHA) {
+      try {
+        // In Hive 4.0.1 and 4.1.0, setUpZooKeeperAuth() is not called here.
+        // This seems to be a bug which is fixed in HIVE-29138.
+        setUpZooKeeperAuth(hiveConf);
+        zooKeeperClient = hiveConf.getZKConfig().startZookeeperClient(zooKeeperAclProvider, false);
+      } catch (Exception e) {
+        LOG.error("Error in creating ZooKeeper Client", e);
+        throw new ServiceException(e);
+      }
+    }
+
+    // Limits.COUNTERS_MAX should be the same in both HiveServer2 and DAGAppMaster
+    TezConfiguration tezConf = new TezConfiguration(hiveConf);
+    Limits.setConfiguration(tezConf);
+
+    if (hiveConf.getVar(ConfVars.HIVE_EXECUTION_ENGINE).equals("tez")) {
+      // must call before server.start() because server.start() may start LeaderWatcher which can then be
+      // triggered even before server.start() returns
+      try {
+        MR3SessionManagerImpl.getInstance().setup(hiveConf, zooKeeperClient);
+      } catch (Exception e) {
+        LOG.error("Error in setting up MR3SessionManager", e);
+        throw new ServiceException(e);
+      }
+      //   1. serviceDiscovery == true && activePassiveHA == true: multiple HS2 instances, leader exists
+      //      - use service discovery and share ApplicationID
+      //      - ApplicationConnectionWatcher has been created
+      //      - LeaderWatcher is created when isLeader() is called
+      //   2. serviceDiscovery == true && activePassiveHA == false: multiple HS2 instances, no leader exists
+      //      - only for using service discovery (without sharing ApplicationID)
+      //      - ApplicationConnectionWatcher is not created
+      ///     - isLeader() is never called
+      //   3. serviceDiscovery == false: no ZooKeeper
+      //      - same as in case 2
     }
 
     // Add a shutdown hook for catching SIGTERM & SIGINT
@@ -755,7 +803,10 @@ public class HiveServer2 extends CompositeService {
     // If we're supporting dynamic service discovery, we'll add the service uri for this
     // HiveServer2 instance to Zookeeper as a znode.
     HiveConf hiveConf = getHiveConf();
-    if (!serviceDiscovery || !activePassiveHA) {
+    String engine = hiveConf.getVar(ConfVars.HIVE_EXECUTION_ENGINE);
+    if (engine.equals("tez")) {
+      allowClientSessions();
+    } else if (!serviceDiscovery || !activePassiveHA) {
       allowClientSessions();
     }
     if (serviceDiscovery) {
@@ -764,28 +815,38 @@ public class HiveServer2 extends CompositeService {
           hs2HARegistry.registerLeaderLatchListener(leaderLatchListener, leaderActionsExecutorService);
           hs2HARegistry.start();
           LOG.info("HS2 HA registry started");
-        } else {
-          boolean publishConfigs =
-                  hiveConf.getBoolVar(HiveConf.ConfVars.HIVE_SERVER2_ZOOKEEPER_PUBLISH_CONFIGS);
-          String instanceURI = getServerInstanceURI();
-          String znodeData;
-          if (publishConfigs) {
-            // HiveServer2 configs that this instance will publish to ZooKeeper,
-            // so that the clients can read these and configure themselves properly.
-            addConfsToPublish(hiveConf, confsToPublish, getServerInstanceURI());
-            znodeData = Joiner.on(';').withKeyValueSeparator("=").join(confsToPublish);
-          } else {
-            znodeData = instanceURI;
+          if (engine.equals("tez")) {
+            parentSession = SessionState.get();
+            invokeApplicationConnectionWatcher();
           }
-
-          // Add a Znode to the specified ZooKeeper with name: serverUri=host:port;
-          // version=versionInfo; sequence=sequenceNumber
-          zooKeeperHelper = hiveConf.getZKConfig();
-          String znodePathPrefix = "serverUri=" + instanceURI + ";" +
-                  "version=" + HiveVersionInfo.getVersion() + ";" + "sequence=";
-          zooKeeperHelper.addServerInstanceToZooKeeper(znodePathPrefix, znodeData,
-                  zooKeeperAclProvider, new DeRegisterWatcher(zooKeeperHelper));
         }
+
+        // In the original Hive, if activePassiveHA == true, only the Leader HS2 receives all the traffic.
+        // In contrast, in the case of Hive-MR3, 'activePassiveHA == true' means that all HS2 instances
+        // share the traffic from Beeline connections in order to take advantage of a common MR3 DAGAppMaster.
+        //
+        // We always call addServerInstanceToZooKeeper() so that ZooKeeper can find all HS2 instances.
+        boolean publishConfigs =
+                hiveConf.getBoolVar(HiveConf.ConfVars.HIVE_SERVER2_ZOOKEEPER_PUBLISH_CONFIGS);
+        String instanceURI = getServerInstanceURI();
+        String znodeData;
+        if (publishConfigs) {
+          // HiveServer2 configs that this instance will publish to ZooKeeper,
+          // so that the clients can read these and configure themselves properly.
+          addConfsToPublish(hiveConf, confsToPublish, getServerInstanceURI());
+          znodeData = Joiner.on(';').withKeyValueSeparator("=").join(confsToPublish);
+        } else {
+          znodeData = instanceURI;
+        }
+
+        // Add a Znode to the specified ZooKeeper with name: serverUri=host:port;
+        // version=versionInfo; sequence=sequenceNumber
+        zooKeeperHelper = hiveConf.getZKConfig();
+        String znodePathPrefix = "serverUri=" + instanceURI + ";" +
+                "version=" + HiveVersionInfo.getVersion() + ";" + "sequence=";
+        zooKeeperHelper.addServerInstanceToZooKeeper(znodePathPrefix, znodeData,
+                zooKeeperAclProvider, new DeRegisterWatcher(zooKeeperHelper));
+
       } catch (Exception e) {
         LOG.error("Error adding this HiveServer2 instance to ZooKeeper: ", e);
         throw new ServiceException(e);
@@ -809,15 +870,9 @@ public class HiveServer2 extends CompositeService {
       }
     }
 
-    if (hiveConf.getVar(ConfVars.HIVE_EXECUTION_ENGINE).equals("tez")) {
+    if (engine.equals("tez")) {
       if (!activePassiveHA) {
-        LOG.info("HS2 interactive HA not enabled. Starting tez sessions..");
-        try {
-          startOrReconnectTezSessions();
-        } catch (Exception e) {
-          LOG.error("Error starting  Tez sessions: ", e);
-          throw new ServiceException(e);
-        }
+        LOG.info("HS2 interactive HA not enabled. Starting sessions..");
       } else {
         LOG.info("HS2 interactive HA enabled. Tez sessions will be started/reconnected by the leader.");
       }
@@ -844,9 +899,12 @@ public class HiveServer2 extends CompositeService {
       if (parentSession != null) {
         SessionState.setCurrentSessionState(parentSession);
       }
-      hiveServer2.startOrReconnectTezSessions();
-      LOG.info("Started/Reconnected tez sessions.");
-      hiveServer2.allowClientSessions();
+      if (hiveServer2.getHiveConf().getVar(ConfVars.HIVE_EXECUTION_ENGINE).equals("tez")) {
+        hiveServer2.invokeLeaderWatcher();
+      } else {
+        hiveServer2.allowClientSessions();
+      }
+      // For MR3, do not call hiveServer2.allowClientSessions() because it is always allowed.
 
       // resolve futures used for testing
       if (HiveConf.getBoolVar(hiveServer2.getHiveConf(), ConfVars.HIVE_IN_TEST)) {
@@ -858,10 +916,11 @@ public class HiveServer2 extends CompositeService {
     @Override
     public void notLeader() {
       LOG.info("HS2 instance {} LOST LEADERSHIP. Stopping/Disconnecting tez sessions..", hiveServer2.serviceUri);
+      // do not call hiveServer2.closeHiveSessions() because there is no need to close active Beeline connections
       hiveServer2.isLeader.set(false);
-      hiveServer2.closeAndDisallowHiveSessions();
-      hiveServer2.stopOrDisconnectTezSessions();
-      LOG.info("Stopped/Disconnected tez sessions.");
+      if (!hiveServer2.getHiveConf().getVar(ConfVars.HIVE_EXECUTION_ENGINE).equals("tez")) {
+        hiveServer2.closeAndDisallowHiveSessions();
+      }
 
       // resolve futures used for testing
       if (HiveConf.getBoolVar(hiveServer2.getHiveConf(), ConfVars.HIVE_IN_TEST)) {
@@ -1036,6 +1095,12 @@ public class HiveServer2 extends CompositeService {
     LOG.info("Shutting down HiveServer2");
     HiveConf hiveConf = this.getHiveConf();
     super.stop();
+
+    String engine = hiveConf != null ? hiveConf.getVar(ConfVars.HIVE_EXECUTION_ENGINE) : "";
+    if (serviceDiscovery && activePassiveHA && engine.equals("tez")) {
+      watcherThreadExecutor.shutdown();
+    }
+
     if (scheduledQueryService != null) {
       try {
         scheduledQueryService.close();
@@ -1079,8 +1144,21 @@ public class HiveServer2 extends CompositeService {
       }
     }
 
-    stopOrDisconnectTezSessions();
+    if (engine.equals("tez")) {
+      try {
+        MR3SessionManagerImpl.getInstance().shutdown();
+      } catch(Exception ex) {
+        LOG.error("MR3 session pool manager failed to stop during HiveServer2 shutdown.", ex);
+      }
+    }
 
+    if (cliService != null) {
+      cliService.closeStartupAuthorizationSessionState();
+    }
+
+    if (zooKeeperClient != null) {
+      zooKeeperClient.close();
+    }
     if (zKClientForPrivSync != null) {
       zKClientForPrivSync.close();
     }
@@ -1705,5 +1783,277 @@ public class HiveServer2 extends CompositeService {
       }
       System.exit(0);
     }
+  }
+
+  private void invokeApplicationConnectionWatcher() {
+    ApplicationConnectionWatcher watcher = new ApplicationConnectionWatcher();
+    watcher.process(new WatchedEvent(Watcher.Event.EventType.NodeDataChanged,
+            Watcher.Event.KeeperState.SyncConnected, ""));
+  }
+
+  private void invokeLeaderWatcher() {
+    LeaderWatcher leaderWatcher = new LeaderWatcher();
+    leaderWatcher.process(new WatchedEvent(Watcher.Event.EventType.NodeDataChanged,
+            Watcher.Event.KeeperState.SyncConnected, ""));
+  }
+
+  private abstract class ApplicationWatcher implements CuratorWatcher {
+    private static final String appIdPath = MR3ZooKeeperUtils.APP_ID_PATH;
+    private static final String appIdLockPath = MR3ZooKeeperUtils.APP_ID_LOCK_PATH;
+    private static final String appIdCheckRequestPath = MR3ZooKeeperUtils.APP_ID_CHECK_REQUEST_PATH;
+
+    private InterProcessMutex appIdLock;
+    private String namespace;
+
+    ApplicationWatcher() {
+      this.namespace = "/" + HiveServer2.this.getHiveConf().getVar(HiveConf.ConfVars.MR3_ZOOKEEPER_APPID_NAMESPACE);
+      this.appIdLock = new InterProcessMutex(HiveServer2.this.zooKeeperClient, this.namespace + appIdLockPath);
+    }
+
+    @Override
+    public void process(WatchedEvent watchedEvent) {
+      HiveServer2.this.watcherThreadExecutor.execute(() -> this.run(watchedEvent));
+    }
+
+    public abstract void run(WatchedEvent watchedEvent);
+
+    protected void lockAppId() throws Exception {
+      appIdLock.acquire();
+    }
+
+    protected void unlockAppId() throws Exception {
+      if (appIdLock.isAcquiredInThisProcess()) {
+        appIdLock.release();
+      }
+    }
+
+    protected String readAppId() throws Exception {
+      if (!appIdLock.isAcquiredInThisProcess()) {
+        throw new RuntimeException("appIdLock is not acquired before reading appId");
+      }
+      return new String(HiveServer2.this.zooKeeperClient.getData().forPath(namespace + appIdPath));
+    }
+
+    protected void updateAppId(String newAppId) throws Exception {
+      if (!appIdLock.isAcquiredInThisProcess()) {
+        throw new RuntimeException("appIdLock is not acquired before updating appId");
+      }
+      if (HiveServer2.this.zooKeeperClient.checkExists().forPath(namespace + appIdPath) == null) {
+        HiveServer2.this.zooKeeperClient.create().forPath(namespace + appIdPath, newAppId.getBytes());
+      } else {
+        HiveServer2.this.zooKeeperClient.setData().forPath(namespace + appIdPath, newAppId.getBytes());
+      }
+    }
+
+    protected void registerWatcher(CuratorWatcher watcher, boolean isLeaderWatcher) throws Exception {
+      if (isLeaderWatcher) {
+        HiveServer2.this.zooKeeperClient.checkExists().usingWatcher(watcher).forPath(namespace + appIdCheckRequestPath);
+      } else {
+        HiveServer2.this.zooKeeperClient.checkExists().usingWatcher(watcher).forPath(namespace + appIdPath);
+      }
+    }
+
+    // 1. return a non-empty string if readAppId() succeeds
+    // 2. return "" if readAppId() reads nothing
+    // 3. return null if ZooKeeper operation fails
+    // 4. raise InterruptedException if interrupted
+    // potentially creates an infinite loop if releaseLock == true
+    protected String getSharedAppIdStr(boolean releaseLock) throws InterruptedException {
+      String sharedAppIdStr;
+
+      try {
+        lockAppId();
+        sharedAppIdStr = readAppId();
+      } catch (KeeperException.NoNodeException ex) {
+        sharedAppIdStr = "";
+      } catch (InterruptedException ie) {
+        throw new InterruptedException("Interrupted while reading ApplicationId");
+      } catch (Exception ex) {
+        LOG.error("Failed to connect to ZooKeeper while trying to read ApplicationId", ex);
+        return null;
+      } finally {
+        if (releaseLock) {
+          releaseAppIdLock();
+        }
+      }
+
+      return sharedAppIdStr;
+    }
+
+    // potentially creates an infinite loop
+    protected void releaseAppIdLock() throws InterruptedException {
+      boolean unlockedAppId = false;
+      while (!unlockedAppId) {
+        try {
+          unlockAppId();
+          unlockedAppId = true;
+        } catch (InterruptedException ie) {
+          throw new InterruptedException("Interrupted while releasing lock for ApplicationId");
+        } catch (Exception ex) {
+          LOG.warn("Failed to release lock for ApplicationId, retrying in 10 seconds", ex);
+          Thread.sleep(10000L);
+        }
+      }
+    }
+
+    // return true if successful
+    // return false if interrupted
+    // potentially creates an infinite loop
+    protected boolean registerNextWatcher(boolean isLeaderWatcher) {
+      boolean registeredNewWatcher = false;
+      while (!registeredNewWatcher) {
+        try {
+          registerWatcher(this, isLeaderWatcher);
+          LOG.info("New ApplicationConnectionWatcher registered");
+          registeredNewWatcher = true;
+        } catch (InterruptedException ie) {
+          LOG.error("Interrupted while registering ApplicationConnectionWatcher, giving up");
+          return false;
+        } catch (Exception ex) {
+          LOG.warn("Failed to register ApplicationConnectionWatcher, retrying in 10 seconds", ex);
+          try {
+            Thread.sleep(10000L);
+            // TODO: in the case of isLeaderWatcher == true, we could give up after a certain number of
+            // retries by calling HiveServer.this.stop()
+          } catch (InterruptedException ie) {
+            LOG.error("Interrupted while registering ApplicationConnectionWatcher, giving up");
+            return false;
+          }
+        }
+      }
+      LOG.info("Registered the next Watcher: isLeaderWatcher = " + isLeaderWatcher);
+      return true;
+    }
+  }
+
+  private class ApplicationConnectionWatcher extends ApplicationWatcher {
+    private Logger LOG = LoggerFactory.getLogger(ApplicationConnectionWatcher.class);
+
+    ApplicationConnectionWatcher() {
+      super();
+    }
+
+    public void run(WatchedEvent watchedEvent) {
+      LOG.info("ApplicationConnectionWatcher triggered from " + watchedEvent.getPath());
+
+      SessionState.setCurrentSessionState(parentSession);
+
+      if (!registerNextWatcher(false)) {
+        return;
+      }
+      // now we have the next ApplicationConnectionWatcher running
+
+      String sharedAppIdStr;
+      try {
+        sharedAppIdStr = getSharedAppIdStr(true);
+      } catch (InterruptedException ie) {
+        LOG.error("ApplicationConnectionWatcher interrupted", ie);
+        return;
+      }
+      if (sharedAppIdStr == null) {
+        return;
+      }
+      if (sharedAppIdStr.isEmpty()) {
+        // called in the first ApplicationConnectionWatcher of the first HiveServer2
+        return;
+      }
+
+      try {
+        LOG.info("Setting active Application: " + sharedAppIdStr);
+        MR3SessionManagerImpl.getInstance().setActiveApplication(sharedAppIdStr);
+      } catch (HiveException ex) {
+        LOG.info("Error in setting active Application ", ex);
+        // no need to take further action because Beeline will keep complaining about connecting to the
+        // current MR3Session, which will in turn trigger ApplicationConnectionWatcher
+      }
+    }
+  }
+
+  private class LeaderWatcher extends ApplicationWatcher {
+    private Logger LOG = LoggerFactory.getLogger(LeaderWatcher.class);
+
+    LeaderWatcher() {
+      super();
+    }
+
+    public void run(WatchedEvent watchedEvent) {
+      LOG.info("LeaderWatcher triggered from " + watchedEvent.getPath());
+
+      SessionState.setCurrentSessionState(parentSession);
+
+      if (!HiveServer2.this.isLeader())
+        return;
+
+      boolean stopHiveServer2 = false;
+      boolean tryReleaseLock = true;
+      try {
+        String sharedAppIdStr;
+        try {
+          sharedAppIdStr = getSharedAppIdStr(false);
+        } catch (InterruptedException ie) {
+          LOG.error("LeaderWatcher interrupted", ie);
+          return;
+        }
+        if (sharedAppIdStr == null) {
+          // take no action because we only have register the next Watcher
+        } else {
+          String finalAppIdStr = null;
+          boolean createdNewApplication = false;
+          try {
+            if (sharedAppIdStr.isEmpty()) {
+              finalAppIdStr = createNewApplication();
+              createdNewApplication = true;
+            } else {
+              if (MR3SessionManagerImpl.getInstance().checkIfValidApplication(sharedAppIdStr)) {
+                finalAppIdStr = sharedAppIdStr;
+                createdNewApplication = false;  // unnecessary
+              } else  {
+                MR3SessionManagerImpl.getInstance().closeApplication(sharedAppIdStr);
+                LOG.info("closed Application " + sharedAppIdStr);
+                finalAppIdStr = createNewApplication();
+                createdNewApplication = true;
+              }
+            }
+            updateAppId(finalAppIdStr);
+          } catch (InterruptedException ie) {
+            LOG.error("LeaderWatcher interrupted", ie);
+            return;
+          } catch (HiveException e) {
+            LOG.error("Failed to create MR3 Application, killing HiveServer2", e);
+            stopHiveServer2 = true;
+          } catch (Exception e) {
+            // MR3SessionManager worked okay, but ZooKeeper failed somehow
+            if (createdNewApplication) {
+              assert finalAppIdStr != null;
+              MR3SessionManagerImpl.getInstance().closeApplication(finalAppIdStr);
+            }
+            stopHiveServer2 = true;
+            tryReleaseLock = false;   // because trying to release lock is likely to end up with an infinite loop in releaseAppIdLock()
+          }
+        }
+      } finally {
+        if (tryReleaseLock) {
+          try {
+            releaseAppIdLock();
+          } catch (InterruptedException ie) {
+            LOG.error("LeaderWatcher interrupted", ie);
+            return;
+          }
+        }
+      }
+
+      if (stopHiveServer2)  {
+        HiveServer2.this.closeAndDisallowHiveSessions();
+        HiveServer2.this.stop();
+      } else {
+        registerNextWatcher(true);
+      }
+    }
+  }
+
+  private String createNewApplication() throws HiveException {
+    String newAppIdStr = MR3SessionManagerImpl.getInstance().createNewApplication();
+    LOG.info("created new Application " + newAppIdStr);
+    return newAppIdStr;
   }
 }


### PR DESCRIPTION
### Motivation

- Integrate MR3 execution semantics into the Hive service layer so client progress and server lifecycle behave correctly when using MR3/Tez execution.
- Provide ZooKeeper-based coordination for shared MR3 applications across HS2 instances and ensure MR3 session resources are managed on startup/leader changes.
- Improve async SQL operation cleanup to avoid interrupting MR3 RPC waits while still ensuring queries are terminated.

### Description

- Add `MR3ProgressMonitorStatusMapper` (`service/src/java/org/apache/hive/service/cli/MR3ProgressMonitorStatusMapper.java`) to map MR3 DAG states to Thrift `TJobExecutionStatus` for client progress responses.
- Wire the MR3 mapper into Thrift status responses by updating `ThriftCLIService` to use `MR3ProgressMonitorStatusMapper` when the engine is `tez`.
- Update `SQLOperation` to emit an MR3 completion message to the operation log and to avoid cancelling background futures when the operation state is `CLOSED`, while still calling `driver.close()` to request graceful MR3 termination.
- Add lifecycle handling in `CLIService` to track and close the `startupAuthorizationSessionState` created during authorization setup.
- Extend `HiveServer2` with MR3-specific startup and HA handling, including ZooKeeper client initialization, `MR3SessionManagerImpl` setup, `watcherThreadExecutor`, and new `ApplicationWatcher`/`ApplicationConnectionWatcher`/`LeaderWatcher` classes to coordinate shared ApplicationIDs and leader actions via ZooKeeper.
- Adjust HS2 start/stop/leader logic to support MR3 semantics (conditional session handling, safe shutdown of MR3 session manager, closing startup authorization state, and closing the ZooKeeper client), and add related imports and configuration handling.

### Testing

- Attempted `mvn -pl service -DskipTests compile`, which failed due to an external repository resolution error for `org.apache:apache:pom:23` (HTTP 403) in the environment, so a full module compile could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a453eb066a08328b845beb5888399d0)