### PR TITLE
Render COMPLETE progress updates even before operation log appears and add tests

### DIFF
--- a/beeline/src/java/org/apache/hive/beeline/logs/BeelineInPlaceUpdateStream.java
+++ b/beeline/src/java/org/apache/hive/beeline/logs/BeelineInPlaceUpdateStream.java
@@ -43,11 +43,15 @@ public class BeelineInPlaceUpdateStream implements InPlaceUpdateStream {
         for example, DDL statements
       */
       notifier.progressBarCompleted();
-    } else if (notifier.isOperationLogUpdatedAtLeastOnce()) {
+    } else if (notifier.isOperationLogUpdatedAtLeastOnce()
+        || response.getStatus() == TJobExecutionStatus.COMPLETE) {
       /*
         try to render in place update progress bar only if the operations logs is update at least once
         as this will hopefully allow printing the metadata information like query id, application id
-        etc. have to remove these notifiers when the operation logs get merged into GetOperationStatus
+        etc. Operation logs and progress updates are intentionally delivered independently, so a
+        completed response must still be rendered: for short queries it can be the only progress
+        response and can arrive before the log thread has displayed its first operation log.
+        Have to remove these notifiers when the operation logs get merged into GetOperationStatus.
       */
       inPlaceUpdate.render(new ProgressMonitorWrapper(response));
     }

--- a/beeline/src/test/org/apache/hive/beeline/logs/TestBeelineInPlaceUpdateStream.java
+++ b/beeline/src/test/org/apache/hive/beeline/logs/TestBeelineInPlaceUpdateStream.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hive.beeline.logs;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.apache.hive.jdbc.logs.InPlaceUpdateStream;
+import org.apache.hive.service.rpc.thrift.TJobExecutionStatus;
+import org.apache.hive.service.rpc.thrift.TProgressUpdateResp;
+import org.junit.Test;
+
+public class TestBeelineInPlaceUpdateStream {
+
+  @Test
+  public void testCompletedProgressRenderedBeforeOperationLog() {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    BeelineInPlaceUpdateStream stream = new BeelineInPlaceUpdateStream(new PrintStream(output),
+        new InPlaceUpdateStream.EventNotifier());
+
+    stream.update(progressResponse(TJobExecutionStatus.COMPLETE));
+
+    assertTrue(new String(output.toByteArray(), UTF_8).contains("ELAPSED TIME"));
+  }
+
+  @Test
+  public void testInProgressUpdateWaitsForOperationLog() {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    BeelineInPlaceUpdateStream stream = new BeelineInPlaceUpdateStream(new PrintStream(output),
+        new InPlaceUpdateStream.EventNotifier());
+
+    stream.update(progressResponse(TJobExecutionStatus.IN_PROGRESS));
+
+    assertFalse(new String(output.toByteArray(), UTF_8).contains("ELAPSED TIME"));
+  }
+
+  private TProgressUpdateResp progressResponse(TJobExecutionStatus status) {
+    return new TProgressUpdateResp(
+        Arrays.asList("VERTICES", "MODE", "STATUS", "TOTAL", "COMPLETED", "RUNNING",
+            "PENDING", "FAILED", "KILLED"),
+        Collections.singletonList(Arrays.asList("Map 1", "container", "SUCCEEDED", "1", "1",
+            "0", "0", "0", "0")),
+        1.0,
+        status,
+        "VERTICES: 01/01",
+        System.currentTimeMillis());
+  }
+}


### PR DESCRIPTION
### Motivation
- Short-running queries can return a single `TProgressUpdateResp` with status `COMPLETE` before any operation log output is produced, which prevents the in-place progress bar from being rendered.
- Ensure completed progress updates are shown immediately so users can see final progress/elapsed-time metadata even if operation logs haven't been emitted yet.

### Description
- Update the rendering condition in `BeelineInPlaceUpdateStream` to also render when `response.getStatus() == TJobExecutionStatus.COMPLETE` in addition to when `notifier.isOperationLogUpdatedAtLeastOnce()`.
- Clarified the inline comment to explain that operation logs and progress updates are delivered independently and that completed responses may be the only progress response for short queries.
- Add `TestBeelineInPlaceUpdateStream` with two unit tests that verify a `COMPLETE` response renders the progress output and an `IN_PROGRESS` response does not render until operation logs are present.

### Testing
- Ran the new unit tests in `TestBeelineInPlaceUpdateStream` and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64cc94c4a88328998458b816b2e023)