### PR TITLE
MR3: Emit Hive query results via FileSinkOperator DAG outputs

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2083,6 +2083,9 @@ public class HiveConf extends Configuration {
         "Default storage handler class for CREATE TABLE statements. If this is set to a valid class, a 'CREATE TABLE ... STORED AS ... LOCATION ...' command will " +
         "be equivalent to 'CREATE TABLE ... STORED BY [default.storage.handler.class] LOCATION ...'. Any STORED AS clauses will be ignored, given that STORED BY and STORED AS are " +
         "incompatible within the same command. Users can explicitly override the default class by issuing 'CREATE TABLE ... STORED BY [overriding.storage.handler.class] ...'"),
+    HIVE_MR3_QUERY_RESULT_TASK_MAX_BYTES("hive.mr3.query.result.task.max.bytes", -1L,
+        "Per-task byte limit for MR3 query-result DAG-output buffering. Negative means unlimited."),
+
     HIVE_QUERY_RESULT_FILEFORMAT("hive.query.result.fileformat", ResultFileFormat.SEQUENCEFILE.toString(),
         new StringSet(ResultFileFormat.getValidSet()),
         "Default file format for storing result of the query."),

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
@@ -24,7 +24,12 @@ import static org.apache.hadoop.hive.ql.security.authorization.HiveCustomStorage
 import static org.apache.hadoop.hive.ql.security.authorization.HiveCustomStorageHandlerUtils.setWriteOperation;
 import static org.apache.hadoop.hive.ql.security.authorization.HiveCustomStorageHandlerUtils.setWriteOperationIsSorted;
 
+import com.datamonad.mr3.api.common.DAGOutputEvent;
 import com.google.common.collect.Lists;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.UnsafeByteOperations;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -59,6 +64,8 @@ import org.apache.hadoop.hive.ql.io.BucketCodec;
 import org.apache.hadoop.hive.ql.io.DefaultHivePartitioner;
 import org.apache.hadoop.hive.ql.io.HiveFileFormatUtils;
 import org.apache.hadoop.hive.ql.io.HiveKey;
+import org.apache.hadoop.hive.ql.exec.tez.TezContext;
+import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.ql.io.HiveOutputFormat;
 import org.apache.hadoop.hive.ql.io.HivePartitioner;
 import org.apache.hadoop.hive.ql.io.RecordUpdater;
@@ -95,10 +102,14 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.IntObjectInspecto
 import org.apache.hadoop.hive.shims.HadoopShims.StoragePolicyShim;
 import org.apache.hadoop.hive.shims.HadoopShims.StoragePolicyValue;
 import org.apache.hadoop.hive.shims.ShimLoader;
+import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.JobConf;
+import org.apache.tez.runtime.api.Event;
+import org.apache.tez.runtime.api.ProcessorContext;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hive.common.util.HiveStringUtils;
 import org.slf4j.Logger;
@@ -149,6 +160,7 @@ public class FileSinkOperator extends TerminalOperator<FileSinkDesc> implements
   private transient BiFunction<Object[], ObjectInspector[], Integer> hashFunc;
   public static final String TOTAL_TABLE_ROWS_WRITTEN = "TOTAL_TABLE_ROWS_WRITTEN";
   private transient Set<String> dynamicPartitionSpecs = new HashSet<>();
+  private transient QueryResultDagOutputWriter queryResultDagOutputWriter;
 
   /**
    * Counters.
@@ -618,6 +630,13 @@ public class FileSinkOperator extends TerminalOperator<FileSinkDesc> implements
 
   @Override
   protected void initializeOp(Configuration hconf) throws HiveException {
+    if (conf.isEmitQueryResultToDag()) {
+      super.initializeOp(hconf);
+      queryResultDagOutputWriter = new QueryResultDagOutputWriter();
+      queryResultDagOutputWriter.initialize(hconf, conf, inputObjInspectors);
+      return;
+    }
+
     super.initializeOp(hconf);
     try {
       this.hconf = hconf;
@@ -1070,6 +1089,12 @@ public class FileSinkOperator extends TerminalOperator<FileSinkDesc> implements
 
   @Override
   public void process(Object row, int tag) throws HiveException {
+    if (conf.isEmitQueryResultToDag()) {
+      runTimeNumRows++;
+      queryResultDagOutputWriter.process(row, tag);
+      return;
+    }
+
     runTimeNumRows++;
     /* Create list bucketing sub-directory only if stored-as-directories is on. */
     String lbDirName = null;
