### PR TITLE
Rebuild DAG on MR3Session replacement and simplify query-result materialization handling

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2083,6 +2083,9 @@ public class HiveConf extends Configuration {
         "Default storage handler class for CREATE TABLE statements. If this is set to a valid class, a 'CREATE TABLE ... STORED AS ... LOCATION ...' command will " +
         "be equivalent to 'CREATE TABLE ... STORED BY [default.storage.handler.class] LOCATION ...'. Any STORED AS clauses will be ignored, given that STORED BY and STORED AS are " +
         "incompatible within the same command. Users can explicitly override the default class by issuing 'CREATE TABLE ... STORED BY [overriding.storage.handler.class] ...'"),
+    HIVE_MR3_QUERY_RESULT_TASK_MAX_BYTES("hive.mr3.query.result.task.max.bytes", -1L,
+        "Per-task byte limit for MR3 query-result DAG-output buffering. Negative means unlimited."),
+
     HIVE_QUERY_RESULT_FILEFORMAT("hive.query.result.fileformat", ResultFileFormat.SEQUENCEFILE.toString(),
         new StringSet(ResultFileFormat.getValidSet()),
         "Default file format for storing result of the query."),

--- a/ql/src/java/org/apache/hadoop/hive/ql/Context.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Context.java
@@ -889,7 +889,11 @@ public class Context {
    * @return next available tmp path on local fs
    */
   public Path getLocalTmpPath() {
-    return new Path(getLocalScratchDir(true), LOCAL_PREFIX + nextPathId());
+    return getLocalTmpPath(true);
+  }
+
+  public Path getLocalTmpPath(boolean mkDir) {
+    return new Path(getLocalScratchDir(mkDir), LOCAL_PREFIX + nextPathId());
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
@@ -25,12 +25,17 @@ import static org.apache.hadoop.hive.ql.security.authorization.HiveCustomStorage
 import static org.apache.hadoop.hive.ql.security.authorization.HiveCustomStorageHandlerUtils.setWriteOperationIsSorted;
 
 import com.google.common.collect.Lists;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.UnsafeByteOperations;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -59,6 +64,8 @@ import org.apache.hadoop.hive.ql.io.BucketCodec;
 import org.apache.hadoop.hive.ql.io.DefaultHivePartitioner;
 import org.apache.hadoop.hive.ql.io.HiveFileFormatUtils;
 import org.apache.hadoop.hive.ql.io.HiveKey;
+import org.apache.hadoop.hive.ql.exec.tez.TezContext;
+import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.ql.io.HiveOutputFormat;
 import org.apache.hadoop.hive.ql.io.HivePartitioner;
 import org.apache.hadoop.hive.ql.io.RecordUpdater;
@@ -95,10 +102,15 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.IntObjectInspecto
 import org.apache.hadoop.hive.shims.HadoopShims.StoragePolicyShim;
 import org.apache.hadoop.hive.shims.HadoopShims.StoragePolicyValue;
 import org.apache.hadoop.hive.shims.ShimLoader;
+import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.JobConf;
+import org.apache.tez.runtime.api.Event;
+import org.apache.tez.runtime.api.ProcessorContext;
+import org.apache.tez.runtime.api.events.DAGOutputEvent;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hive.common.util.HiveStringUtils;
 import org.slf4j.Logger;
@@ -149,6 +161,7 @@ public class FileSinkOperator extends TerminalOperator<FileSinkDesc> implements
   private transient BiFunction<Object[], ObjectInspector[], Integer> hashFunc;
   public static final String TOTAL_TABLE_ROWS_WRITTEN = "TOTAL_TABLE_ROWS_WRITTEN";
   private transient Set<String> dynamicPartitionSpecs = new HashSet<>();
+  private transient QueryResultDagOutputWriter queryResultDagOutputWriter;
 
   /**
    * Counters.
@@ -618,6 +631,13 @@ public class FileSinkOperator extends TerminalOperator<FileSinkDesc> implements
 
   @Override
   protected void initializeOp(Configuration hconf) throws HiveException {
+    if (conf.isEmitQueryResultToDag()) {
+      super.initializeOp(hconf);
+      queryResultDagOutputWriter = new QueryResultDagOutputWriter();
+      queryResultDagOutputWriter.initialize(hconf, conf, inputObjInspectors);
+      return;
+    }
+
     super.initializeOp(hconf);
     try {
       this.hconf = hconf;
@@ -1070,6 +1090,12 @@ public class FileSinkOperator extends TerminalOperator<FileSinkDesc> implements
 
   @Override
   public void process(Object row, int tag) throws HiveException {
+    if (conf.isEmitQueryResultToDag()) {
+      runTimeNumRows++;
+      queryResultDagOutputWriter.process(row, tag);
+      return;
+    }
+
     runTimeNumRows++;
     /* Create list bucketing sub-directory only if stored-as-directories is on. */
     String lbDirName = null;
@@ -1482,6 +1508,13 @@ public class FileSinkOperator extends TerminalOperator<FileSinkDesc> implements
 
   @Override
   public void closeOp(boolean abort) throws HiveException {
+    if (conf.isEmitQueryResultToDag()) {
+      if (queryResultDagOutputWriter != null) {
+        queryResultDagOutputWriter.close(abort);
+      }
+      super.closeOp(abort);   // for consistency with the ordinary branch
+      return;
+    }
 
     row_count.set(conf.isDeleteOfSplitUpdate() ? 0 : numRows);
 
@@ -1598,6 +1631,13 @@ public class FileSinkOperator extends TerminalOperator<FileSinkDesc> implements
   @Override
   public void jobCloseOp(Configuration hconf, boolean success)
       throws HiveException {
+    // MR3Task has already materialized successful DAG outputs directly at the
+    // result path.  There are no FileSink temporary files to commit or abort in
+    // this mode, but the normal operator lifecycle still has to be completed.
+    if (conf.isEmitQueryResultToDag()) {
+      super.jobCloseOp(hconf, success);   // for consistency with the ordinary branch
+      return;
+    }
     try {
       if ((conf != null) && isNativeTable()) {
         Path specPath = conf.getDirName();
@@ -1879,4 +1919,160 @@ public class FileSinkOperator extends TerminalOperator<FileSinkDesc> implements
     LOG.debug("Parsed the attemptId " + attemptId.toString() + " from the task ID " + taskId);
     return attemptId;
   }
+
+  static class QueryResultDagOutputWriter {
+    private FileSinkDesc conf;
+    private AbstractSerDe serializer;
+    private ObjectInspector inputOI;
+    private ObjectInspector[] inputObjInspectors;
+    private ByteArrayOutputStream writer;
+    private DataOutputStream dataOut;
+    private ProcessorContext processorContext;
+    private long numRows;
+    private long maxBytes;
+    private int rowSeparator;
+
+    void initialize(Configuration hconf, FileSinkDesc conf, ObjectInspector[] inputObjInspectors)
+        throws HiveException {
+      this.conf = conf;
+      this.inputObjInspectors = inputObjInspectors;
+      try {
+        serializer = conf.getTableInfo().getSerDeClass().newInstance();
+        serializer.initialize(hconf, conf.getTableInfo().getProperties(), null);
+      } catch (InstantiationException | IllegalAccessException | SerDeException e) {
+        throw new HiveException("Unable to initialize MR3 query-result DAG-output serializer", e);
+      }
+      inputOI = inputObjInspectors[0];
+      writer = new ByteArrayOutputStream();
+      dataOut = new DataOutputStream(writer);
+      maxBytes = conf.getQueryResultMaxBytes();
+      if (maxBytes < 0) {
+        maxBytes = HiveConf.getLongVar(hconf, HiveConf.ConfVars.HIVE_MR3_QUERY_RESULT_TASK_MAX_BYTES);
+      }
+      rowSeparator = getRowSeparator(conf.getTableInfo().getProperties());
+      MapredContext mapredContext = MapredContext.get();
+      if (!(mapredContext instanceof TezContext)) {
+        throw new HiveException("MR3 query-result DAG-output mode requires Tez/MR3 context");
+      }
+      processorContext = ((TezContext) mapredContext).getTezProcessorContext();
+      if (processorContext == null) {
+        throw new HiveException("MR3 query-result DAG-output mode requires processor context");
+      }
+      if (conf.getQueryResultId() == null || conf.getQueryResultId().isEmpty()) {
+        throw new HiveException("MR3 query-result DAG-output mode requires queryResultId");
+      }
+    }
+
+    void process(Object row, int tag) throws HiveException {
+      try {
+        Writable recordValue = serializer.serialize(row, inputObjInspectors[tag]);
+        if (recordValue == null) {
+          return;
+        }
+        writeRecord(recordValue);
+        numRows++;
+      } catch (SerDeException | IOException e) {
+        throw new HiveException("Error writing MR3 query-result DAG-output row", e);
+      }
+    }
+
+    void close(boolean abort) throws HiveException {
+      try {
+        if (!abort && conf.isUsingBatchingSerDe()) {
+          Writable recordValue = serializer.serialize(null, inputOI);
+          if (recordValue != null) {
+            writeRecord(recordValue);
+            numRows++;
+          }
+        }
+        if (dataOut != null) {
+          dataOut.flush();
+        }
+        if (abort) {
+          return;
+        }
+        waitForCanCommit();
+        commitDagOutput();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new HiveException("Interrupted while committing MR3 query-result DAG output", e);
+      } catch (IOException | SerDeException e) {
+        throw new HiveException("Error closing MR3 query-result DAG-output writer", e);
+      }
+    }
+
+    private void waitForCanCommit() throws IOException, InterruptedException {
+      while (!processorContext.canCommit()) {
+        Thread.sleep(500);
+      }
+    }
+
+    private void commitDagOutput() throws IOException {
+      byte[] payload = writer.toByteArray();
+      if (payload.length == 0) {
+        return;
+      }
+      if (numRows > Integer.MAX_VALUE) {
+        throw new IOException("MR3 query-result DAG output row count exceeds supported limit: " + numRows);
+      }
+      ByteString dagOutput = UnsafeByteOperations.unsafeWrap(payload);
+      Event event = DAGOutputEvent.create(conf.getQueryResultId(), dagOutput, (int) numRows);
+      processorContext.sendEvents(Collections.singletonList(event));
+    }
+
+    private void writeRecord(Writable writable) throws IOException, HiveException {
+      if (conf.isUsingBatchingSerDe()) {
+        writeBinaryRecord(writable);
+      } else {
+        writeTextRecord(writable);
+      }
+      enforceMaxBytes();
+    }
+
+    private void writeTextRecord(Writable writable) throws IOException {
+      if (writable instanceof Text) {
+        Text text = (Text) writable;
+        dataOut.write(text.getBytes(), 0, text.getLength());
+      } else if (writable instanceof BytesWritable) {
+        BytesWritable bytes = (BytesWritable) writable;
+        dataOut.write(bytes.get(), 0, bytes.getSize());
+      } else {
+        throw new IOException("Unsupported query-result writable: " + writable.getClass().getName());
+      }
+      dataOut.write(rowSeparator);
+    }
+
+    private void writeBinaryRecord(Writable writable) throws IOException {
+      if (writable instanceof BytesWritable) {
+        BytesWritable bytes = (BytesWritable) writable;
+        dataOut.writeInt(bytes.getSize());
+        dataOut.write(bytes.get(), 0, bytes.getSize());
+        return;
+      }
+      if (writable instanceof Text) {
+        Text text = (Text) writable;
+        dataOut.writeInt(text.getLength());
+        dataOut.write(text.getBytes(), 0, text.getLength());
+        return;
+      }
+      throw new IOException("Unsupported binary query-result writable: " + writable.getClass().getName());
+    }
+
+    private void enforceMaxBytes() throws HiveException {
+      if (maxBytes >= 0 && writer.size() > maxBytes) {
+        throw new HiveException("Query result for resultId=" + conf.getQueryResultId()
+            + " exceeded per-task limit " + maxBytes + " bytes");
+      }
+    }
+
+    private static int getRowSeparator(Properties tableProperties) {
+      String rowSeparatorString = tableProperties.getProperty(serdeConstants.LINE_DELIM, "\n");
+      try {
+        return Byte.parseByte(rowSeparatorString);
+      } catch (NumberFormatException e) {
+        return rowSeparatorString.charAt(0);
+      }
+    }
+  }
+
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/MR3Task.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/MR3Task.java
@@ -209,7 +209,7 @@ public class MR3Task {
       // effectful: conf is updated
       JobConf jobConf = dagUtils.createConfiguration(conf);
 
-      DAG dag = setupSubmit(jobConf, tezWork, context, workToConf);
+      DAG dag = setupSubmit(jobConf, tezWork, context, workToConf, false);
 
       // 4. submit
       try {
@@ -238,8 +238,10 @@ public class MR3Task {
           if (mr3ScratchDir != null && mr3ScratchDirCreated) {
             dagUtils.cleanMr3Dir(mr3ScratchDir, conf);
           }
-          // 2. call again
-          DAG newDag = setupSubmit(jobConf, tezWork, context, workToConf);
+          // 2. call again. Do not reuse dag: the replacement session has its own scratch directory
+          // and AM-localization state. setupSubmit() recreates the LocalResources and vertex JobConfs
+          // after the previous session's MR3 scratch directory has been cleaned above.
+          DAG newDag = setupSubmit(jobConf, tezWork, context, workToConf, true);
           // mr3Session can be closed at any time, so the call may fail
           mr3JobRef = mr3Session.submit(
               newDag, amDagCommonLocalResources, conf, tezWork.getWorkMap(), context, isShutdown, perfLogger);
@@ -356,7 +358,7 @@ public class MR3Task {
   }
 
   private DAG setupSubmit(JobConf jobConf, TezWork tezWork, Context context,
-                          Map<BaseWork, JobConf> workToConf) throws Exception {
+                          Map<BaseWork, JobConf> workToConf, boolean isSubmissionRetry) throws Exception {
     mr3Session = getMr3Session(conf);
     // mr3Session can be closed at any time
     Path sessionScratchDir = mr3Session.getSessionScratchDir();
@@ -375,7 +377,8 @@ public class MR3Task {
     amDagCommonLocalResources = dagUtils.convertLocalResourceListToMap(confLocalResources);
 
     // 3. create DAG
-    DAG dag = buildDag(jobConf, tezWork, context, amDagCommonLocalResources, sessionScratchDir, workToConf);
+    DAG dag = buildDag(
+        jobConf, tezWork, context, amDagCommonLocalResources, sessionScratchDir, workToConf, isSubmissionRetry);
     console.printInfo("Finished building DAG, now submitting: " + tezWork.getName());
 
     if (this.isShutdown.get()) {
@@ -450,7 +453,7 @@ public class MR3Task {
   private DAG buildDag(
       JobConf jobConf, TezWork tezWork, Context context,
       Map<String, LocalResource> amDagCommonLocalResources, Path sessionScratchDir,
-      Map<BaseWork, JobConf> workToConf) throws Exception {
+      Map<BaseWork, JobConf> workToConf, boolean isSubmissionRetry) throws Exception {
     perfLogger.perfLogBegin(CLASS_NAME, PerfLogger.MR3_BUILD_DAG);
     Map<BaseWork, Vertex> workToVertex = new HashMap<BaseWork, Vertex>();
 
@@ -514,7 +517,8 @@ public class MR3Task {
       if (w instanceof UnionWork) {
         buildVertexGroupEdges(dag, tezWork, (UnionWork) w, workToVertex, workToConf);
       } else {
-        buildRegularVertexEdge(jobConf, dag, tezWork, w, workToVertex, workToConf, mr3ScratchDir, context);
+        buildRegularVertexEdge(
+            jobConf, dag, tezWork, w, workToVertex, workToConf, mr3ScratchDir, context, isSubmissionRetry);
       }
       perfLogger.perfLogEnd(CLASS_NAME, PerfLogger.MR3_CREATE_VERTEX + w.getName());
     }
@@ -611,13 +615,14 @@ public class MR3Task {
       Map<BaseWork, Vertex> workToVertex,
       Map<BaseWork, JobConf> workToConf,
       Path mr3ScratchDir,
-      Context context) throws Exception {
+      Context context,
+      boolean isSubmissionRetry) throws Exception {
     JobConf vertexJobConf = dagUtils.initializeVertexConf(jobConf, context, baseWork);
     checkOutputSpec(baseWork, vertexJobConf);
     TezWork.VertexType vertexType = tezWork.getVertexType(baseWork);
     boolean isFinal = tezWork.getLeaves().contains(baseWork);
 
-    enableQueryResultDagOutputModeIfNeeded(baseWork, isFinal, vertexJobConf);
+    enableQueryResultDagOutputModeIfNeeded(baseWork, isFinal, vertexJobConf, isSubmissionRetry);
 
     // update vertexJobConf before calling createVertex() which calls createBy
     int numChildren = tezWork.getChildren(baseWork).size();
@@ -662,7 +667,7 @@ public class MR3Task {
   }
 
   private void enableQueryResultDagOutputModeIfNeeded(
-      BaseWork baseWork, boolean isFinal, JobConf vertexJobConf) {
+      BaseWork baseWork, boolean isFinal, JobConf vertexJobConf, boolean isSubmissionRetry) {
     if (!isFinal || SessionState.get() == null || !SessionState.get().isHiveServerQuery()) {
       return;
     }
@@ -673,10 +678,9 @@ public class MR3Task {
         if (isEligibleQueryResultSink(desc)) {
           String queryId = HiveConf.getVar(conf, HiveConf.ConfVars.HIVE_QUERY_ID);
           String resultId = queryId + "_" + baseWork.getName() + "_" + fsOp.getIdentifier();
-          QueryResultMaterializationContext ctx = new QueryResultMaterializationContext(
-              resultId, fsOp, desc, desc.getDirName(), desc.getTableInfo(), desc.isUsingBatchingSerDe(),
-              getRowSeparator(desc), desc.isUsingBatchingSerDe(), baseWork.getName(), fsOp.getIdentifier());
+          QueryResultMaterializationContext ctx = new QueryResultMaterializationContext(resultId, desc);
           enableQueryResultDagOutputMode(fsOp, ctx,
+              isSubmissionRetry,
               HiveConf.getLongVar(vertexJobConf, HiveConf.ConfVars.HIVE_MR3_QUERY_RESULT_TASK_MAX_BYTES));
         } else {
           // if desc.isMr3QueryResultLocal() == true, we must enable DAG-output mode and thus cannot reach here
@@ -702,7 +706,7 @@ public class MR3Task {
   }
 
   private void enableQueryResultDagOutputMode(
-      FileSinkOperator fsOp, QueryResultMaterializationContext ctx, long maxBytes) {
+      FileSinkOperator fsOp, QueryResultMaterializationContext ctx, boolean isSubmissionRetry, long maxBytes) {
     FileSinkDesc desc = fsOp.getConf();
 
     // emitQueryResultToDag = how the MR3 worker should transport result rows to HiveServer2
@@ -710,13 +714,12 @@ public class MR3Task {
     // (emitQueryResultToDag, mr3QueryResultLocal) = (false, true) is an invalid state.
 
     if (desc.isEmitQueryResultToDag()) {
-      if (!ctx.resultId.equals(desc.getQueryResultId())) {
-        throw new IllegalStateException("Conflicting MR3 query-result id for FileSinkOperator. existing="
-            + desc.getQueryResultId() + ", new=" + ctx.resultId);
-      }
-      registerMaterializationContextIfAbsent(ctx);
+      assert isSubmissionRetry;
+      assert ctx.resultId.equals(desc.getQueryResultId());
+      assert queryResultMaterializationContexts.containsKey(ctx.resultId);
       return;
     }
+    assert !desc.isEmitQueryResultToDag();
     desc.setEmitQueryResultToDag(true);
     desc.setQueryResultId(ctx.resultId);
     desc.setQueryResultMaxBytes(maxBytes);
@@ -753,15 +756,16 @@ public class MR3Task {
 
   private void materializeQueryResult(QueryResultMaterializationContext ctx, List<ByteString> outputs)
       throws IOException {
-    assert !ctx.fileSinkDesc.isMr3QueryResultLocal() || "file".equalsIgnoreCase(ctx.resultDir.toUri().getScheme());
+    Path resultDir = ctx.fileSinkDesc.getDirName();
+    assert !ctx.fileSinkDesc.isMr3QueryResultLocal() || "file".equalsIgnoreCase(resultDir.toUri().getScheme());
 
     // if isMr3QueryResultLocal() == true, store the result in the local file system
     // if isMr3QueryResultLocal() == false, we have finished executing a cache-miss query and thus
     // should use the query-results-cache destination directory.
     org.apache.hadoop.fs.FileSystem fs = ctx.fileSinkDesc.isMr3QueryResultLocal()
         ? org.apache.hadoop.fs.FileSystem.getLocal(conf)
-        : ctx.resultDir.getFileSystem(conf);
-    Path resultDir = fs.makeQualified(ctx.resultDir);
+        : resultDir.getFileSystem(conf);
+    resultDir = fs.makeQualified(resultDir);
 
     if (fs.exists(resultDir)) {
       fs.delete(resultDir, true);
@@ -770,7 +774,7 @@ public class MR3Task {
 
     Path resultFile = new Path(resultDir, "000000_0");
     try {
-      if (ctx.binaryFramed) {
+      if (ctx.fileSinkDesc.isUsingBatchingSerDe()) {
         materializeBinaryQueryResult(ctx, resultFile, outputs);
       } else {
         try (org.apache.hadoop.fs.FSDataOutputStream out = fs.create(resultFile, true)) {
@@ -789,13 +793,14 @@ public class MR3Task {
   private void materializeBinaryQueryResult(
       QueryResultMaterializationContext ctx, Path resultFile, List<ByteString> outputs) throws IOException {
     JobConf jc = new JobConf(conf);
+    org.apache.hadoop.hive.ql.plan.TableDesc tableDesc = ctx.fileSinkDesc.getTableInfo();
     org.apache.hadoop.hive.ql.io.HiveOutputFormat outputFormat =
         org.apache.hadoop.util.ReflectionUtils.newInstance(
-            ctx.tableDesc.getOutputFileFormatClass().asSubclass(
+            tableDesc.getOutputFileFormatClass().asSubclass(
                 org.apache.hadoop.hive.ql.io.HiveOutputFormat.class), jc);
     FileSinkOperator.RecordWriter recordWriter = outputFormat.getHiveRecordWriter(
         jc, resultFile, org.apache.hadoop.io.BytesWritable.class, false,
-        ctx.tableDesc.getProperties(), null);
+        tableDesc.getProperties(), null);
     try {
       for (ByteString output : outputs) {
         try (DataInputStream in = new DataInputStream(output.newInput())) {
@@ -812,41 +817,13 @@ public class MR3Task {
     }
   }
 
-  private int getRowSeparator(FileSinkDesc desc) {
-    String rowSeparatorString = desc.getTableInfo().getProperties()
-        .getProperty(org.apache.hadoop.hive.serde.serdeConstants.LINE_DELIM, "\n");
-    try {
-      return Byte.parseByte(rowSeparatorString);
-    } catch (NumberFormatException e) {
-      return rowSeparatorString.charAt(0);
-    }
-  }
-
   private static final class QueryResultMaterializationContext {
     final String resultId;
-    final FileSinkOperator fileSinkOperator;
     final FileSinkDesc fileSinkDesc;
-    final Path resultDir;
-    final org.apache.hadoop.hive.ql.plan.TableDesc tableDesc;
-    final boolean usingBatchingSerDe;
-    final int rowSeparator;
-    final boolean binaryFramed;
-    final String workName;
-    final String operatorId;
 
-    QueryResultMaterializationContext(String resultId, FileSinkOperator fileSinkOperator,
-        FileSinkDesc fileSinkDesc, Path resultDir, org.apache.hadoop.hive.ql.plan.TableDesc tableDesc,
-        boolean usingBatchingSerDe, int rowSeparator, boolean binaryFramed, String workName, String operatorId) {
+    QueryResultMaterializationContext(String resultId, FileSinkDesc fileSinkDesc) {
       this.resultId = resultId;
-      this.fileSinkOperator = fileSinkOperator;
       this.fileSinkDesc = fileSinkDesc;
-      this.resultDir = resultDir;
-      this.tableDesc = tableDesc;
-      this.usingBatchingSerDe = usingBatchingSerDe;
-      this.rowSeparator = rowSeparator;
-      this.binaryFramed = binaryFramed;
-      this.workName = workName;
-      this.operatorId = operatorId;
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/MR3Task.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/MR3Task.java
@@ -617,7 +617,7 @@ public class MR3Task {
     TezWork.VertexType vertexType = tezWork.getVertexType(baseWork);
     boolean isFinal = tezWork.getLeaves().contains(baseWork);
 
-    enableQueryResultDagOutputModeIfNeeded(tezWork, baseWork, isFinal, vertexJobConf, context);
+    enableQueryResultDagOutputModeIfNeeded(baseWork, isFinal, vertexJobConf);
 
     // update vertexJobConf before calling createVertex() which calls createBy
     int numChildren = tezWork.getChildren(baseWork).size();
@@ -662,7 +662,7 @@ public class MR3Task {
   }
 
   private void enableQueryResultDagOutputModeIfNeeded(
-      TezWork tezWork, BaseWork baseWork, boolean isFinal, JobConf vertexJobConf, Context context) {
+      BaseWork baseWork, boolean isFinal, JobConf vertexJobConf) {
     if (!isFinal || SessionState.get() == null || !SessionState.get().isHiveServerQuery()) {
       return;
     }
@@ -678,6 +678,9 @@ public class MR3Task {
               getRowSeparator(desc), desc.isUsingBatchingSerDe(), baseWork.getName(), fsOp.getIdentifier());
           enableQueryResultDagOutputMode(fsOp, ctx,
               HiveConf.getLongVar(vertexJobConf, HiveConf.ConfVars.HIVE_MR3_QUERY_RESULT_TASK_MAX_BYTES));
+        } else {
+          // if desc.isMr3QueryResultLocal() == true, we must enable DAG-output mode and thus cannot reach here
+          assert !desc.isMr3QueryResultLocal();
         }
       }
     }
@@ -701,6 +704,11 @@ public class MR3Task {
   private void enableQueryResultDagOutputMode(
       FileSinkOperator fsOp, QueryResultMaterializationContext ctx, long maxBytes) {
     FileSinkDesc desc = fsOp.getConf();
+
+    // emitQueryResultToDag = how the MR3 worker should transport result rows to HiveServer2
+    // mr3QueryResultLocal = where HiveServer2 should materialize the collected result artifact
+    // (emitQueryResultToDag, mr3QueryResultLocal) = (false, true) is an invalid state.
+
     if (desc.isEmitQueryResultToDag()) {
       if (!ctx.resultId.equals(desc.getQueryResultId())) {
         throw new IllegalStateException("Conflicting MR3 query-result id for FileSinkOperator. existing="
@@ -745,12 +753,22 @@ public class MR3Task {
 
   private void materializeQueryResult(QueryResultMaterializationContext ctx, List<ByteString> outputs)
       throws IOException {
-    org.apache.hadoop.fs.FileSystem fs = ctx.resultDir.getFileSystem(conf);
-    if (fs.exists(ctx.resultDir)) {
-      fs.delete(ctx.resultDir, true);
+    assert !ctx.fileSinkDesc.isMr3QueryResultLocal() || "file".equalsIgnoreCase(ctx.resultDir.toUri().getScheme());
+
+    // if isMr3QueryResultLocal() == true, store the result in the local file system
+    // if isMr3QueryResultLocal() == false, we have finished executing a cache-miss query and thus
+    // should use the query-results-cache destination directory.
+    org.apache.hadoop.fs.FileSystem fs = ctx.fileSinkDesc.isMr3QueryResultLocal()
+        ? org.apache.hadoop.fs.FileSystem.getLocal(conf)
+        : ctx.resultDir.getFileSystem(conf);
+    Path resultDir = fs.makeQualified(ctx.resultDir);
+
+    if (fs.exists(resultDir)) {
+      fs.delete(resultDir, true);
     }
-    fs.mkdirs(ctx.resultDir);
-    Path resultFile = new Path(ctx.resultDir, "000000_0");
+    fs.mkdirs(resultDir);
+
+    Path resultFile = new Path(resultDir, "000000_0");
     try {
       if (ctx.binaryFramed) {
         materializeBinaryQueryResult(ctx, resultFile, outputs);
@@ -762,7 +780,7 @@ public class MR3Task {
         }
       }
     } catch (IOException e) {
-      fs.delete(ctx.resultDir, true);
+      fs.delete(resultDir, true);
       throw e;
     }
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/MR3Task.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/MR3Task.java
@@ -22,6 +22,8 @@ import com.datamonad.mr3.api.client.DAGStatus;
 import com.datamonad.mr3.api.client.VertexStatus;
 import com.datamonad.mr3.api.common.MR3Exception;
 import com.google.protobuf.ByteString;
+import java.io.DataInputStream;
+import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -79,10 +81,10 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -93,6 +95,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
+import scala.Tuple2;
+import scala.collection.Iterator;
 
 import static org.apache.hadoop.hive.ql.exec.tez.TezTask.JOB_ID_TEMPLATE;
 import static org.apache.hadoop.hive.ql.exec.tez.TezTask.ICEBERG_PROPERTY_PREFIX;
@@ -132,6 +136,7 @@ public class MR3Task {
 
   private Map<BaseWork, Vertex> workToVertex = null;
   private Map<BaseWork, JobConf> workToConf = null;
+  private final Map<String, QueryResultMaterializationContext> queryResultMaterializationContexts = new LinkedHashMap<>();
 
   public MR3Task(HiveConf conf, SessionState.LogHelper console, AtomicBoolean isShutdown) {
     this.conf = conf;
@@ -273,6 +278,7 @@ public class MR3Task {
         }
         String dagIdStr = mr3JobRef.getDagIdStr();    // may throw MR3Exception
         collectCommitInformation(tezWork, dagStatus, dagIdStr);
+        collectDagOutputs(dagStatus);
         mr3Session.setAlreadyExecutedAnyDag();
       }
 
@@ -611,6 +617,8 @@ public class MR3Task {
     TezWork.VertexType vertexType = tezWork.getVertexType(baseWork);
     boolean isFinal = tezWork.getLeaves().contains(baseWork);
 
+    enableQueryResultDagOutputModeIfNeeded(tezWork, baseWork, isFinal, vertexJobConf, context);
+
     // update vertexJobConf before calling createVertex() which calls createBy
     int numChildren = tezWork.getChildren(baseWork).size();
     if (numChildren > 1) {  // added from HIVE-22744
@@ -650,6 +658,177 @@ public class MR3Task {
       Edge e = dagUtils.createEdge(
           vertexJobConf, jobConf, vertex, workToVertex.get(v), edgeProp, v, tezWork);
       dag.addEdge(e);
+    }
+  }
+
+  private void enableQueryResultDagOutputModeIfNeeded(
+      TezWork tezWork, BaseWork baseWork, boolean isFinal, JobConf vertexJobConf, Context context) {
+    if (!isFinal || SessionState.get() == null || !SessionState.get().isHiveServerQuery()) {
+      return;
+    }
+    for (Operator<?> op : baseWork.getAllOperators()) {
+      if (op instanceof FileSinkOperator) {
+        FileSinkOperator fsOp = (FileSinkOperator) op;
+        FileSinkDesc desc = fsOp.getConf();
+        if (isEligibleQueryResultSink(desc)) {
+          String queryId = HiveConf.getVar(conf, HiveConf.ConfVars.HIVE_QUERY_ID);
+          String resultId = queryId + "_" + baseWork.getName() + "_" + fsOp.getIdentifier();
+          QueryResultMaterializationContext ctx = new QueryResultMaterializationContext(
+              resultId, fsOp, desc, desc.getDirName(), desc.getTableInfo(), desc.isUsingBatchingSerDe(),
+              getRowSeparator(desc), desc.isUsingBatchingSerDe(), baseWork.getName(), fsOp.getIdentifier());
+          enableQueryResultDagOutputMode(fsOp, ctx,
+              HiveConf.getLongVar(vertexJobConf, HiveConf.ConfVars.HIVE_MR3_QUERY_RESULT_TASK_MAX_BYTES));
+        }
+      }
+    }
+  }
+
+  private boolean isEligibleQueryResultSink(FileSinkDesc desc) {
+    return desc != null
+        && desc.isHiveServerQuery()
+        && desc.getIsQuery()
+        && !desc.isMmCtas()
+        && !desc.isCTASorCM()
+        && !desc.getInsertOverwrite()
+        && !desc.isDirectInsert()
+        && desc.getDynPartCtx() == null
+        && !desc.isGatherStats()
+        && !desc.isMerge()
+        && desc.getWriteType() == org.apache.hadoop.hive.ql.io.AcidUtils.Operation.NOT_ACID
+        && desc.getAcidOperation() == null;
+  }
+
+  private void enableQueryResultDagOutputMode(
+      FileSinkOperator fsOp, QueryResultMaterializationContext ctx, long maxBytes) {
+    FileSinkDesc desc = fsOp.getConf();
+    if (desc.isEmitQueryResultToDag()) {
+      if (!ctx.resultId.equals(desc.getQueryResultId())) {
+        throw new IllegalStateException("Conflicting MR3 query-result id for FileSinkOperator. existing="
+            + desc.getQueryResultId() + ", new=" + ctx.resultId);
+      }
+      registerMaterializationContextIfAbsent(ctx);
+      return;
+    }
+    desc.setEmitQueryResultToDag(true);
+    desc.setQueryResultId(ctx.resultId);
+    desc.setQueryResultMaxBytes(maxBytes);
+    registerMaterializationContextIfAbsent(ctx);
+  }
+
+  private void registerMaterializationContextIfAbsent(QueryResultMaterializationContext ctx) {
+    queryResultMaterializationContexts.putIfAbsent(ctx.resultId, ctx);
+  }
+
+  private void collectDagOutputs(DAGStatus dagStatus) throws Exception {
+    if (queryResultMaterializationContexts.isEmpty()) {
+      return;
+    }
+    Map<String, List<ByteString>> outputsById = getDagOutputsById(dagStatus);
+    for (QueryResultMaterializationContext ctx : queryResultMaterializationContexts.values()) {
+      List<ByteString> outputs = outputsById.get(ctx.resultId);
+      materializeQueryResult(ctx, outputs == null ? Collections.emptyList() : outputs);
+    }
+  }
+
+  private Map<String, List<ByteString>> getDagOutputsById(DAGStatus dagStatus) {
+    Map<String, List<ByteString>> result = new HashMap<>();
+    Iterator<Tuple2<String, ByteString>> outputs = dagStatus.dagOutputs().iterator();
+    while (outputs.hasNext()) {
+      Tuple2<String, ByteString> output = outputs.next();
+      String id = output._1();
+      if (queryResultMaterializationContexts.containsKey(id)) {
+        result.computeIfAbsent(id, ignored -> new ArrayList<>()).add(output._2());
+      }
+    }
+    return result;
+  }
+
+  private void materializeQueryResult(QueryResultMaterializationContext ctx, List<ByteString> outputs)
+      throws IOException {
+    org.apache.hadoop.fs.FileSystem fs = ctx.resultDir.getFileSystem(conf);
+    if (fs.exists(ctx.resultDir)) {
+      fs.delete(ctx.resultDir, true);
+    }
+    fs.mkdirs(ctx.resultDir);
+    Path resultFile = new Path(ctx.resultDir, "000000_0");
+    try {
+      if (ctx.binaryFramed) {
+        materializeBinaryQueryResult(ctx, resultFile, outputs);
+      } else {
+        try (org.apache.hadoop.fs.FSDataOutputStream out = fs.create(resultFile, true)) {
+          for (ByteString output : outputs) {
+            output.writeTo(out);
+          }
+        }
+      }
+    } catch (IOException e) {
+      fs.delete(ctx.resultDir, true);
+      throw e;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private void materializeBinaryQueryResult(
+      QueryResultMaterializationContext ctx, Path resultFile, List<ByteString> outputs) throws IOException {
+    JobConf jc = new JobConf(conf);
+    org.apache.hadoop.hive.ql.io.HiveOutputFormat outputFormat =
+        org.apache.hadoop.util.ReflectionUtils.newInstance(
+            ctx.tableDesc.getOutputFileFormatClass().asSubclass(
+                org.apache.hadoop.hive.ql.io.HiveOutputFormat.class), jc);
+    FileSinkOperator.RecordWriter recordWriter = outputFormat.getHiveRecordWriter(
+        jc, resultFile, org.apache.hadoop.io.BytesWritable.class, false,
+        ctx.tableDesc.getProperties(), null);
+    try {
+      for (ByteString output : outputs) {
+        try (DataInputStream in = new DataInputStream(output.newInput())) {
+          while (in.available() > 0) {
+            int len = in.readInt();
+            byte[] bytes = new byte[len];
+            in.readFully(bytes);
+            recordWriter.write(new org.apache.hadoop.io.BytesWritable(bytes));
+          }
+        }
+      }
+    } finally {
+      recordWriter.close(false);
+    }
+  }
+
+  private int getRowSeparator(FileSinkDesc desc) {
+    String rowSeparatorString = desc.getTableInfo().getProperties()
+        .getProperty(org.apache.hadoop.hive.serde.serdeConstants.LINE_DELIM, "\n");
+    try {
+      return Byte.parseByte(rowSeparatorString);
+    } catch (NumberFormatException e) {
+      return rowSeparatorString.charAt(0);
+    }
+  }
+
+  private static final class QueryResultMaterializationContext {
+    final String resultId;
+    final FileSinkOperator fileSinkOperator;
+    final FileSinkDesc fileSinkDesc;
+    final Path resultDir;
+    final org.apache.hadoop.hive.ql.plan.TableDesc tableDesc;
+    final boolean usingBatchingSerDe;
+    final int rowSeparator;
+    final boolean binaryFramed;
+    final String workName;
+    final String operatorId;
+
+    QueryResultMaterializationContext(String resultId, FileSinkOperator fileSinkOperator,
+        FileSinkDesc fileSinkDesc, Path resultDir, org.apache.hadoop.hive.ql.plan.TableDesc tableDesc,
+        boolean usingBatchingSerDe, int rowSeparator, boolean binaryFramed, String workName, String operatorId) {
+      this.resultId = resultId;
+      this.fileSinkOperator = fileSinkOperator;
+      this.fileSinkDesc = fileSinkDesc;
+      this.resultDir = resultDir;
+      this.tableDesc = tableDesc;
+      this.usingBatchingSerDe = usingBatchingSerDe;
+      this.rowSeparator = rowSeparator;
+      this.binaryFramed = binaryFramed;
+      this.workName = workName;
+      this.operatorId = operatorId;
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -92,7 +92,6 @@ import org.apache.hadoop.hive.common.metrics.common.MetricsConstant;
 import org.apache.hadoop.hive.conf.Constants;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
-import org.apache.hadoop.hive.conf.HiveConf.ResultFileFormat;
 import org.apache.hadoop.hive.conf.HiveConf.StrictChecks;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.TransactionalValidationListener;
@@ -2655,7 +2654,9 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
           } else {
             // This is the only place where isQuery is set to true; it defaults to false.
             qb.setIsQuery(true);
-            Path stagingPath = getStagingDirectoryPathname(qb, conf, ctx);
+            Path stagingPath = isHiveServer2Mr3Execution(conf)
+                ? ctx.getLocalTmpPath(false)
+                : getStagingDirectoryPathname(qb, conf, ctx);
             fname = stagingPath.toString();
             ctx.setResDir(stagingPath);
           }
@@ -7530,6 +7531,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     StructObjectInspector specificRowObjectInspector = null;
     int currentTableId = 0;
     boolean isLocal = false;
+    boolean useLocalMr3QueryResult = false;
     SortBucketRSCtx rsCtx = new SortBucketRSCtx();
     DynamicPartitionCtx dpCtx = null;
     LoadTableDesc ltd = null;
@@ -7929,7 +7931,26 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         isPartitioned = false;
       }
 
-      if (isLocal) {
+      // useLocalMr3QueryResult == true:
+      //   This is a non-cached HiveServer2 MR3 query result
+      //   which should be materialized in HiveServer2 local scratch.
+      useLocalMr3QueryResult =
+          qb.getIsQuery()       // must be a logical query result rather than a table/directory write
+          && tblDesc == null    // must not be a CTAS-style result carrying a create-table descriptor
+          && viewDesc == null   // must not be a materialized-view creation result
+          && !ctx.isResultCacheDir(destinationPath)   // must not be intended for persistent query-results-cache
+          && isHiveServer2Mr3Execution(conf);   // if true, local result materialization is supported
+      // Note:
+      // If ctx.isResultCacheDir(destinationPath) is true, SemanticAnalyzer has assigned this cache-miss execution
+      // a query-results-cache destination and prevents it from using HiveServer2 local scratch.
+      // If its final HiveServer2 MR3 FileSink is eligible, MR3Task will later use DAG-output mode
+      // and materializes the collected output at that cache destination.
+
+      if (useLocalMr3QueryResult) {
+        // Later MR3Task must enable DAG-output mode.
+        queryTmpdir = destinationPath;
+        ctx.setResDir(queryTmpdir);
+      } else if (isLocal) {
         assert !isMmTable;
         // for local directory - we always write to map-red intermediate
         // store and then copy to local fs
@@ -8227,6 +8248,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     } else {
       fileSinkDesc.setIsUsingBatchingSerDe(false);
     }
+    fileSinkDesc.setMr3QueryResultLocal(useLocalMr3QueryResult);
 
     Operator output = putOpInsertMap(OperatorFactory.getAndMakeChild(
         fileSinkDesc, fsRS, input), inputRR);
@@ -8369,6 +8391,14 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   private boolean useBatchingSerializer(String serdeClassName) {
     return SessionState.get().isHiveServerQuery() &&
       hasSetBatchSerializer(serdeClassName);
+  }
+
+  private static boolean isHiveServer2Mr3Execution(HiveConf conf) {
+    SessionState sessionState = SessionState.get();
+    return sessionState != null
+        && sessionState.isHiveServerQuery()
+        && "tez".equalsIgnoreCase(
+            HiveConf.getVar(conf, HiveConf.ConfVars.HIVE_EXECUTION_ENGINE));
   }
 
   private boolean hasSetBatchSerializer(String serdeClassName) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -7990,10 +7990,12 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
             tableDescriptor = PlanUtils.getTableDesc(viewDesc, cols, colTypes);
           } else if (qb.getIsQuery()) {
             Class<? extends Deserializer> serdeClass = LazySimpleSerDe.class;
-            String fileFormat = conf.getResultFileFormat().toString();
-            if (SessionState.get().getIsUsingThriftJDBCBinarySerDe()) {
+            boolean isUsingThriftJDBCBinarySerDe =
+                SessionState.get().getIsUsingThriftJDBCBinarySerDe();
+            String fileFormat = PlanUtils.getQueryResultFileFormat(
+                conf, SessionState.get().isHiveServerQuery(), isUsingThriftJDBCBinarySerDe).toString();
+            if (isUsingThriftJDBCBinarySerDe) {
               serdeClass = ThriftJDBCBinarySerDe.class;
-              fileFormat = ResultFileFormat.SEQUENCEFILE.toString();
               // Set the fetch formatter to be a no-op for the ListSinkOperator, since we'll
               // write out formatted thrift objects to SequenceFile
               conf.set(SerDeUtils.LIST_SINK_OUTPUT_FORMATTER, NoOpFetchFormatter.class.getName());

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
@@ -200,11 +200,13 @@ public abstract class TaskCompiler {
       TableDesc resultTab = pCtx.getFetchTableDesc();
       boolean shouldSetOutputFormatter = false;
       if (resultTab == null) {
-        ResultFileFormat resFileFormat = conf.getResultFileFormat();
+        boolean isUsingThriftJDBCBinarySerDe =
+            SessionState.get().getIsUsingThriftJDBCBinarySerDe();
+        ResultFileFormat resFileFormat = PlanUtils.getQueryResultFileFormat(
+            conf, SessionState.get().isHiveServerQuery(), isUsingThriftJDBCBinarySerDe);
         String fileFormat;
         Class<? extends Deserializer> serdeClass;
-        if (SessionState.get().getIsUsingThriftJDBCBinarySerDe()
-            && resFileFormat == ResultFileFormat.SEQUENCEFILE) {
+        if (isUsingThriftJDBCBinarySerDe && resFileFormat == ResultFileFormat.SEQUENCEFILE) {
           fileFormat = resFileFormat.toString();
           serdeClass = ThriftJDBCBinarySerDe.class;
           shouldSetOutputFormatter = true;

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/FileSinkDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/FileSinkDesc.java
@@ -126,6 +126,37 @@ public class FileSinkDesc extends AbstractOperatorDesc implements IStatsGatherDe
    */
   private boolean isUsingBatchingSerDe = false;
 
+  /**
+   * MR3 execution-only query-result transport flag.
+   *
+   * This flag does not change the logical Hive meaning of FileSinkOperator.
+   * The logical result sink is still a FileSinkOperator whose output is
+   * consumed through the normal query-result/fetch contract.
+   *
+   * When this flag is true in MR3 task execution, FileSinkOperator does not
+   * create normal task-side FileSink writers. Instead it serializes final
+   * query-result rows and emits them through MR3 DAGOutputEvent. MR3Task later
+   * materializes those DAG-output bytes into the result artifact expected by
+   * the normal FileSink/FetchTask contract.
+   *
+   * Generic Hive planning, FetchTask, HiveServer2 result decoding, analyze
+   * logic, and normal FileSink output-path setup must not use this flag to
+   * infer SQL semantics or logical result semantics.
+   */
+  private boolean emitQueryResultToDag = false;
+
+  /**
+   * Exact MR3 DAG-output id used when emitQueryResultToDag is true.
+   * MR3Task.collectDagOutputs() must match DAG outputs by this exact id.
+   */
+  private String queryResultId;
+
+  /**
+   * Per-task byte limit for MR3 query-result DAG-output buffering.
+   * A negative value means no explicit per-task limit.
+   */
+  private long queryResultMaxBytes = -1;
+
   private boolean isInsertOverwrite = false;
 
   private boolean isDirectInsert = false;
@@ -209,6 +240,9 @@ public class FileSinkDesc extends AbstractOperatorDesc implements IStatsGatherDe
     ret.setIsDirectInsert(isDirectInsert);
     ret.setAcidOperation(acidOperation);
     ret.setMoveTaskId(moveTaskId);
+    ret.setEmitQueryResultToDag(emitQueryResultToDag);
+    ret.setQueryResultId(queryResultId);
+    ret.setQueryResultMaxBytes(queryResultMaxBytes);
     return ret;
   }
 
@@ -246,6 +280,30 @@ public class FileSinkDesc extends AbstractOperatorDesc implements IStatsGatherDe
 
   public void setIsUsingBatchingSerDe(boolean isUsingBatchingSerDe) {
     this.isUsingBatchingSerDe = isUsingBatchingSerDe;
+  }
+
+  public boolean isEmitQueryResultToDag() {
+    return emitQueryResultToDag;
+  }
+
+  public void setEmitQueryResultToDag(boolean emitQueryResultToDag) {
+    this.emitQueryResultToDag = emitQueryResultToDag;
+  }
+
+  public String getQueryResultId() {
+    return queryResultId;
+  }
+
+  public void setQueryResultId(String queryResultId) {
+    this.queryResultId = queryResultId;
+  }
+
+  public long getQueryResultMaxBytes() {
+    return queryResultMaxBytes;
+  }
+
+  public void setQueryResultMaxBytes(long queryResultMaxBytes) {
+    this.queryResultMaxBytes = queryResultMaxBytes;
   }
 
   public void setIsDirectInsert(boolean isDirectInsert) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/FileSinkDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/FileSinkDesc.java
@@ -157,6 +157,13 @@ public class FileSinkDesc extends AbstractOperatorDesc implements IStatsGatherDe
    */
   private long queryResultMaxBytes = -1;
 
+  /**
+   * Whether the MR3 query-result artifact is assigned to HiveServer2 local scratch space.
+   * A FileSink carrying this flag must use the MR3 DAG-output transport; a worker must never
+   * open this path as an ordinary FileSink output path.
+   */
+  private boolean mr3QueryResultLocal = false;
+
   private boolean isInsertOverwrite = false;
 
   private boolean isDirectInsert = false;
@@ -243,6 +250,7 @@ public class FileSinkDesc extends AbstractOperatorDesc implements IStatsGatherDe
     ret.setEmitQueryResultToDag(emitQueryResultToDag);
     ret.setQueryResultId(queryResultId);
     ret.setQueryResultMaxBytes(queryResultMaxBytes);
+    ret.setMr3QueryResultLocal(mr3QueryResultLocal);
     return ret;
   }
 
@@ -304,6 +312,14 @@ public class FileSinkDesc extends AbstractOperatorDesc implements IStatsGatherDe
 
   public void setQueryResultMaxBytes(long queryResultMaxBytes) {
     this.queryResultMaxBytes = queryResultMaxBytes;
+  }
+
+  public boolean isMr3QueryResultLocal() {
+    return mr3QueryResultLocal;
+  }
+
+  public void setMr3QueryResultLocal(boolean mr3QueryResultLocal) {
+    this.mr3QueryResultLocal = mr3QueryResultLocal;
   }
 
   public void setIsDirectInsert(boolean isDirectInsert) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
@@ -312,6 +312,22 @@ public final class PlanUtils {
   }
 
   /**
+   * MR3 transports ordinary HiveServer2 query results as delimited serialized rows, so the
+   * compiler-visible result artifact must use the matching text format. Task-side Thrift JDBC
+   * serialization remains a sequence-file contract because its payload consists of binary batches.
+   */
+  public static HiveConf.ResultFileFormat getQueryResultFileFormat(
+      HiveConf conf, boolean isHiveServerQuery, boolean isUsingThriftJDBCBinarySerDe) {
+    if (isHiveServerQuery
+        && "tez".equals(HiveConf.getVar(conf, HiveConf.ConfVars.HIVE_EXECUTION_ENGINE))) {
+      return isUsingThriftJDBCBinarySerDe
+          ? HiveConf.ResultFileFormat.SEQUENCEFILE
+          : HiveConf.ResultFileFormat.TEXTFILE;
+    }
+    return conf.getResultFileFormat();
+  }
+
+  /**
    * Generate a table descriptor from a createTableDesc.
    */
   public static TableDesc getTableDesc(CreateTableDesc crtTblDesc, String cols, String colTypes) {


### PR DESCRIPTION
### Motivation

- Ensure we do not reuse DAG-local resources or AM-localization state when the MR3Session is replaced during submit, and correctly re-create per-submission LocalResources and vertex JobConfs.
- Simplify and correct query-result materialization by using the `FileSinkDesc` as the authoritative source and fix handling for batching SerDe and local vs cached result destinations.

### Description

- Introduce an `isSubmissionRetry` boolean propagated through `setupSubmit`, `buildDag`, `buildRegularVertexEdge`, and `enableQueryResultDagOutputMode` and pass `true` when retrying submission after replacing the MR3Session so the DAG and LocalResources are recreated.
- On MR3Session replacement, rebuild the DAG instead of reusing the previous DAG, and add explanatory comments about scratch directory and AM-localization state.
- Change `QueryResultMaterializationContext` to only contain `resultId` and `FileSinkDesc`, and update `materializeQueryResult`/`materializeBinaryQueryResult` to derive paths, batching and table metadata from `FileSinkDesc` (use `getDirName()`, `isUsingBatchingSerDe()`, and `getTableInfo()`).
- Add runtime assertions in `enableQueryResultDagOutputMode` to validate the retry path (existing `emitQueryResultToDag` state and registered contexts) and assert expected invariants; set `emitQueryResultToDag`, `queryResultId`, and max bytes when enabling.
- Remove obsolete fields and helper `getRowSeparator` now that table properties are accessed via the `FileSinkDesc`/`TableDesc` directly.

### Testing

- Built the `ql` module and ran the unit test suite with `mvn -DskipTests=false -pl ql test`, and the tests completed successfully.
- Performed local verification of the MR3 submit retry path and query-result materialization behavior (smoke checks) to confirm DAG rebuild and result materialization code exercised correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76c0ce7964832899a3266e0eac92ee)