### PR TITLE
Use NullRowsInputFormat for dummy scans and avoid creating dummy files

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/DAGUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/DAGUtils.java
@@ -62,6 +62,7 @@ import org.apache.hadoop.hive.ql.io.HiveFileFormatUtils.NullOutputCommitter;
 import org.apache.hadoop.hive.ql.io.HiveInputFormat;
 import org.apache.hadoop.hive.ql.io.HiveKey;
 import org.apache.hadoop.hive.ql.io.HiveOutputFormatImpl;
+import org.apache.hadoop.hive.ql.io.NullRowsInputFormat;
 import org.apache.hadoop.hive.ql.io.merge.MergeFileMapper;
 import org.apache.hadoop.hive.ql.io.merge.MergeFileOutputFormat;
 import org.apache.hadoop.hive.ql.io.merge.MergeFileWork;
@@ -776,8 +777,10 @@ public class DAGUtils {
     }
 
     if (mapWork.getDummyTableScan()) {
-      // hive input format doesn't handle the special condition of no paths + 1 split correctly.
-      inpFormat = CombineHiveInputFormat.class.getName();
+      // A dummy scan is an engine-level synthetic input. NullRowsInputFormat creates its
+      // DummyInputSplit directly from the logical MapWork path and performs no filesystem
+      // discovery, so this must not depend on the user-configured top-level input format.
+      inpFormat = NullRowsInputFormat.class.getName();
     }
 
     jobConf.set(Utilities.MAPRED_MAPPER_CLASS, ExecMapper.class.getName());

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -76,7 +76,6 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -305,7 +304,6 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.hadoop.hive.shims.HadoopShims;
 import org.apache.hadoop.hive.shims.Utils;
-import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.OutputFormat;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
@@ -12547,10 +12545,15 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     opParseCtx.get(operator).setRowResolver(newRR);
   }
 
+  private static final Path DUMMY_TABLE_PATH = new Path("file:/__hive_dummy__");
+
   Path dummyPath;
   public Table getDummyTable() throws SemanticException {
     if (dummyPath == null) {
-      dummyPath = createDummyFile();
+      // NullRowsInputFormat produces a synthetic split and never reads this path.  Keep a
+      // path in the table metadata for the legacy MapWork path-to-partition mapping, but do
+      // not create a dummy file (and, in particular, do not create distributed MR scratch).
+      dummyPath = DUMMY_TABLE_PATH;
     }
 
     Table desc = new Table(DUMMY_DATABASE, DUMMY_TABLE);
@@ -12559,27 +12562,6 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     desc.setInputFormatClass(NullRowsInputFormat.class);
     desc.setOutputFormatClass(HiveIgnoreKeyTextOutputFormat.class);
     return desc;
-  }
-
-  // add dummy data for not removed by CombineHiveInputFormat, etc.
-  private Path createDummyFile() throws SemanticException {
-    Path dummyPath = new Path(ctx.getMRScratchDir(), "dummy_path");
-    Path dummyFile = new Path(dummyPath, "dummy_file");
-    FSDataOutputStream fout = null;
-    try {
-      FileSystem fs = dummyFile.getFileSystem(conf);
-      if (fs.exists(dummyFile)) {
-        return dummyPath;
-      }
-      fout = fs.create(dummyFile);
-      fout.write(1);
-      fout.close();
-    } catch (IOException e) {
-      throw new SemanticException(e);
-    } finally {
-      IOUtils.closeStream(fout);
-    }
-    return dummyPath;
   }
 
   /**


### PR DESCRIPTION
### Motivation

- Dummy table scans are engine-level synthetic inputs and should not trigger filesystem discovery or creation of scratch dummy files, so use a split-producing input format that does not depend on real files.

### Description

- Import and use `NullRowsInputFormat` in `DAGUtils.initializeMapVertexConf` when `mapWork.getDummyTableScan()` is true, replacing the previous `CombineHiveInputFormat` choice.
- Add a static `DUMMY_TABLE_PATH` (`file:/__hive_dummy__`) and update `SemanticAnalyzer.getDummyTable()` to return a `Table` with `NullRowsInputFormat` while avoiding creation of a dummy file or distributed scratch paths.
- Remove the `createDummyFile()` helper and related filesystem write logic along with now-unused imports `FSDataOutputStream` and `IOUtils`.

### Testing

- Ran the project's automated test suite with `mvn -DskipTests=false test`, and the existing unit tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a783b72b518832891109b8efa10ecd1)