### PR TITLE
Add configurable context-root rewrite regex and MR3 UI client-route support

### DIFF
--- a/common/src/java/org/apache/hive/http/HttpServer.java
+++ b/common/src/java/org/apache/hive/http/HttpServer.java
@@ -177,6 +177,7 @@ public class HttpServer {
     private String allowedHeaders;
     private PamAuthenticator pamAuthenticator;
     private String contextRootRewriteTarget = "/index.html";
+    private String contextRootRewritePathRegex;
     private boolean xFrameEnabled;
     private XFrameOption xFrameOption = XFrameOption.SAMEORIGIN;
     private final List<Pair<String, Class<? extends HttpServlet>>> servlets =
@@ -310,6 +311,15 @@ public class HttpServer {
 
     public Builder setContextRootRewriteTarget(String contextRootRewriteTarget) {
       this.contextRootRewriteTarget = contextRootRewriteTarget;
+      return this;
+    }
+
+    /**
+     * Sets the request-path regular expression that should be served by the context root target.
+     * This is useful for browser routes owned by a single-page application.
+     */
+    public Builder setContextRootRewritePathRegex(String pathRegex) {
+      contextRootRewritePathRegex = pathRegex;
       return this;
     }
 
@@ -623,8 +633,9 @@ public class HttpServer {
    * handler for the rewritten requests.
    *
    * <p>This method creates a {@link RewriteHandler} that rewrites requests to the root path
-   * ("/") to a new target URI specified by the {@code builder.contextRootRewriteTarget}. 
-   * The URI rewrite is applied before forwarding the request to the given {@link WebAppContext}.</p>
+   * ("/"), as well as any configured client-side application paths, to a new target URI specified
+   * by the {@code builder.contextRootRewriteTarget}. The URI rewrite is applied before forwarding
+   * the request to the given {@link WebAppContext}.</p>
    *
    * @param builder The builder object containing configuration values, such as the 
    *                target for URI rewrite.
@@ -643,6 +654,14 @@ public class HttpServer {
     rootRule.setTerminating(true);
 
     rwHandler.addRule(rootRule);
+
+    if (builder.contextRootRewritePathRegex != null) {
+      RewriteRegexRule pathRule = new RewriteRegexRule();
+      pathRule.setRegex(builder.contextRootRewritePathRegex);
+      pathRule.setReplacement(builder.contextRootRewriteTarget);
+      pathRule.setTerminating(true);
+      rwHandler.addRule(pathRule);
+    }
     rwHandler.setHandler(webAppContext);
     
     return rwHandler;

--- a/service/src/java/org/apache/hive/service/server/HiveServer2.java
+++ b/service/src/java/org/apache/hive/service/server/HiveServer2.java
@@ -432,6 +432,11 @@ public class HiveServer2 extends CompositeService {
           boolean mr3UIEnabled =
               HiveConf.getBoolVar(hiveConf, ConfVars.HIVE_MR3_UI_CREATE_SERVER);
           builder.setContextRootRewriteTarget(mr3UIEnabled ? "/index.html" : HS2_WEBUI_ROOT_URI);
+          if (mr3UIEnabled) {
+            // MR3-UI uses browser-side routing. Direct requests for those routes must load the
+            // application entry point before its router can render the requested page.
+            builder.setContextRootRewritePathRegex("^/(?:dag|applications)(?:/.*)?$");
+          }
 
           String webUIAuthMethodConfig = hiveConf.getVar(ConfVars.HIVE_SERVER2_WEBUI_AUTH_METHOD);
           WebUIAuthMethod webUIAuthMethod = getWebUIAuthMethod(webUIAuthMethodConfig);


### PR DESCRIPTION
### Motivation

- Allow the HTTP server to rewrite additional request paths (such as SPA client-side routes) to the context root target so single-page apps load their entry point for direct navigations.
- Enable MR3 UI routes to be served by the same static entry point when browser-side routing is used.

### Description

- Added a new `Builder` field `contextRootRewritePathRegex` and a setter `setContextRootRewritePathRegex(String)` to configure a request-path regular expression for rewrites.
- Updated `createRewriteHandler` to add an additional `RewriteRegexRule` when `contextRootRewritePathRegex` is set, rewriting matching paths to `contextRootRewriteTarget` before dispatching to the `WebAppContext`.
- Wired the new option into `HiveServer2` so that when MR3 UI is enabled, `builder.setContextRootRewritePathRegex("^/(?:dag|applications)(?:/.*)?$")` is applied to support MR3 client-side routes.
- Clarified Javadoc and comments to document the behavior for rewriting root and SPA routes.

### Testing

- Built the project and executed the test suite with `mvn test`; the unit tests completed successfully.
- Verified the server starts with MR3 UI enabled and the new rewrite rule is installed via automated integration tests that exercise web UI routing, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9e68e2e910832889cdccdd9c438fae)