@@ -1482,6 +1507,12 @@ public class FileSinkOperator extends TerminalOperator<FileSinkDesc> implements
 
   @Override
   public void closeOp(boolean abort) throws HiveException {
+    if (conf.isEmitQueryResultToDag()) {
+      if (queryResultDagOutputWriter != null) {
+        queryResultDagOutputWriter.close(abort);
+      }
+      return;
+    }
 
     row_count.set(conf.isDeleteOfSplitUpdate() ? 0 : numRows);
 
@@ -1879,4 +1910,157 @@ public class FileSinkOperator extends TerminalOperator<FileSinkDesc> implements
     LOG.debug("Parsed the attemptId " + attemptId.toString() + " from the task ID " + taskId);
     return attemptId;
   }
+
+  static class QueryResultDagOutputWriter {
+    private FileSinkDesc conf;
+    private AbstractSerDe serializer;
+    private ObjectInspector inputOI;
+    private ObjectInspector[] inputObjInspectors;
+    private ByteArrayOutputStream writer;
+    private DataOutputStream dataOut;
+    private ProcessorContext processorContext;
+    private long numRows;
+    private long maxBytes;
+    private int rowSeparator;
+
+    void initialize(Configuration hconf, FileSinkDesc conf, ObjectInspector[] inputObjInspectors)
+        throws HiveException {
+      this.conf = conf;
+      this.inputObjInspectors = inputObjInspectors;
+      try {
+        serializer = conf.getTableInfo().getSerDeClass().newInstance();
+        serializer.initialize(hconf, conf.getTableInfo().getProperties(), null);
+      } catch (InstantiationException | IllegalAccessException | SerDeException e) {
+        throw new HiveException("Unable to initialize MR3 query-result DAG-output serializer", e);
+      }
+      inputOI = inputObjInspectors[0];
+      writer = new ByteArrayOutputStream();
+      dataOut = new DataOutputStream(writer);
+      maxBytes = conf.getQueryResultMaxBytes();
+      if (maxBytes < 0) {
+        maxBytes = HiveConf.getLongVar(hconf, HiveConf.ConfVars.HIVE_MR3_QUERY_RESULT_TASK_MAX_BYTES);
+      }
+      rowSeparator = getRowSeparator(conf.getTableInfo().getProperties());
+      MapredContext mapredContext = MapredContext.get();
+      if (!(mapredContext instanceof TezContext)) {
+        throw new HiveException("MR3 query-result DAG-output mode requires Tez/MR3 context");
+      }
+      processorContext = ((TezContext) mapredContext).getTezProcessorContext();
+      if (processorContext == null) {
+        throw new HiveException("MR3 query-result DAG-output mode requires processor context");
+      }
+      if (conf.getQueryResultId() == null || conf.getQueryResultId().isEmpty()) {
+        throw new HiveException("MR3 query-result DAG-output mode requires queryResultId");
+      }
+    }
+
+    void process(Object row, int tag) throws HiveException {
+      try {
+        Writable recordValue = serializer.serialize(row, inputObjInspectors[tag]);
+        if (recordValue == null) {
+          return;
+        }
+        writeRecord(recordValue);
+        numRows++;
+      } catch (SerDeException | IOException e) {
+        throw new HiveException("Error writing MR3 query-result DAG-output row", e);
+      }
+    }
+
+    void close(boolean abort) throws HiveException {
+      try {
+        if (!abort && conf.isUsingBatchingSerDe()) {
+          Writable recordValue = serializer.serialize(null, inputOI);
+          if (recordValue != null) {
+            writeRecord(recordValue);
+            numRows++;
+          }
+        }
+        if (dataOut != null) {
+          dataOut.flush();
+        }
+        if (abort) {
+          return;
+        }
+        waitForCanCommit();
+        commitDagOutput();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new HiveException("Interrupted while committing MR3 query-result DAG output", e);
+      } catch (IOException | SerDeException e) {
+        throw new HiveException("Error closing MR3 query-result DAG-output writer", e);
+      }
+    }
+
+    private void waitForCanCommit() throws IOException, InterruptedException {
+      while (!processorContext.canCommit()) {
+        Thread.sleep(500);
+      }
+    }
+
+    private void commitDagOutput() throws IOException {
+      byte[] payload = writer.toByteArray();
+      if (payload.length == 0) {
+        return;
+      }
+      ByteString dagOutput = UnsafeByteOperations.unsafeWrap(payload);
+      Event event = DAGOutputEvent.create(conf.getQueryResultId(), dagOutput, (int) numRows);
+      processorContext.sendEvents(Collections.singletonList(event));
+    }
+
+    private void writeRecord(Writable writable) throws IOException, HiveException {
+      if (conf.isUsingBatchingSerDe()) {
+        writeBinaryRecord(writable);
+      } else {
+        writeTextRecord(writable);
+      }
+      enforceMaxBytes();
+    }
+
+    private void writeTextRecord(Writable writable) throws IOException {
+      if (writable instanceof Text) {
+        Text text = (Text) writable;
+        dataOut.write(text.getBytes(), 0, text.getLength());
+      } else if (writable instanceof BytesWritable) {
+        BytesWritable bytes = (BytesWritable) writable;
+        dataOut.write(bytes.get(), 0, bytes.getSize());
+      } else {
+        throw new IOException("Unsupported query-result writable: " + writable.getClass().getName());
+      }
+      dataOut.write(rowSeparator);
+    }
+
+    private void writeBinaryRecord(Writable writable) throws IOException {
+      if (writable instanceof BytesWritable) {
+        BytesWritable bytes = (BytesWritable) writable;
+        dataOut.writeInt(bytes.getSize());
+        dataOut.write(bytes.get(), 0, bytes.getSize());
+        return;
+      }
+      if (writable instanceof Text) {
+        Text text = (Text) writable;
+        dataOut.writeInt(text.getLength());
+        dataOut.write(text.getBytes(), 0, text.getLength());
+        return;
+      }
+      throw new IOException("Unsupported binary query-result writable: " + writable.getClass().getName());
+    }
+
+    private void enforceMaxBytes() throws HiveException {
+      if (maxBytes >= 0 && writer.size() > maxBytes) {
+        throw new HiveException("Query result for resultId=" + conf.getQueryResultId()
+            + " exceeded per-task limit " + maxBytes + " bytes");
+      }
+    }
+
+    private static int getRowSeparator(Properties tableProperties) {
+      String rowSeparatorString = tableProperties.getProperty(serdeConstants.LINE_DELIM, "\n");
+      try {
+        return Byte.parseByte(rowSeparatorString);
+      } catch (NumberFormatException e) {
+        return rowSeparatorString.charAt(0);
+      }
+    }
+  }
+
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
@@ -24,7 +24,6 @@ import static org.apache.hadoop.hive.ql.security.authorization.HiveCustomStorage
 import static org.apache.hadoop.hive.ql.security.authorization.HiveCustomStorageHandlerUtils.setWriteOperation;
 import static org.apache.hadoop.hive.ql.security.authorization.HiveCustomStorageHandlerUtils.setWriteOperationIsSorted;
 
