### PR TITLE
Propagate MR3 DAG ID and terminal status from MR3Task to TezTask

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/MR3Task.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/MR3Task.java
@@ -114,6 +114,8 @@ public class MR3Task {
   private final HiveConf conf;
   private final SessionState.LogHelper console;
   private final AtomicBoolean isShutdown;
+  private String dagIdStr;
+  private String terminalDagStatus;
   private final DAGUtils dagUtils;
 
   private TezCounters counters;
@@ -151,6 +153,37 @@ public class MR3Task {
     exception = ex;
   }
 
+  public String getDagIdStr() {
+    return dagIdStr;
+  }
+
+  public String getTerminalDagStatus() {
+    return terminalDagStatus;
+  }
+
+  private void updateDagId(MR3JobRef mr3JobRef) {
+    try {
+      dagIdStr = mr3JobRef.getDagIdStr();
+    } catch (MR3Exception e) {
+      LOG.debug("DAG ID is not available yet: {}", e.getMessage());
+    }
+  }
+
+  private void setTerminalDagStatus(int returnCode) {
+    switch (returnCode) {
+    case 0:
+      terminalDagStatus = "SUCCEEDED";
+      break;
+    case 1:
+      terminalDagStatus = "KILLED";
+      break;
+    case 2:
+    default:
+      terminalDagStatus = "FAILED";
+      break;
+    }
+  }
+
   public int execute(Context contextFromTezTask, TezWork tezWork) {
     int returnCode = 1;   // 1 == error
     boolean cleanContext = false;
@@ -177,6 +210,7 @@ public class MR3Task {
       try {
         mr3JobRef = mr3Session.submit(
             dag, amDagCommonLocalResources, conf, tezWork.getWorkMap(), context, isShutdown, perfLogger);
+        updateDagId(mr3JobRef);
         // mr3Session can be closed at any time, so the call may fail
         // handle only Exception from mr3Session.submit()
       } catch (Exception submitEx) {
@@ -204,6 +238,7 @@ public class MR3Task {
           // mr3Session can be closed at any time, so the call may fail
           mr3JobRef = mr3Session.submit(
               newDag, amDagCommonLocalResources, conf, tezWork.getWorkMap(), context, isShutdown, perfLogger);
+          updateDagId(mr3JobRef);
         }
       }
 
@@ -213,6 +248,8 @@ public class MR3Task {
       // console.printInfo(
       //     "Status: Running (Executing on MR3 DAGAppMaster with ApplicationID " + mr3JobRef.getJobId() + ")");
       returnCode = mr3JobRef.monitorJob();
+      updateDagId(mr3JobRef);
+      setTerminalDagStatus(returnCode);
       if (returnCode != 0) {
         this.setException(new HiveException(mr3JobRef.getDiagnostics()));
       }
@@ -243,6 +280,12 @@ public class MR3Task {
       LOG.info("MR3Task completed");
     } catch (Exception e) {
       LOG.error("Failed to execute MR3Task", e);
+      if (mr3JobRef != null) {
+        updateDagId(mr3JobRef);
+      }
+      if (terminalDagStatus == null) {
+        terminalDagStatus = "FAILED";
+      }
       StringWriter sw = new StringWriter();
       e.printStackTrace(new PrintWriter(sw));
       this.setException(new HiveException(sw.toString()));

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
@@ -166,6 +166,12 @@ public class TezTask extends Task<TezWork> {
     org.apache.hadoop.hive.ql.exec.mr3.MR3Task mr3Task =
       new org.apache.hadoop.hive.ql.exec.mr3.MR3Task(conf, console, isShutdownMr3);
     int returnCode = mr3Task.execute(context, this.getWork());
+    if (mr3Task.getDagIdStr() != null) {
+      this.jobID = mr3Task.getDagIdStr();
+    }
+    if (mr3Task.getTerminalDagStatus() != null) {
+      setStatusMessage(mr3Task.getTerminalDagStatus());
+    }
     // Utils.mergeTezCounters is null-safe.
     counters = Utils.mergeTezCounters(mr3Task.getTezCounters(), counters);
     Throwable exFromMr3 = mr3Task.getException();


### PR DESCRIPTION
### Motivation
- Surface MR3 DAG identification and final status back to the higher-level Tez/Hive task so the running query shows the MR3 DAG ApplicationID and terminal status for monitoring and diagnostics.
- Ensure diagnostic and commit handling logic has access to the DAG id and final status even when failures occur during submission or execution.

### Description
- Add `dagIdStr` and `terminalDagStatus` fields with getters to `MR3Task`, and introduce `updateDagId(MR3JobRef)` and `setTerminalDagStatus(int)` helpers to populate them from MR3 return values.
- Call `updateDagId` after successful `mr3Session.submit(...)` calls and again after `monitorJob()` returns, and set `terminalDagStatus` from the `monitorJob()` return code and default it to `FAILED` on exceptions.
- Propagate the collected values into `TezTask` by updating `jobID` with the DAG id and calling `setStatusMessage` with the terminal status when `executeMr3()` returns.
- Preserve existing counter, exception, and commit behaviors while adding the extra diagnostic fields and logging.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61c9c56ffc8328a6cd4e84c610a494)