### PR TITLE
Log output committer class in MR3Task.collectCommitInformation for Iceberg debugging

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/MR3Task.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/MR3Task.java
@@ -280,6 +280,10 @@ public class MR3Task {
     for (BaseWork w : work.getAllWork()) {
       JobConf jobConf = workToConf.get(w);
       Vertex vertex = workToVertex.get(w);
+      String outputCommitterClass = Optional.ofNullable(jobConf).map(JobConf::getOutputCommitter)
+          .map(Object::getClass).map(Class::getName).orElse(null);
+      LOG.error("kkkkk collectCommitInformation workName={}, vertexName={}, outputCommitterClass={}",
+          w.getName(), vertex == null ? null : vertex.getName(), outputCommitterClass);
       boolean hasIcebergCommitter = Optional.ofNullable(jobConf).map(JobConf::getOutputCommitter)
           .map(Object::getClass).map(Class::getName)
           .filter(name -> name.endsWith("HiveIcebergNoJobCommitter")).isPresent();


### PR DESCRIPTION
### Motivation
- Add visibility into which output committer is set on jobs when collecting Iceberg commit information to help diagnose commit/committer-related issues.

### Description
- In `MR3Task.collectCommitInformation` capture the output committer class name from `JobConf.getOutputCommitter()` and emit it via `LOG.error` alongside the work and vertex names to aid troubleshooting, without changing the existing commit-detection logic.

### Testing
- No tests were added; the change was compiled and the existing automated unit test suite was executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52df6540708328b8d63c516d35b882)