### PR TITLE
Use configurable scratch dir permissions for non-shared MR3 sessions and add shared-session helper

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/session/MR3SessionImpl.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/session/MR3SessionImpl.java
@@ -244,8 +244,11 @@ public class MR3SessionImpl implements MR3Session {
     Path mr3SessionScratchDir = new Path(SessionState.get().getHdfsScratchDirURIString(), MR3_DIR);
     mr3SessionScratchDir = new Path(mr3SessionScratchDir, sessionId);
     FileSystem fs = mr3SessionScratchDir.getFileSystem(sessionConf);
+    FsPermission sessionScratchDirPermission = shareMr3Session
+        ? new FsPermission(SessionState.SESSION_SCRATCH_DIR_PERMISSION)
+        : new FsPermission(HiveConf.getVar(sessionConf, HiveConf.ConfVars.SCRATCH_DIR_PERMISSION));
     Utilities.createDirsWithPermission(
-        sessionConf, mr3SessionScratchDir, new FsPermission(SessionState.SESSION_SCRATCH_DIR_PERMISSION), true);
+        sessionConf, mr3SessionScratchDir, sessionScratchDirPermission, true);
     // Make sure the path is normalized.
     FileStatus dirStatus = DAGUtils.validateTargetDir(mr3SessionScratchDir, sessionConf);
     assert dirStatus != null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/session/MR3SessionManagerImpl.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/session/MR3SessionManagerImpl.java
@@ -283,6 +283,12 @@ public class MR3SessionManagerImpl implements MR3SessionManager {
     return shareMr3Session;
   }
 
+  public static boolean isSharedMr3Session(HiveConf hiveConf) {
+    return hiveConf.getBoolVar(HiveConf.ConfVars.HIVE_SERVER2_MR3_SHARE_SESSION)
+        || (hiveConf.getBoolVar(HiveConf.ConfVars.HIVE_SERVER2_SUPPORT_DYNAMIC_SERVICE_DISCOVERY)
+            && hiveConf.getBoolVar(HiveConf.ConfVars.HIVE_SERVER2_ACTIVE_PASSIVE_HA_ENABLE));
+  }
+
   @Override
   public synchronized MR3Session getSession(HiveConf hiveConf) throws HiveException {
     if (!initializedClientFactory) {  // e.g., called from Hive-CLI

--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
@@ -786,8 +786,10 @@ public class SessionState implements ISessionAuthState {
     // 1. HDFS scratch dir
     path = new Path(rootHDFSDirPath, userName);
     hdfsScratchDirURIString = path.toUri().toString();
-    // HDFS scratch dir does not necessarily mean 'isLocal==true' when using MR3
-    Utilities.createDirsWithPermission(conf, path, new FsPermission(SESSION_SCRATCH_DIR_PERMISSION), true);
+    FsPermission hdfsScratchDirPermission = MR3SessionManagerImpl.isSharedMr3Session(conf)
+        ? new FsPermission(SESSION_SCRATCH_DIR_PERMISSION)
+        : new FsPermission(scratchDirPermission);
+    Utilities.createDirsWithPermission(conf, path, hdfsScratchDirPermission, true);
     // 2. Local scratch dir
     path = new Path(HiveConf.getVar(conf, HiveConf.ConfVars.LOCAL_SCRATCH_DIR));
     createPath(conf, path, scratchDirPermission, true, false);


### PR DESCRIPTION
### Motivation

- Ensure correct filesystem permissions are applied for MR3 session scratch directories depending on whether MR3 sessions are shared or not.
- Centralize the logic that determines whether an MR3 session is shared so it can be reused in multiple places.

### Description

- In `MR3SessionImpl.createSessionScratchDir()` choose the scratch-dir `FsPermission` based on `shareMr3Session` rather than always using `SessionState.SESSION_SCRATCH_DIR_PERMISSION` and pass it to `Utilities.createDirsWithPermission()`.
- Add `MR3SessionManagerImpl.isSharedMr3Session(HiveConf)` static helper that returns whether MR3 sessions are shared using `HIVE_SERVER2_MR3_SHARE_SESSION` or the combination of `HIVE_SERVER2_SUPPORT_DYNAMIC_SERVICE_DISCOVERY` and `HIVE_SERVER2_ACTIVE_PASSIVE_HA_ENABLE`.
- Update `SessionState.createSessionDirs()` to use `MR3SessionManagerImpl.isSharedMr3Session(conf)` to select the HDFS scratch-dir permission so non-shared sessions use the configured `SCRATCH_DIR_PERMISSION` while shared sessions keep `SESSION_SCRATCH_DIR_PERMISSION`.

### Testing

- No automated tests were added for this change and no test suite was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60dc09e4fc8328baf5b156069e2124)