### PR TITLE
Add diagnostics for MR3 DAG timeline entities and log before/after ingestion/store

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/timeline/ATSResource.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/timeline/ATSResource.java
@@ -141,7 +141,7 @@ public class ATSResource {
       final long currentTime = System.currentTimeMillis();
       e.addOtherInfo(EntityKey.currentTime(), java.lang.Long.valueOf(currentTime));
       if (TimelineEntityDiagnostics.isDag(e)) {
-        LOG.info("MR3 timeline diagnostics before detail response: {}",
+        LOG.info("xxx MR3 timeline diagnostics before detail response: {}",
             TimelineEntityDiagnostics.describeDag(e));
       }
       return e;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/timeline/ATSResource.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/timeline/ATSResource.java
@@ -140,6 +140,10 @@ public class ATSResource {
       if (e == null) throw new WebApplicationException(Response.Status.NOT_FOUND);
       final long currentTime = System.currentTimeMillis();
       e.addOtherInfo(EntityKey.currentTime(), java.lang.Long.valueOf(currentTime));
+      if (TimelineEntityDiagnostics.isDag(e)) {
+        LOG.info("MR3 timeline diagnostics before detail response: {}",
+            TimelineEntityDiagnostics.describeDag(e));
+      }
       return e;
     } catch (IOException e) {
       throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/timeline/MR3TimelineIngestionService.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/timeline/MR3TimelineIngestionService.java
@@ -109,7 +109,7 @@ public class MR3TimelineIngestionService implements AutoCloseable {
       if (numEntities > 0) {
         for (TimelineEntity entity : entities) {
           if (TimelineEntityDiagnostics.isDag(entity)) {
-            LOG.info("MR3 timeline diagnostics after AM call: fromIndex={} {}",
+            LOG.info("xxx MR3 timeline diagnostics after AM call: fromIndex={} {}",
                 fromIndex, TimelineEntityDiagnostics.describeDag(entity));
           }
         }
@@ -130,14 +130,14 @@ public class MR3TimelineIngestionService implements AutoCloseable {
           UserGroupInformation currentUser = UserGroupInformation.getCurrentUser();
           TimelineEntity storedEntity = timelineDataManager.getEntity(
               incomingEntity.getEntityType(), incomingEntity.getEntityId(), null, currentUser);
-          LOG.info("MR3 timeline diagnostics after store: applicationAttemptId={} sequenceNumber={} "
+          LOG.info("xxx MR3 timeline diagnostics after store: applicationAttemptId={} sequenceNumber={} "
                   + "incoming=[{}] stored=[{}]",
               applicationAttemptId, sequenceNumber,
               TimelineEntityDiagnostics.describeDag(incomingEntity),
               TimelineEntityDiagnostics.describeDag(storedEntity));
         } catch (IOException e) {
           // Diagnostics must not cause a successfully stored batch to be fetched again.
-          LOG.warn("Unable to read MR3 DAG {} after store for timeline diagnostics",
+          LOG.warn("xxx Unable to read MR3 DAG {} after store for timeline diagnostics",
               incomingEntity.getEntityId(), e);
         }
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/timeline/MR3TimelineIngestionService.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/timeline/MR3TimelineIngestionService.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.mr3.session.MR3Session;
 import org.apache.hadoop.hive.ql.exec.mr3.session.MR3SessionManagerImpl;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.api.records.timeline.TimelineEntity;
 import org.apache.hadoop.yarn.api.records.timeline.TimelinePutResponse;
 import org.slf4j.Logger;
@@ -106,6 +107,12 @@ public class MR3TimelineIngestionService implements AutoCloseable {
           JavaConverters.seqAsJavaListConverter(timelineEntities).asJava();
       numEntities = entities.size();
       if (numEntities > 0) {
+        for (TimelineEntity entity : entities) {
+          if (TimelineEntityDiagnostics.isDag(entity)) {
+            LOG.info("MR3 timeline diagnostics after AM call: fromIndex={} {}",
+                fromIndex, TimelineEntityDiagnostics.describeDag(entity));
+          }
+        }
         appendTimelineEntities(applicationAttemptId, fromIndex, entities);
         fromIndex += numEntities;
       }
@@ -116,7 +123,26 @@ public class MR3TimelineIngestionService implements AutoCloseable {
       String applicationAttemptId,
       long sequenceNumber,
       List<TimelineEntity> entities) throws IOException {
-    return timelineDataManager.postEntities(entities);
+    TimelinePutResponse response = timelineDataManager.postEntities(entities);
+    for (TimelineEntity incomingEntity : entities) {
+      if (TimelineEntityDiagnostics.isDag(incomingEntity)) {
+        try {
+          UserGroupInformation currentUser = UserGroupInformation.getCurrentUser();
+          TimelineEntity storedEntity = timelineDataManager.getEntity(
+              incomingEntity.getEntityType(), incomingEntity.getEntityId(), null, currentUser);
+          LOG.info("MR3 timeline diagnostics after store: applicationAttemptId={} sequenceNumber={} "
+                  + "incoming=[{}] stored=[{}]",
+              applicationAttemptId, sequenceNumber,
+              TimelineEntityDiagnostics.describeDag(incomingEntity),
+              TimelineEntityDiagnostics.describeDag(storedEntity));
+        } catch (IOException e) {
+          // Diagnostics must not cause a successfully stored batch to be fetched again.
+          LOG.warn("Unable to read MR3 DAG {} after store for timeline diagnostics",
+              incomingEntity.getEntityId(), e);
+        }
+      }
+    }
+    return response;
   }
 
   @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/timeline/TimelineEntityDiagnostics.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/timeline/TimelineEntityDiagnostics.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.mr3.timeline;
+
+import com.datamonad.mr3.history.EntityType;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.hadoop.yarn.api.records.timeline.TimelineEntity;
+
+/** Produces compact diagnostics for duplicate DAG vertices and edges. */
+final class TimelineEntityDiagnostics {
+
+  private TimelineEntityDiagnostics() {
+  }
+
+  static boolean isDag(TimelineEntity entity) {
+    return entity != null && EntityType.MR3_DAG().equals(entity.getEntityType());
+  }
+
+  static String describeDag(TimelineEntity entity) {
+    if (entity == null) {
+      return "entity=null";
+    }
+    return "entityId=" + entity.getEntityId()
+        + " vertices={" + describeField(entity, "vertices", "vertexName") + "}"
+        + " edges={" + describeField(entity, "edges", "edgeId") + "}";
+  }
+
+  private static String describeField(TimelineEntity entity, String fieldName, String identifierName) {
+    Map<String, Object> otherInfo = entity.getOtherInfo();
+    Object value = otherInfo == null ? null : otherInfo.get(fieldName);
+    if (!(value instanceof Collection)) {
+      return value == null ? "count=0 distinct=0 duplicates={}"
+          : "unexpectedType=" + value.getClass().getName();
+    }
+
+    Collection<?> values = (Collection<?>) value;
+    Map<String, Integer> counts = new LinkedHashMap<>();
+    for (Object item : values) {
+      String identifier = getIdentifier(item, identifierName);
+      counts.put(identifier, counts.getOrDefault(identifier, 0) + 1);
+    }
+
+    Map<String, Integer> duplicates = new LinkedHashMap<>();
+    for (Map.Entry<String, Integer> count : counts.entrySet()) {
+      if (count.getValue() > 1) {
+        duplicates.put(count.getKey(), count.getValue());
+      }
+    }
+    return "count=" + values.size() + " distinct=" + counts.size() + " duplicates=" + duplicates;
+  }
+
+  private static String getIdentifier(Object item, String identifierName) {
+    if (item instanceof Map) {
+      Object identifier = ((Map<?, ?>) item).get(identifierName);
+      if (identifier != null) {
+        return String.valueOf(identifier);
+      }
+    }
+    // Retain useful duplicate detection if an MR3 version uses a different identifier field.
+    return "<missing " + identifierName + "> " + String.valueOf(item);
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/timeline/TimelineEntityDiagnostics.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/timeline/TimelineEntityDiagnostics.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hive.ql.exec.mr3.timeline;
 
+import com.datamonad.mr3.history.EntityKey;
 import com.datamonad.mr3.history.EntityType;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -45,9 +46,10 @@ final class TimelineEntityDiagnostics {
 
   private static String describeField(TimelineEntity entity, String fieldName, String identifierName) {
     Map<String, Object> otherInfo = entity.getOtherInfo();
-    Object value = otherInfo == null ? null : otherInfo.get(fieldName);
+    Object dagProto = otherInfo == null ? null : otherInfo.get(EntityKey.dagProto());
+    Object value = dagProto instanceof Map ? ((Map<?, ?>) dagProto).get(fieldName) : null;
     if (!(value instanceof Collection)) {
-      return value == null ? "count=0 distinct=0 duplicates={}"
+      return value == null ? "count=0 distinct=0 duplicates={} dagProtoType=" + typeName(dagProto)
           : "unexpectedType=" + value.getClass().getName();
     }
 
@@ -65,6 +67,10 @@ final class TimelineEntityDiagnostics {
       }
     }
     return "count=" + values.size() + " distinct=" + counts.size() + " duplicates=" + duplicates;
+  }
+
+  private static String typeName(Object value) {
+    return value == null ? "null" : value.getClass().getName();
   }
 
   private static String getIdentifier(Object item, String identifierName) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/timeline/TimelineEntityDiagnostics.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr3/timeline/TimelineEntityDiagnostics.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.ql.exec.mr3.timeline;
 
 import com.datamonad.mr3.history.EntityKey;
 import com.datamonad.mr3.history.EntityType;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -47,7 +48,8 @@ final class TimelineEntityDiagnostics {
   private static String describeField(TimelineEntity entity, String fieldName, String identifierName) {
     Map<String, Object> otherInfo = entity.getOtherInfo();
     Object dagProto = otherInfo == null ? null : otherInfo.get(EntityKey.dagProto());
-    Object value = dagProto instanceof Map ? ((Map<?, ?>) dagProto).get(fieldName) : null;
+    Map<?, ?> dagProtoMap = asMap(dagProto);
+    Object value = dagProtoMap == null ? null : dagProtoMap.get(fieldName);
     if (!(value instanceof Collection)) {
       return value == null ? "count=0 distinct=0 duplicates={} dagProtoType=" + typeName(dagProto)
           : "unexpectedType=" + value.getClass().getName();
@@ -71,6 +73,20 @@ final class TimelineEntityDiagnostics {
 
   private static String typeName(Object value) {
     return value == null ? "null" : value.getClass().getName();
+  }
+
+  private static Map<?, ?> asMap(Object value) {
+    if (value instanceof Map) {
+      return (Map<?, ?>) value;
+    }
+    try {
+      Object converted = value instanceof String
+          ? GenericObjectMapper.OBJECT_READER.readValue((String) value)
+          : GenericObjectMapper.read(GenericObjectMapper.write(value));
+      return converted instanceof Map ? (Map<?, ?>) converted : null;
+    } catch (IOException | RuntimeException e) {
+      return null;
+    }
   }
 
   private static String getIdentifier(Object item, String identifierName) {

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/mr3/timeline/TestTimelineEntityDiagnostics.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/mr3/timeline/TestTimelineEntityDiagnostics.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.mr3.timeline;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.datamonad.mr3.history.EntityType;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.yarn.api.records.timeline.TimelineEntity;
+import org.junit.Test;
+
+public class TestTimelineEntityDiagnostics {
+
+  @Test
+  public void testDescribeDagReportsDuplicateIdentifiers() {
+    TimelineEntity entity = new TimelineEntity();
+    entity.setEntityId("dag_1");
+    entity.setEntityType(EntityType.MR3_DAG());
+    entity.addOtherInfo("vertices", items("vertexName", "Map 1", "Map 2", "Map 1"));
+    entity.addOtherInfo("edges", items("edgeId", "Map 1-Map 2", "Map 1-Map 2"));
+
+    String description = TimelineEntityDiagnostics.describeDag(entity);
+
+    assertTrue(description.contains("vertices={count=3 distinct=2 duplicates={Map 1=2}}"));
+    assertTrue(description.contains("edges={count=2 distinct=1 duplicates={Map 1-Map 2=2}}"));
+  }
+
+  @Test
+  public void testDescribeDagHandlesAbsentCollections() {
+    TimelineEntity entity = new TimelineEntity();
+    entity.setEntityId("dag_2");
+    entity.setEntityType(EntityType.MR3_DAG());
+
+    assertEquals("entityId=dag_2 vertices={count=0 distinct=0 duplicates={}} "
+            + "edges={count=0 distinct=0 duplicates={}}",
+        TimelineEntityDiagnostics.describeDag(entity));
+  }
+
+  private static List<Map<String, Object>> items(String key, String... identifiers) {
+    List<Map<String, Object>> result = new ArrayList<>();
+    for (String identifier : identifiers) {
+      Map<String, Object> item = new HashMap<>();
+      item.put(key, identifier);
+      result.add(item);
+    }
+    return result;
+  }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/mr3/timeline/TestTimelineEntityDiagnostics.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/mr3/timeline/TestTimelineEntityDiagnostics.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hive.ql.exec.mr3.timeline;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.datamonad.mr3.history.EntityKey;
 import com.datamonad.mr3.history.EntityType;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -36,8 +37,10 @@ public class TestTimelineEntityDiagnostics {
     TimelineEntity entity = new TimelineEntity();
     entity.setEntityId("dag_1");
     entity.setEntityType(EntityType.MR3_DAG());
-    entity.addOtherInfo("vertices", items("vertexName", "Map 1", "Map 2", "Map 1"));
-    entity.addOtherInfo("edges", items("edgeId", "Map 1-Map 2", "Map 1-Map 2"));
+    Map<String, Object> dagProto = new HashMap<>();
+    dagProto.put("vertices", items("vertexName", "Map 1", "Map 2", "Map 1"));
+    dagProto.put("edges", items("edgeId", "Map 1-Map 2", "Map 1-Map 2"));
+    entity.addOtherInfo(EntityKey.dagProto(), dagProto);
 
     String description = TimelineEntityDiagnostics.describeDag(entity);
 
@@ -51,8 +54,8 @@ public class TestTimelineEntityDiagnostics {
     entity.setEntityId("dag_2");
     entity.setEntityType(EntityType.MR3_DAG());
 
-    assertEquals("entityId=dag_2 vertices={count=0 distinct=0 duplicates={}} "
-            + "edges={count=0 distinct=0 duplicates={}}",
+    assertEquals("entityId=dag_2 vertices={count=0 distinct=0 duplicates={} dagProtoType=null} "
+            + "edges={count=0 distinct=0 duplicates={} dagProtoType=null}",
         TimelineEntityDiagnostics.describeDag(entity));
   }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/mr3/timeline/TestTimelineEntityDiagnostics.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/mr3/timeline/TestTimelineEntityDiagnostics.java
@@ -59,6 +59,20 @@ public class TestTimelineEntityDiagnostics {
         TimelineEntityDiagnostics.describeDag(entity));
   }
 
+  @Test
+  public void testDescribeDagHandlesJsonDagProto() {
+    TimelineEntity entity = new TimelineEntity();
+    entity.setEntityId("dag_3");
+    entity.setEntityType(EntityType.MR3_DAG());
+    entity.addOtherInfo(EntityKey.dagProto(), "{\"vertices\":[{\"vertexName\":\"Map 29\"},"
+        + "{\"vertexName\":\"Map 29\"}],\"edges\":[{\"edgeId\":\"Map 12-Map 29\"}]}");
+
+    String description = TimelineEntityDiagnostics.describeDag(entity);
+
+    assertTrue(description.contains("vertices={count=2 distinct=1 duplicates={Map 29=2}}"));
+    assertTrue(description.contains("edges={count=1 distinct=1 duplicates={}}"));
+  }
+
   private static List<Map<String, Object>> items(String key, String... identifiers) {
     List<Map<String, Object>> result = new ArrayList<>();
     for (String identifier : identifiers) {


### PR DESCRIPTION
### Motivation

- Provide compact diagnostics for MR3 DAG timeline entities to detect duplicate vertices and edges and aid debugging of timeline ingestion and serving.
- Emit diagnostics at key points (after AM call, after storage, and before HTTP detail response) to make it easier to correlate incoming vs stored timeline data.

### Description

- Add `TimelineEntityDiagnostics` with `isDag` and `describeDag` helpers that summarize vertex/edge counts, distinct identifiers, and duplicates for DAG entities.
- Log DAG diagnostics in `ATSResource.detail()` before returning an entity by calling `TimelineEntityDiagnostics.describeDag` when `isDag` is true.
- Log DAG diagnostics after fetching entities from the MR3 session in `MR3TimelineIngestionService.ingestTimelineEvents()` when a DAG is present.
- Change `MR3TimelineIngestionService.appendTimelineEntities()` to capture the `TimelinePutResponse`, and for each incoming DAG attempt to read back the stored entity using `UserGroupInformation.getCurrentUser()` and `timelineDataManager.getEntity()` and log a comparison; failures to read back are caught and logged as warnings.
- Import `UserGroupInformation` and adjust method flow to return the `TimelinePutResponse` after diagnostics.
- Add unit tests in `TestTimelineEntityDiagnostics` covering duplicate detection and handling of absent collections.

### Testing

- Ran the new unit tests in `TestTimelineEntityDiagnostics` and they passed.
- Exercised the timeline ingestion code paths that were modified via automated build/compile which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9b8cfdcca8832885ecf78eec3816e4)