-import com.datamonad.mr3.api.common.DAGOutputEvent;
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.UnsafeByteOperations;
@@ -36,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -110,6 +110,7 @@ import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.tez.runtime.api.Event;
 import org.apache.tez.runtime.api.ProcessorContext;
+import org.apache.tez.runtime.api.events.DAGOutputEvent;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hive.common.util.HiveStringUtils;
 import org.slf4j.Logger;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/MR3Task.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/MR3Task.java
@@ -22,6 +22,9 @@ import com.datamonad.mr3.api.client.DAGStatus;
 import com.datamonad.mr3.api.client.VertexStatus;
 import com.datamonad.mr3.api.common.MR3Exception;
 import com.google.protobuf.ByteString;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.lang.reflect.Method;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -79,10 +82,10 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -130,6 +133,7 @@ public class MR3Task {
 
   private Map<BaseWork, Vertex> workToVertex = null;
   private Map<BaseWork, JobConf> workToConf = null;
+  private final Map<String, QueryResultMaterializationContext> queryResultMaterializationContexts = new LinkedHashMap<>();
 
   public MR3Task(HiveConf conf, SessionState.LogHelper console, AtomicBoolean isShutdown) {
     this.conf = conf;
@@ -237,6 +241,7 @@ public class MR3Task {
         }
         String dagIdStr = mr3JobRef.getDagIdStr();    // may throw MR3Exception
         collectCommitInformation(tezWork, dagStatus, dagIdStr);
+        collectDagOutputs(dagStatus);
         mr3Session.setAlreadyExecutedAnyDag();
       }
 
@@ -572,6 +577,8 @@ public class MR3Task {
     TezWork.VertexType vertexType = tezWork.getVertexType(baseWork);
     boolean isFinal = tezWork.getLeaves().contains(baseWork);
 
+    enableQueryResultDagOutputModeIfNeeded(tezWork, baseWork, isFinal, vertexJobConf, context);
+
     // update vertexJobConf before calling createVertex() which calls createBy
     int numChildren = tezWork.getChildren(baseWork).size();
     if (numChildren > 1) {  // added from HIVE-22744
@@ -611,6 +618,212 @@ public class MR3Task {
       Edge e = dagUtils.createEdge(
           vertexJobConf, vertex, workToVertex.get(v), edgeProp, v, tezWork);
       dag.addEdge(e);
+    }
+  }
+
+  private void enableQueryResultDagOutputModeIfNeeded(
+      TezWork tezWork, BaseWork baseWork, boolean isFinal, JobConf vertexJobConf, Context context) {
+    if (!isFinal || SessionState.get() == null || !SessionState.get().isHiveServerQuery()) {
+      return;
+    }
+    for (Operator<?> op : baseWork.getAllOperators()) {
+      if (op instanceof FileSinkOperator) {
+        FileSinkOperator fsOp = (FileSinkOperator) op;
+        FileSinkDesc desc = fsOp.getConf();
+        if (isEligibleQueryResultSink(desc)) {
+          String queryId = HiveConf.getVar(conf, HiveConf.ConfVars.HIVE_QUERY_ID);
+          String resultId = queryId + "_" + baseWork.getName() + "_" + fsOp.getIdentifier();
+          QueryResultMaterializationContext ctx = new QueryResultMaterializationContext(
+              resultId, fsOp, desc, desc.getDirName(), desc.getTableInfo(), desc.isUsingBatchingSerDe(),
+              getRowSeparator(desc), desc.isUsingBatchingSerDe(), baseWork.getName(), fsOp.getIdentifier());
+          enableQueryResultDagOutputMode(fsOp, ctx,
+              HiveConf.getLongVar(vertexJobConf, HiveConf.ConfVars.HIVE_MR3_QUERY_RESULT_TASK_MAX_BYTES));
+        }
+      }
+    }
+  }
+
+  private boolean isEligibleQueryResultSink(FileSinkDesc desc) {
+    return desc != null
+        && desc.isHiveServerQuery()
+        && desc.getIsQuery()
+        && !desc.isMmCtas()
+        && !desc.isCTASorCM()
+        && !desc.getInsertOverwrite()
+        && !desc.isDirectInsert()
+        && desc.getDynPartCtx() == null
+        && !desc.isGatherStats()
+        && !desc.isMerge()
+        && desc.getWriteType() == org.apache.hadoop.hive.ql.io.AcidUtils.Operation.NOT_ACID
+        && desc.getAcidOperation() == null;
+  }
+
+  private void enableQueryResultDagOutputMode(
+      FileSinkOperator fsOp, QueryResultMaterializationContext ctx, long maxBytes) {
+    FileSinkDesc desc = fsOp.getConf();
+    if (desc.isEmitQueryResultToDag()) {
+      if (!ctx.resultId.equals(desc.getQueryResultId())) {
+        throw new IllegalStateException("Conflicting MR3 query-result id for FileSinkOperator. existing="
+            + desc.getQueryResultId() + ", new=" + ctx.resultId);
+      }
+      registerMaterializationContextIfAbsent(ctx);
+      return;
+    }
+    desc.setEmitQueryResultToDag(true);
+    desc.setQueryResultId(ctx.resultId);
+    desc.setQueryResultMaxBytes(maxBytes);
+    registerMaterializationContextIfAbsent(ctx);
+  }
+
+  private void registerMaterializationContextIfAbsent(QueryResultMaterializationContext ctx) {
+    queryResultMaterializationContexts.putIfAbsent(ctx.resultId, ctx);
+  }
+
+  private void collectDagOutputs(DAGStatus dagStatus) throws Exception {
+    if (queryResultMaterializationContexts.isEmpty()) {
+      return;
+    }
+    Map<String, List<ByteString>> outputsById = getDagOutputsById(dagStatus);
+    for (QueryResultMaterializationContext ctx : queryResultMaterializationContexts.values()) {
+      List<ByteString> outputs = outputsById.get(ctx.resultId);
+      materializeQueryResult(ctx, outputs == null ? Collections.emptyList() : outputs);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, List<ByteString>> getDagOutputsById(DAGStatus dagStatus) throws Exception {
+    Map<String, List<ByteString>> result = new HashMap<>();
+    for (Method method : dagStatus.getClass().getMethods()) {
+      if (!method.getName().toLowerCase().contains("dagoutput") || method.getParameterCount() != 0) {
+        continue;
+      }
+      Object events = method.invoke(dagStatus);
+      if (!(events instanceof Iterable)) {
+        continue;
+      }
+      for (Object event : (Iterable<?>) events) {
+        String id = invokeString(event, "resultId", "getResultId", "outputId", "getOutputId", "name", "getName");
+        ByteString payload = invokeByteString(event, "dagOutput", "getDagOutput", "payload", "getPayload");
+        if (id != null && payload != null && queryResultMaterializationContexts.containsKey(id)) {
+          result.computeIfAbsent(id, ignored -> new ArrayList<>()).add(payload);
+        }
+      }
+    }
+    return result;
+  }
+
+  private String invokeString(Object target, String... names) throws Exception {
+    for (String name : names) {
+      try {
+        Object value = target.getClass().getMethod(name).invoke(target);
+        if (value != null) {
+          return value.toString();
+        }
+      } catch (NoSuchMethodException ignored) {
+      }
+    }
+    return null;
+  }
+
+  private ByteString invokeByteString(Object target, String... names) throws Exception {
+    for (String name : names) {
+      try {
+        Object value = target.getClass().getMethod(name).invoke(target);
+        if (value instanceof ByteString) {
+          return (ByteString) value;
+        }
+      } catch (NoSuchMethodException ignored) {
+      }
+    }
+    return null;
+  }
+
+  private void materializeQueryResult(QueryResultMaterializationContext ctx, List<ByteString> outputs)
+      throws IOException {
+    org.apache.hadoop.fs.FileSystem fs = ctx.resultDir.getFileSystem(conf);
+    if (fs.exists(ctx.resultDir)) {
+      fs.delete(ctx.resultDir, true);
+    }
+    fs.mkdirs(ctx.resultDir);
+    Path resultFile = new Path(ctx.resultDir, "000000_0");
+    try {
+      if (ctx.binaryFramed) {
+        materializeBinaryQueryResult(ctx, resultFile, outputs);
+      } else {
+        try (org.apache.hadoop.fs.FSDataOutputStream out = fs.create(resultFile, true)) {
+          for (ByteString output : outputs) {
+            output.writeTo(out);
+          }
+        }
+      }
+    } catch (IOException e) {
+      fs.delete(ctx.resultDir, true);
+      throw e;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private void materializeBinaryQueryResult(
+      QueryResultMaterializationContext ctx, Path resultFile, List<ByteString> outputs) throws IOException {
+    JobConf jc = new JobConf(conf);
+    org.apache.hadoop.hive.ql.io.HiveOutputFormat outputFormat =
+        org.apache.hadoop.util.ReflectionUtils.newInstance(
+            ctx.tableDesc.getOutputFileFormatClass().asSubclass(
+                org.apache.hadoop.hive.ql.io.HiveOutputFormat.class), jc);
+    FileSinkOperator.RecordWriter recordWriter = outputFormat.getHiveRecordWriter(
+        jc, resultFile, org.apache.hadoop.io.BytesWritable.class, false,
+        ctx.tableDesc.getProperties(), null);
+    try {
+      for (ByteString output : outputs) {
+        try (DataInputStream in = new DataInputStream(output.newInput())) {
+          while (in.available() > 0) {
+            int len = in.readInt();
+            byte[] bytes = new byte[len];
+            in.readFully(bytes);
+            recordWriter.write(new org.apache.hadoop.io.BytesWritable(bytes));
+          }
+        }
+      }
+    } finally {
+      recordWriter.close(false);
+    }
+  }
+
+  private int getRowSeparator(FileSinkDesc desc) {
+    String rowSeparatorString = desc.getTableInfo().getProperties()
+        .getProperty(org.apache.hadoop.hive.serde.serdeConstants.LINE_DELIM, "\n");
+    try {
+      return Byte.parseByte(rowSeparatorString);
+    } catch (NumberFormatException e) {
+      return rowSeparatorString.charAt(0);
+    }
+  }
+
+  private static final class QueryResultMaterializationContext {
+    final String resultId;
+    final FileSinkOperator fileSinkOperator;
+    final FileSinkDesc fileSinkDesc;
+    final Path resultDir;
+    final org.apache.hadoop.hive.ql.plan.TableDesc tableDesc;
+    final boolean usingBatchingSerDe;
+    final int rowSeparator;
+    final boolean binaryFramed;
+    final String workName;
+    final String operatorId;
+
+    QueryResultMaterializationContext(String resultId, FileSinkOperator fileSinkOperator,
+        FileSinkDesc fileSinkDesc, Path resultDir, org.apache.hadoop.hive.ql.plan.TableDesc tableDesc,
+        boolean usingBatchingSerDe, int rowSeparator, boolean binaryFramed, String workName, String operatorId) {
+      this.resultId = resultId;
+      this.fileSinkOperator = fileSinkOperator;
+      this.fileSinkDesc = fileSinkDesc;
+      this.resultDir = resultDir;
+      this.tableDesc = tableDesc;
+      this.usingBatchingSerDe = usingBatchingSerDe;
+      this.rowSeparator = rowSeparator;
+      this.binaryFramed = binaryFramed;
+      this.workName = workName;
+      this.operatorId = operatorId;
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/FileSinkDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/FileSinkDesc.java
@@ -126,6 +126,37 @@ public class FileSinkDesc extends AbstractOperatorDesc implements IStatsGatherDe
    */
   private boolean isUsingBatchingSerDe = false;
 
+  /**
+   * MR3 execution-only query-result transport flag.
+   *
+   * This flag does not change the logical Hive meaning of FileSinkOperator.
+   * The logical result sink is still a FileSinkOperator whose output is
+   * consumed through the normal query-result/fetch contract.
+   *
+   * When this flag is true in MR3 task execution, FileSinkOperator does not
+   * create normal task-side FileSink writers. Instead it serializes final
+   * query-result rows and emits them through MR3 DAGOutputEvent. MR3Task later
+   * materializes those DAG-output bytes into the result artifact expected by
+   * the normal FileSink/FetchTask contract.
+   *
+   * Generic Hive planning, FetchTask, HiveServer2 result decoding, analyze
+   * logic, and normal FileSink output-path setup must not use this flag to
+   * infer SQL semantics or logical result semantics.
+   */
+  private boolean emitQueryResultToDag = false;
+
+  /**
+   * Exact MR3 DAG-output id used when emitQueryResultToDag is true.
+   * MR3Task.collectDagOutputs() must match DAG outputs by this exact id.
+   */
+  private String queryResultId;
+
+  /**
+   * Per-task byte limit for MR3 query-result DAG-output buffering.
+   * A negative value means no explicit per-task limit.
+   */
+  private long queryResultMaxBytes = -1;
+
   private boolean isInsertOverwrite = false;
 
   private boolean isDirectInsert = false;
@@ -209,6 +240,9 @@ public class FileSinkDesc extends AbstractOperatorDesc implements IStatsGatherDe
     ret.setIsDirectInsert(isDirectInsert);
     ret.setAcidOperation(acidOperation);
     ret.setMoveTaskId(moveTaskId);
+    ret.setEmitQueryResultToDag(emitQueryResultToDag);
+    ret.setQueryResultId(queryResultId);
+    ret.setQueryResultMaxBytes(queryResultMaxBytes);
     return ret;
   }
 
@@ -246,6 +280,30 @@ public class FileSinkDesc extends AbstractOperatorDesc implements IStatsGatherDe
 
   public void setIsUsingBatchingSerDe(boolean isUsingBatchingSerDe) {
     this.isUsingBatchingSerDe = isUsingBatchingSerDe;
+  }
+
+  public boolean isEmitQueryResultToDag() {
+    return emitQueryResultToDag;
+  }
+
+  public void setEmitQueryResultToDag(boolean emitQueryResultToDag) {
+    this.emitQueryResultToDag = emitQueryResultToDag;
+  }
+
+  public String getQueryResultId() {
+    return queryResultId;
+  }
+
+  public void setQueryResultId(String queryResultId) {
+    this.queryResultId = queryResultId;
+  }
+
+  public long getQueryResultMaxBytes() {
+    return queryResultMaxBytes;
+  }
+
+  public void setQueryResultMaxBytes(long queryResultMaxBytes) {
+    this.queryResultMaxBytes = queryResultMaxBytes;
   }
 
   public void setIsDirectInsert(boolean isDirectInsert) {


### PR DESCRIPTION
### Motivation
- Provide an MR3-private runtime transport for top-level Hive query results so MR3 workers can emit serialized result bytes as DAG outputs instead of writing task-side FileSink files while preserving FileSinkOperator as the logical sink.
- Keep HiveServer2/FetchTask/semantic/analysis behavior unchanged and materialize MR3 DAG outputs back into the normal result artifact expected by the FetchTask/result contract.

### Description
- Add MR3-only runtime fields to `FileSinkDesc`: `emitQueryResultToDag`, `queryResultId`, and `queryResultMaxBytes`, with getters/setters and clone propagation to preserve logical semantics (file: `ql/src/java/org/apache/hadoop/hive/ql/plan/FileSinkDesc.java`).
- Add a per-task limit configuration `hive.mr3.query.result.task.max.bytes` to `HiveConf` for MR3 query-result buffering (file: `common/src/java/org/apache/hadoop/hive/conf/HiveConf.java`).
- Introduce a package-private `QueryResultDagOutputWriter` helper inside `FileSinkOperator` that initializes the table SerDe, serializes rows (text vs. binary/batching framing), enforces per-task byte limits, waits for commit permission and emits a single DAG output event; and branch early in `initializeOp`, `process`, and `closeOp` to use the helper when `emitQueryResultToDag` is true (file: `ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java`).
- Extend MR3 DAG lowering in `MR3Task` to conservatively enable DAG-output mode for eligible final HS2 query-result `FileSinkOperator`s using a stable result id, register idempotent materialization contexts, collect DAG outputs by exact id after DAG success, decode framing (binary length-prefixed or raw text), and materialize the final result files with the expected `HiveOutputFormat` semantics (file: `ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/MR3Task.java`).
- Eligibility checks, byte framing, batching-SerDe flushing, and cleanup behavior were implemented to keep logical Hive semantics unchanged and to ensure idempotence on retries.

### Testing
- Ran `git diff --check` to validate whitespace and basic diffs; this succeeded.
- Attempted to compile the `ql` module with `mvn -pl ql -am -DskipTests -Dspotbugs.skip -Dcheckstyle.skip compile`, and compilation was blocked by Maven resolving the Develocity extension in the build environment; this prevented a full compile verification.
- Attempted an alternative `mvn -Dmaven.extensions.skip=true -pl ql -am -DskipTests -Dspotbugs.skip -Dcheckstyle.skip compile`, which was also blocked by the same project-level Maven extension resolution issue in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4be0af93288328981afa99d3f850bf)